### PR TITLE
Unit tests for routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "A collection of Node web application utilities developed for the Meetup web platform",
   "scripts": {
     "coveralls": "cat coverage/lcov.info | coveralls",
+    "lint": "eslint . --ext .js,.jsx --fix",
     "test": "jest --silent --config jest.config.json --coverage"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "request": "2.75.0",
     "rxjs": "^5.0.0-beta.11",
     "source-map-support": "0.4.3",
+    "tough-cookie": "2.3.1",
     "url-search-params": "0.6.1"
   }
 }

--- a/routes.js
+++ b/routes.js
@@ -50,10 +50,11 @@ export default function getRoutes(
 	{
 		API_SERVER_ROOT_URL,
 		PHOTO_SCALER_SALT,
-	}) {
+	},
+	apiProxyFn$ = apiProxy$) {
 
 	console.log(chalk.green(`Supported languages:\n${Object.keys(renderRequestMap).join('\n')}`));
-	const proxyApiRequest$ = apiProxy$({
+	const proxyApiRequest$ = apiProxyFn$({
 		baseUrl: API_SERVER_ROOT_URL,
 		duotoneUrls: getDuotoneUrls(duotones, PHOTO_SCALER_SALT),
 	});

--- a/routes.test.js
+++ b/routes.test.js
@@ -1,106 +1,62 @@
-import { Cookie } from 'tough-cookie';
-import { Observable } from 'rxjs';
-import Hapi from 'hapi';
 import getRoutes from './routes';
 import getConfig from './util/config';
+import {
+	MOCK_API_RESULT,
+	MOCK_OAUTH_COOKIES,
+	MOCK_renderRequestMap,
+	MOCK_API_PROXY$,
+	MOCK_RENDER_RESULT,
+	MOCK_REQUEST_COOKIES,
+} from './util/mocks/app';
+import {
+	parseCookieHeader,
+	getServer,
+} from './util/testUtils';
 
-const server = new Hapi.Server();
-
-server.connection();
-
-// mock the anonAuthPlugin
-server.decorate(
-	'request',
-	'authorize',
-	request => () => Observable.of(request),
-	{ apply: true }
-);
-
+// RegEx to verify UUID
 const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
-const MOCK_RESULT = 'asdf';
-const MOCK_RENDER_REQUEST = () => Observable.of({ result: MOCK_RESULT, statusCode: 200 });
-
-const MOCK_renderRequestMap = {
-	'en-US': MOCK_RENDER_REQUEST,
-};
-
-const MOCK_OAUTH_COOKIES = {
-	oauth_token: '1234',
-	refresh_token: 'asdf',
-	anonymous: true
-};
-
-const MOCK_API_RESULT = {
-	queries: [],
-	responses: [],
-};
-
-const serverReady = getConfig()
-	.then(config => getRoutes(MOCK_renderRequestMap, config, () => () => Observable.of(MOCK_API_RESULT)))
-	.then(server.route.bind(server));
-
-const simulateRequestWithCookies = () => {
-	const cookie = Object.keys(MOCK_OAUTH_COOKIES)
-		.reduce((acc, key) => acc += `${key}=${JSON.stringify(MOCK_OAUTH_COOKIES[key])}; `, '');
-
-	return server.inject({
-		url: '/',
-		headers: { cookie },
-		app: {
-			setCookies: true
-		}
-	});
-};
-
-const getCookiesFromResponse = (cookieHeader) => {
-	const cookies = (cookieHeader instanceof Array) ?
-		cookieHeader.map(Cookie.parse) :
-		[Cookie.parse(cookieHeader)];
-
-	return cookies.reduce(
-		(acc, cookie) => ({ ...acc, [cookie.key]: cookie.value }),
-		{}
-	);
-
-};
+function getResponse(injectRequest, server=getServer()) {
+	// a Promise that returns the server instance after it has been
+	// configured with the routes being tested
+	return getConfig()
+		.then(config => getRoutes(
+			MOCK_renderRequestMap,
+			config,
+			MOCK_API_PROXY$)
+		)
+		.then(server.route.bind(server))
+		.then(() => server.inject(injectRequest));
+}
 
 describe('routes', () => {
 	it('serves the homepage route', () =>
-		serverReady
-			.then(() => server.inject({ url: '/' }))
-			.then(response => expect(response.payload).toEqual(MOCK_RESULT))
+		getResponse({ url: '/' })
+			.then(response => expect(response.payload).toEqual(MOCK_RENDER_RESULT))
 	);
 	it('serves the api route', () =>
-		serverReady
-			.then(() =>
-				server.inject({
-					url: '/api',
-				})
-			)
+		getResponse({ url: '/api' })
 			.then(response => expect(JSON.parse(response.payload)).toEqual(MOCK_API_RESULT))
 	);
-	it('sets oauth cookies in response when require.app.setCookies is true', () =>
-		serverReady
-			.then(simulateRequestWithCookies)
+	it('sets oauth cookies in response when request.app.setCookies is true', () =>
+		getResponse({ ...MOCK_REQUEST_COOKIES, app: { setCookies: true }})
 			.then(response => {
 				const cookieHeader = response.headers['set-cookie'];
 				expect(cookieHeader).not.toBeNull();
 
-				const cookies = getCookiesFromResponse(cookieHeader);
+				const cookies = parseCookieHeader(cookieHeader);
 				expect(cookies.oauth_token).toBe(MOCK_OAUTH_COOKIES.oauth_token);
 				expect(cookies.refresh_token).toBe(MOCK_OAUTH_COOKIES.refresh_token);
 				expect(cookies.anonymous).toBe(MOCK_OAUTH_COOKIES.anonymous.toString());
 			})
 	);
 	it('sets tracking cookie in response', () =>
-		serverReady
-			.then(simulateRequestWithCookies)
+		getResponse({ url: '/' })
 			.then(response => {
 				const cookieHeader = response.headers['set-cookie'];
 				expect(cookieHeader).not.toBeNull();
 
-				const cookies = getCookiesFromResponse(cookieHeader);
+				const cookies = parseCookieHeader(cookieHeader);
 				expect(cookies.meetupTrack).not.toBeNull();
 				expect(UUID_V4_REGEX.test(cookies.meetupTrack)).toBe(true);
 			})

--- a/routes.test.js
+++ b/routes.test.js
@@ -1,0 +1,89 @@
+import { Cookie } from 'tough-cookie';
+import { Observable } from 'rxjs';
+import Hapi from 'hapi';
+import getRoutes from './routes';
+import getConfig from './util/config';
+
+const server = new Hapi.Server();
+
+server.connection();
+
+// mock the anonAuthPlugin
+server.decorate(
+	'request',
+	'authorize',
+	request => () => Observable.of(request),
+	{ apply: true }
+);
+
+const MOCK_RESULT = 'asdf';
+const MOCK_RENDER_REQUEST = () => Observable.of({ result: MOCK_RESULT, statusCode: 200 });
+
+const MOCK_renderRequestMap = {
+	'en-US': MOCK_RENDER_REQUEST,
+};
+
+const MOCK_OAUTH_COOKIES = {
+	oauth_token: '1234',
+	refresh_token: 'asdf',
+	anonymous: true
+};
+
+const MOCK_API_RESULT = {
+	queries: [],
+	responses: [],
+};
+
+const serverReady = getConfig()
+	.then(config => getRoutes(MOCK_renderRequestMap, config, () => () => Observable.of(MOCK_API_RESULT)))
+	.then(server.route.bind(server));
+
+describe('routes', () => {
+	it('serves the homepage route', () =>
+		serverReady
+			.then(() => server.inject({ url: '/' }))
+			.then(response => expect(response.payload).toEqual(MOCK_RESULT))
+	);
+	it('serves the api route', () =>
+		serverReady
+			.then(() =>
+				server.inject({
+					url: '/api',
+				})
+			)
+			.then(response => expect(JSON.parse(response.payload)).toEqual(MOCK_API_RESULT))
+	);
+	it('sets oauth cookies in response when require.app.setCookies is true', () =>
+		serverReady
+			.then(() => {
+				const cookie = Object.keys(MOCK_OAUTH_COOKIES)
+					.reduce((acc, key) => acc += `${key}=${JSON.stringify(MOCK_OAUTH_COOKIES[key])}; `, '');
+
+				return server.inject({
+					url: '/',
+					headers: { cookie },
+					app: {
+						setCookies: true
+					}
+				});
+			})
+			.then(response => {
+				const cookieHeader = response.headers['set-cookie'];
+				const cookies = (cookieHeader instanceof Array) ?
+					cookieHeader.map(Cookie.parse) :
+					[Cookie.parse(cookieHeader)];
+
+				expect(cookieHeader).not.toBeNull();
+
+				const cookieMap = cookies.reduce(
+					(acc, cookie) => ({ ...acc, [cookie.key]: cookie.value }),
+					{}
+				);
+
+				expect(cookieMap.oauth_token).toBe(MOCK_OAUTH_COOKIES.oauth_token);
+				expect(cookieMap.refresh_token).toBe(MOCK_OAUTH_COOKIES.refresh_token);
+				expect(cookieMap.anonymous).toBe(MOCK_OAUTH_COOKIES.anonymous.toString());
+			})
+	);
+});
+

--- a/util/mocks/app.js
+++ b/util/mocks/app.js
@@ -1,3 +1,4 @@
+import { Observable } from 'rxjs';
 import {
 	MOCK_GROUP,
 	MOCK_EVENT,
@@ -44,6 +45,12 @@ export const MOCK_API_RESULT = [{
 	value: MOCK_APP_STATE.app.group.value
 }];
 
+export const MOCK_OAUTH_COOKIES = {
+	oauth_token: '1234',
+	refresh_token: 'asdf',
+	anonymous: true
+};
+
 export const MOCK_RENDERPROPS = {
 	location: {  // https://github.com/reactjs/history/blob/master/docs/Location.md
 		pathname: '/foo',
@@ -85,3 +92,29 @@ export const MOCK_POST_ACTION = {
 		onError: err => ({ type: 'MOCK_ERROR' }),
 	}
 };
+
+// string 'Cookie:' header from MOCK_OAUTH_COOKIES
+export const MOCK_COOKIE_HEADER = Object.keys(MOCK_OAUTH_COOKIES)
+	.reduce((acc, key) => acc += `${key}=${JSON.stringify(MOCK_OAUTH_COOKIES[key])}; `, '');
+
+// mock the renderRequest$ function provided by the server-locale app bundle
+export const MOCK_RENDER_REQUEST$ = () =>
+	Observable.of({ result: MOCK_RENDER_RESULT, statusCode: 200 });
+
+export const MOCK_renderRequestMap = {
+	'en-US': MOCK_RENDER_REQUEST$,
+};
+
+// Arbitrary string response payload from server render
+export const MOCK_RENDER_RESULT = '<html><body><h1>Hello world</h1></body></html>';
+
+export const MOCK_REQUEST_COOKIES = {
+	url: '/',
+	headers: {
+		cookie: MOCK_COOKIE_HEADER
+	},
+};
+
+// mock the whole apiProxy module so that we don't actually invoke it
+export const MOCK_API_PROXY$ = () => () => Observable.of(MOCK_API_RESULT);
+

--- a/util/testUtils.js
+++ b/util/testUtils.js
@@ -3,12 +3,11 @@ import Hapi from 'hapi';
 import Cookie from 'tough-cookie';
 import TestUtils from 'react-addons-test-utils';
 
-export function findComponentsWithType(tree, typeString) {
-	return TestUtils.findAllInRenderedTree(
+export const findComponentsWithType = (tree, typeString) =>
+	TestUtils.findAllInRenderedTree(
 		tree,
 		(component) => component && component.constructor.name === typeString
 	);
-}
 
 export const createFakeStore = fakeData => ({
 	getState() {
@@ -25,7 +24,7 @@ export const middlewareDispatcher = middleware => (storeData, action) => {
 	return dispatched;
 };
 
-export const parseCookieHeader = (cookieHeader) => {
+export const parseCookieHeader = cookieHeader => {
 	const cookies = (cookieHeader instanceof Array) ?
 		cookieHeader.map(Cookie.parse) :
 		[Cookie.parse(cookieHeader)];
@@ -37,9 +36,9 @@ export const parseCookieHeader = (cookieHeader) => {
 
 };
 
-export function getServer() {
+export const getServer = connection => {
 	const server = new Hapi.Server();
-	server.connection();
+	server.connection(connection);
 
 	// mock the anonAuthPlugin
 	server.decorate(
@@ -49,6 +48,5 @@ export function getServer() {
 		{ apply: true }
 	);
 	return server;
-}
-
+};
 

--- a/util/testUtils.js
+++ b/util/testUtils.js
@@ -1,3 +1,6 @@
+import { Observable } from 'rxjs/Observable';
+import Hapi from 'hapi';
+import Cookie from 'tough-cookie';
 import TestUtils from 'react-addons-test-utils';
 
 export function findComponentsWithType(tree, typeString) {
@@ -21,4 +24,31 @@ export const middlewareDispatcher = middleware => (storeData, action) => {
 	dispatch(action);
 	return dispatched;
 };
+
+export const parseCookieHeader = (cookieHeader) => {
+	const cookies = (cookieHeader instanceof Array) ?
+		cookieHeader.map(Cookie.parse) :
+		[Cookie.parse(cookieHeader)];
+
+	return cookies.reduce(
+		(acc, cookie) => ({ ...acc, [cookie.key]: cookie.value }),
+		{}
+	);
+
+};
+
+export function getServer() {
+	const server = new Hapi.Server();
+	server.connection();
+
+	// mock the anonAuthPlugin
+	server.decorate(
+		'request',
+		'authorize',
+		request => () => Observable.of(request),
+		{ apply: true }
+	);
+	return server;
+}
+
 


### PR DESCRIPTION
The meetup-web-platform `routes.js` was almost completely untested, and requires mocking a Hapi request using `server.inject`, which we haven't done before.

I went ahead and set up some basic tests that greatly increase test coverage, but there's more to do.

@sadafie it would be good to add some tests for `initTrackingCookie`

`Prelim` until I can review everything and add some documentation. Lots of opportunities for refactoring into more testable units...