### PR TITLE
WP 7 runtime publicpath

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,27 @@
+## [v0.1.2] to [v0.2.0]
+
+- **Refactor** [`server-render:makeRenderer`](renderers/server-render.jsx#L123)
+now takes `clientFilename` and `assetPublicPath` as separate arguments rather
+than the single combined string arg used previously. `clientFilename`
+is typically provided by the webpack build stats of the client build process.
+`assetPublicPath` is usually constructed from env vars in your server entry
+point.
+- In order to correctly apply the `assetPublicPath` to your server and client
+builds, you must set `__webpack_public_path__` _before_ importing your
+application code, e.g.
+  
+	```js
+	// your client entry point
+	__webpack_public_path__ = window.APP_RUNTIME.assetPublicPath;
+	const routes = require('./routes').default;
+	const reducer = require('./features/shared/reducer').default;
+	const render = makeRenderer(routes, reducer);
+
+	// your server entry point
+	const clientFilename = WEBPACK_CLIENT_FILENAME;
+	const assetPublicPath = ${process.env.ASSET_SERVER_HOST}:${process.env.ASSET_SERVER_PORT}/`;
+	__webpack_public_path__ = assetPublicPath;  // eslint-disable-line no-undef
+	const routes = require('./routes').default;
+	const reducer = require('./features/shared/reducer').default;
+	const renderRequest$ = makeRenderer(routes, reducer, clientFilename, assetPublicPath);
+	```

--- a/components/dom.jsx
+++ b/components/dom.jsx
@@ -66,7 +66,7 @@ const DOM = (props) => {
 			</head>
 			<body style={{ margin: 0, fontFamily:'sans-serif' }}>
 				<div id='outlet' dangerouslySetInnerHTML={getInnerHTML(appMarkup)} />
-				<script dangerouslySetInnerHTML={getInnerHTML(`window.__webpack_public_path__='${assetPublicPath}';`)} />
+				<script dangerouslySetInnerHTML={getInnerHTML(`window.ASSET_PUBLIC_PATH='${assetPublicPath}';`)} />
 				<script dangerouslySetInnerHTML={getInnerHTML(`window.INITIAL_STATE=${JSON.stringify(INITIAL_STATE_SAFE_JSONABLE)};`)} />
 				<script src={`${assetPublicPath}${clientFilename}`} />
 			</body>

--- a/components/dom.jsx
+++ b/components/dom.jsx
@@ -30,7 +30,8 @@ function getInnerHTML(__html) {
  */
 const DOM = (props) => {
 	const {
-		clientPath,
+		clientFilename,
+		assetPublicPath,
 		initialState,
 		appMarkup,
 	} = props;
@@ -65,8 +66,9 @@ const DOM = (props) => {
 			</head>
 			<body style={{ margin: 0, fontFamily:'sans-serif' }}>
 				<div id='outlet' dangerouslySetInnerHTML={getInnerHTML(appMarkup)} />
+				<script dangerouslySetInnerHTML={getInnerHTML(`window.__webpack_public_path__='${assetPublicPath}';`)} />
 				<script dangerouslySetInnerHTML={getInnerHTML(`window.INITIAL_STATE=${JSON.stringify(INITIAL_STATE_SAFE_JSONABLE)};`)} />
-				<script src={clientPath} />
+				<script src={`${assetPublicPath}${clientFilename}`} />
 			</body>
 		</html>
 	);

--- a/components/dom.jsx
+++ b/components/dom.jsx
@@ -49,13 +49,13 @@ const DOM = (props) => {
 	// escape the string
 	const escapedState = escapeHtml(initialStateJson);
 
-	// create a plain object with the escaped string to write to the DOM with JSON.stringify
-	const INITIAL_STATE_SAFE_JSONABLE = {
-		escapedState
-	};
-
 	// Extract the `<head>` information from any page-specific `<Helmet>` components
 	const head = Helmet.rewind();
+
+	const APP_RUNTIME = {
+		assetPublicPath,
+		escapedState
+	};
 
 	return (
 		<html>
@@ -66,8 +66,7 @@ const DOM = (props) => {
 			</head>
 			<body style={{ margin: 0, fontFamily:'sans-serif' }}>
 				<div id='outlet' dangerouslySetInnerHTML={getInnerHTML(appMarkup)} />
-				<script dangerouslySetInnerHTML={getInnerHTML(`window.ASSET_PUBLIC_PATH='${assetPublicPath}';`)} />
-				<script dangerouslySetInnerHTML={getInnerHTML(`window.INITIAL_STATE=${JSON.stringify(INITIAL_STATE_SAFE_JSONABLE)};`)} />
+				<script dangerouslySetInnerHTML={getInnerHTML(`window.APP_RUNTIME=${JSON.stringify(APP_RUNTIME)};`)} />
 				<script src={`${assetPublicPath}${clientFilename}`} />
 			</body>
 		</html>

--- a/renderers/browser-render.jsx
+++ b/renderers/browser-render.jsx
@@ -27,7 +27,7 @@ function makeRenderer(routes, reducer, middleware) {
 	// containing the HTML-escaped JSON string in `window.INITIAL_STATE.escapedState`.
 	// unescape the text using native `textarea.textContent` unescaping
 	const escape = document.createElement('textarea');
-	escape.innerHTML = window.INITIAL_STATE.escapedState;
+	escape.innerHTML = window.APP_RUNTIME.escapedState;
 	const unescapedStateJSON = escape.textContent;
 	const initialState = JSON.parse(unescapedStateJSON);
 	const store = createStore(routes, reducer, initialState, middleware);

--- a/renderers/server-render.jsx
+++ b/renderers/server-render.jsx
@@ -47,7 +47,7 @@ const DOCTYPE = '<!DOCTYPE html>';
  * @return {Object} the statusCode and result used by Hapi's `reply` API
  *   {@link http://hapijs.com/api#replyerr-result}
  */
-function renderAppResult(renderProps, store, clientPath) {
+function renderAppResult(renderProps, store, clientFilename, assetPublicPath) {
 	// pre-render the app-specific markup, this is the string of markup that will
 	// be managed by React on the client.
 	//
@@ -64,7 +64,12 @@ function renderAppResult(renderProps, store, clientPath) {
 	// all the data for the full `<html>` element has been initialized by the app
 	// so go ahead and assemble the full response body
 	const htmlMarkup = ReactDOMServer.renderToString(
-		<Dom clientPath={clientPath} initialState={initialState} appMarkup={appMarkup} />
+		<Dom
+			assetPublicPath={assetPublicPath}
+			clientFilename={clientFilename}
+			initialState={initialState}
+			appMarkup={appMarkup}
+		/>
 	);
 	const result = `${DOCTYPE}${htmlMarkup}`;
 	const statusCode = renderProps.routes.pop().statusCode || 200;
@@ -115,7 +120,15 @@ const dispatchInitActions = (store, { apiUrl, auth }) => ([redirectLocation, ren
  * `oauth_token` in `state`
  * @return {Observable}
  */
-const makeRenderer = (routes, reducer, clientPath, middleware=[]) => request => {
+const makeRenderer = ({
+	routes,
+	reducer,
+	clientFilename,
+	assetPublicPath,
+	middleware
+}) => request => {
+
+	middleware = middleware || [];
 	request.log(['info'], chalk.green(`Rendering ${request.url.href}`));
 	const {
 		url,
@@ -137,6 +150,7 @@ const makeRenderer = (routes, reducer, clientPath, middleware=[]) => request => 
 		expires_in,
 		anonymous,
 	};
+
 	const store = createStore(routes, reducer, {}, middleware);
 	const storeIsReady$ = Rx.Observable.create(obs =>
 			store.subscribe(() => obs.next(store.getState()))
@@ -151,7 +165,7 @@ const makeRenderer = (routes, reducer, clientPath, middleware=[]) => request => 
 		})
 		.do(dispatchInitActions(store, { apiUrl, auth }))
 		.flatMap(args => storeIsReady$.map(() => args))  // `sample` appears not to work - this is equivalent
-		.map(([redirectLocation, renderProps]) => renderAppResult(renderProps, store, clientPath))
+		.map(([redirectLocation, renderProps]) => renderAppResult(renderProps, store, clientFilename, assetPublicPath))
 		.catch(error => {
 			// render errors result in a rendered stack trace using RedBox
 			const appMarkup = ReactDOMServer.renderToString(<RedBox error={error} />);

--- a/renderers/server-render.jsx
+++ b/renderers/server-render.jsx
@@ -120,13 +120,13 @@ const dispatchInitActions = (store, { apiUrl, auth }) => ([redirectLocation, ren
  * `oauth_token` in `state`
  * @return {Observable}
  */
-const makeRenderer = ({
+const makeRenderer = (
 	routes,
 	reducer,
 	clientFilename,
 	assetPublicPath,
 	middleware
-}) => request => {
+) => request => {
 
 	middleware = middleware || [];
 	request.log(['info'], chalk.green(`Rendering ${request.url.href}`));

--- a/renderers/server-render.jsx
+++ b/renderers/server-render.jsx
@@ -125,7 +125,7 @@ const makeRenderer = (
 	reducer,
 	clientFilename,
 	assetPublicPath,
-	middleware
+	middleware=[]
 ) => request => {
 
 	middleware = middleware || [];


### PR DESCRIPTION
Consume client filename and asset server public path in server-render so that these values can be applied at runtime when building the app.