### PR TITLE
Fix RedBox rendering of server-side app render errors

### DIFF
--- a/renderers/server-render.jsx
+++ b/renderers/server-render.jsx
@@ -5,13 +5,11 @@ import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 import RouterContext from 'react-router/lib/RouterContext';
 import match from 'react-router/lib/match';
-import RedBox from 'redbox-react';
 import { Provider } from 'react-redux';
 
 import createStore from '../util/createStore';
 import Dom from '../components/dom';
 import { polyfillNodeIntl } from '../util/localizationUtils';
-import { catchAndReturn$ } from '../util/rxUtils';
 
 import {
 	configureAuth
@@ -59,24 +57,39 @@ function renderAppResult(renderProps, store, clientFilename, assetPublicPath) {
 	// initializes page-specific state that `<Dom />` needs to render, e.g.
 	// `<head>` contents
 	const initialState = store.getState();
-	const appMarkup = ReactDOMServer.renderToString(
-		<Provider store={store}>
-			<RouterContext {...renderProps} />
-		</Provider>
-	);
+	let appMarkup;
+	let result;
+	let statusCode;
 
-	// all the data for the full `<html>` element has been initialized by the app
-	// so go ahead and assemble the full response body
-	const htmlMarkup = ReactDOMServer.renderToString(
-		<Dom
-			assetPublicPath={assetPublicPath}
-			clientFilename={clientFilename}
-			initialState={initialState}
-			appMarkup={appMarkup}
-		/>
-	);
-	const result = `${DOCTYPE}${htmlMarkup}`;
-	const statusCode = renderProps.routes.pop().statusCode || 200;
+	try {
+		appMarkup = ReactDOMServer.renderToString(
+			<Provider store={store}>
+				<RouterContext {...renderProps} />
+			</Provider>
+		);
+
+		// all the data for the full `<html>` element has been initialized by the app
+		// so go ahead and assemble the full response body
+		const htmlMarkup = ReactDOMServer.renderToString(
+			<Dom
+				assetPublicPath={assetPublicPath}
+				clientFilename={clientFilename}
+				initialState={initialState}
+				appMarkup={appMarkup}
+			/>
+		);
+		result = `${DOCTYPE}${htmlMarkup}`;
+		statusCode = renderProps.routes.pop().statusCode || 200;
+	} catch(e) {
+		if (IS_DEV) {  // eslint-disable-line no-undef
+			const { RedBoxError } = require('redbox-react');
+			appMarkup = ReactDOMServer.renderToString(<RedBoxError error={e} />);
+			result = `${DOCTYPE}<html><body>${appMarkup}</body></html>`;
+			statusCode = 500;
+		} else {
+			throw e;
+		}
+	}
 
 	return {
 		statusCode,
@@ -171,19 +184,7 @@ const makeRenderer = (
 		})
 		.do(dispatchInitActions(store, { apiUrl, auth, meetupTrack }))
 		.flatMap(args => storeIsReady$.map(() => args))  // `sample` appears not to work - this is equivalent
-		.map(([redirectLocation, renderProps]) => renderAppResult(renderProps, store, clientFilename, assetPublicPath))
-		.catch(error => {
-			// render errors result in a rendered stack trace using RedBox
-			const appMarkup = ReactDOMServer.renderToString(<RedBox error={error} />);
-			const result = `${DOCTYPE}<html><body>${appMarkup}</body></html>`;
-			const statusCode = 500;
-
-			// also log to the console with `catchAndReturn`
-			return catchAndReturn$({
-				result,
-				statusCode
-			}, request.log)(error);
-		});
+		.map(([redirectLocation, renderProps]) => renderAppResult(renderProps, store, clientFilename, assetPublicPath));
 
 	return render$;
 };

--- a/renderers/server-render.jsx
+++ b/renderers/server-render.jsx
@@ -81,6 +81,8 @@ function renderAppResult(renderProps, store, clientFilename, assetPublicPath) {
 		result = `${DOCTYPE}${htmlMarkup}`;
 		statusCode = renderProps.routes.pop().statusCode || 200;
 	} catch(e) {
+		// log the error stack here because Observable logs not great
+		console.error(e.stack);
 		if (IS_DEV) {  // eslint-disable-line no-undef
 			const { RedBoxError } = require('redbox-react');
 			appMarkup = ReactDOMServer.renderToString(<RedBoxError error={e} />);


### PR DESCRIPTION
Our existing setup for returning friendly error messages to the front end doesn't actually work - errors in the server-side rendering of the app markup don't get caught correctly in the Observable stream, and we end up with the super-unhelpful 500 error and impenetrable Observable error logs.

This fixes that.

<img width="560" alt="screen shot 2016-10-15 at 8 14 12 am" src="https://cloud.githubusercontent.com/assets/1885153/19399720/69f21a5a-92af-11e6-9b9d-b98c2f0d5450.png">
