### PR TITLE
WP 37 - Auth/API Timeouts and better error messages

### DIFF
--- a/apiProxy/api-proxy.js
+++ b/apiProxy/api-proxy.js
@@ -233,7 +233,7 @@ export const apiResponseDuotoneSetter = duotoneUrls => {
  * @param {Object} baseUrl API server base URL for all API requests
  * @return Array$ contains all API responses corresponding to the provided queries
  */
-const apiProxy$ = ({ baseUrl, duotoneUrls }) => {
+const apiProxy$ = ({ API_TIMEOUT=5000, baseUrl, duotoneUrls }) => {
 	const setApiResponseDuotones = apiResponseDuotoneSetter(duotoneUrls);
 
 	return request => {
@@ -245,14 +245,13 @@ const apiProxy$ = ({ baseUrl, duotoneUrls }) => {
 		// to build the query-specific API request options object
 		const apiConfigToRequestOptions = buildRequestArgs(externalRequestOpts);
 
-		const apiTimeout = 5000;
 		return Rx.Observable.from(queries)    // create stream of query objects - fan-out
 			.map(queryToApiConfig)              // convert query to API-specific config
 			.map(apiConfigToRequestOptions)     // API-specific args for api request
 			.do(externalRequestOpts => request.log(['api'], JSON.stringify(externalRequestOpts.url)))  // logging
 			.concatMap(externalRequestOpts =>  // make the API calls - keep order
 				externalRequest$(externalRequestOpts)
-					.timeout(apiTimeout, new Error('API response timeout'))
+					.timeout(API_TIMEOUT, new Error('API response timeout'))
 					.catch(error =>
 						Rx.Observable.of(
 							[null, JSON.stringify({ error: error.message})]

--- a/apiProxy/api-proxy.test.js
+++ b/apiProxy/api-proxy.test.js
@@ -46,13 +46,13 @@ describe('parseApiResponse', () => {
 		expect(parseApiResponse(validJSON)).toEqual(jasmine.any(Object));
 		expect(parseApiResponse(validJSON)).toEqual(MOCK_GROUP);
 	});
-	it('throws a TypeError for invalid JSON', () => {
+	it('returns an object with a string "error" value for invalid JSON', () => {
 		const invalidJSON = 'not valid';
-		expect(() => parseApiResponse(invalidJSON)).toThrow(jasmine.any(TypeError));
+		expect(parseApiResponse(invalidJSON).error).toEqual(jasmine.any(String));
 	});
-	it('throws an error when the api response indicates an API problem', () => {
+	it('returns an object with a string "error" value for API response with "problem"', () => {
 		const responeWithProblem = JSON.stringify(MOCK_API_PROBLEM);
-		expect(() => parseApiResponse(responeWithProblem)).toThrow(jasmine.any(Error));
+		expect(parseApiResponse(responeWithProblem).error).toEqual(jasmine.any(String));
 	});
 });
 
@@ -165,3 +165,4 @@ describe('apiResponseDuotoneSetter', () => {
 		expect(group.duotoneUrl.startsWith(expectedUrl)).toBe(true);
 	});
 });
+

--- a/epics/sync.js
+++ b/epics/sync.js
@@ -49,12 +49,12 @@ export const resetLocationEpic = (action$, store) =>
  *
  * emits (API_SUCCESS || API_ERROR) then API_COMPLETE
  */
-export const fetchQueriesEpic = (action$, store) =>
+export const getFetchQueriesEpic = fetchQueriesFn => (action$, store) =>
 	action$.ofType('API_REQUEST')
 		.map(({ payload }) => payload)  // payload contains the queries array
 		.flatMap(queries => {           // set up the fetch call to the app server
 			const { config, auth } = store.getState();
-			const fetch = fetchQueries(config.apiUrl, { method: 'GET', auth });
+			const fetch = fetchQueriesFn(config.apiUrl, { method: 'GET', auth });
 			return Observable.fromPromise(fetch(queries))  // call fetch
 				.takeUntil(action$.ofType(LOCATION_CHANGE, 'LOCATION_SYNC'))  // cancel this fetch when nav happens
 				.map(apiSuccess)                             // dispatch apiSuccess with server response
@@ -62,11 +62,11 @@ export const fetchQueriesEpic = (action$, store) =>
 				.catch(err => Observable.of(apiError(err)));  // ... or apiError
 		});
 
-export default function getSyncEpic(routes) {
+export default function getSyncEpic(routes, fetchQueriesFn=fetchQueries) {
 	return combineEpics(
 		getNavEpic(routes),
 		resetLocationEpic,
-		fetchQueriesEpic
+		getFetchQueriesEpic(fetchQueriesFn)
 	);
 }
 

--- a/epics/sync.test.js
+++ b/epics/sync.test.js
@@ -50,16 +50,13 @@ describe('Sync epic', () => {
 	});
 
 	it('emits API_SUCCESS and API_COMPLETE on successful API_REQUEST', function() {
-		global.fetch = () => {
-			return Promise.resolve({
-				json: () => Promise.resolve({})
-			});
-		};
+		const mockFetchQueries = () => () => Promise.resolve({});
+
 		const queries = [mockQuery({})];
 		const apiRequest = syncActionCreators.apiRequest(queries);
 		const action$ = ActionsObservable.of(apiRequest);
 		const fakeStore = createFakeStore(MOCK_APP_STATE);
-		return getSyncEpic(routes)(action$, fakeStore)
+		return getSyncEpic(routes, mockFetchQueries)(action$, fakeStore)
 			.toArray()
 			.toPromise()
 			.then(actions =>
@@ -68,12 +65,13 @@ describe('Sync epic', () => {
 	});
 
 	it('emits API_ERROR on failed API_REQUEST', function() {
-		global.fetch = () => Promise.reject(new Error());
+		const mockFetchQueries = () => () => Promise.reject(new Error());
+
 		const queries = [mockQuery({})];
 		const apiRequest = syncActionCreators.apiRequest(queries);
 		const action$ = ActionsObservable.of(apiRequest);
 		const fakeStore = createFakeStore(MOCK_APP_STATE);
-		return getSyncEpic(routes)(action$, fakeStore)
+		return getSyncEpic(routes, mockFetchQueries)(action$, fakeStore)
 			.toPromise()
 			.then(action => expect(action.type).toEqual('API_ERROR'));
 	});

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "node-uuid": "^1.4.7",
     "react": "15.3.2",
     "react-addons-test-utils": "15.3.2",
+    "react-dom": "15.3.2",
     "react-helmet": "^3.1.0",
     "react-intl": "^2.1.5",
     "react-router": "^2.7.0",

--- a/plugins/anonAuthPlugin.js
+++ b/plugins/anonAuthPlugin.js
@@ -2,6 +2,7 @@ import Boom from 'boom';
 import chalk from 'chalk';
 import Rx from 'rxjs';
 
+const AUTH_TIMEOUT = 5000;
 /**
  * @module anonAuthPlugin
  */
@@ -98,15 +99,16 @@ export function getAnonymousCode$({ ANONYMOUS_AUTH_URL, oauth }, redirect_uri) {
 	return () => {
 		console.log(`Fetching anonymous auth code from ${ANONYMOUS_AUTH_URL}`);
 		return Rx.Observable.fromPromise(fetch(anonymousCodeUrl, requestOpts))
-		.flatMap(tryJSON)
-		.catch(error => {
-			console.log(error.stack);
-			return Rx.Observable.of({ code: null });
-		})
-		.map(({ code }) => ({
-			grant_type: 'anonymous_code',
-			token: code
-		}));
+			.timeout(AUTH_TIMEOUT)
+			.flatMap(tryJSON)
+			.catch(error => {
+				console.log(error.stack);
+				return Rx.Observable.of({ code: null });
+			})
+			.map(({ code }) => ({
+				grant_type: 'anonymous_code',
+				token: code
+			}));
 	};
 }
 
@@ -165,6 +167,7 @@ export const getAnonymousAccessToken$ = ({ ANONYMOUS_ACCESS_URL, oauth }, redire
 
 			console.log(`Fetching anonymous access_token from ${ANONYMOUS_ACCESS_URL}`);
 			return Rx.Observable.fromPromise(fetch(url, requestOpts))
+				.timeout(AUTH_TIMEOUT)
 				.flatMap(tryJSON);
 		};
 	};

--- a/plugins/anonAuthPlugin.js
+++ b/plugins/anonAuthPlugin.js
@@ -2,7 +2,6 @@ import Boom from 'boom';
 import chalk from 'chalk';
 import Rx from 'rxjs';
 
-const AUTH_TIMEOUT = 5000;
 /**
  * @module anonAuthPlugin
  */
@@ -79,7 +78,7 @@ export const requestAuthorizer = auth$ => request => {
  * @param {Object} config { ANONYMOUS_AUTH_URL, oauth }
  * @param {String} redirect_uri Return url after anonymous grant
  */
-export function getAnonymousCode$({ ANONYMOUS_AUTH_URL, oauth }, redirect_uri) {
+export function getAnonymousCode$({ API_TIMEOUT=5000, ANONYMOUS_AUTH_URL, oauth }, redirect_uri) {
 	if (!oauth.key) {
 		throw new ReferenceError('OAuth consumer key is required');
 	}
@@ -99,7 +98,7 @@ export function getAnonymousCode$({ ANONYMOUS_AUTH_URL, oauth }, redirect_uri) {
 	return () => {
 		console.log(`Fetching anonymous auth code from ${ANONYMOUS_AUTH_URL}`);
 		return Rx.Observable.fromPromise(fetch(anonymousCodeUrl, requestOpts))
-			.timeout(AUTH_TIMEOUT)
+			.timeout(API_TIMEOUT)
 			.flatMap(tryJSON)
 			.catch(error => {
 				console.log(error.stack);
@@ -121,7 +120,7 @@ export function getAnonymousCode$({ ANONYMOUS_AUTH_URL, oauth }, redirect_uri) {
  * @return {Object} the JSON-parsed response from the authorize endpoint
  *   - contains 'access_token', 'refresh_token'
  */
-export const getAnonymousAccessToken$ = ({ ANONYMOUS_ACCESS_URL, oauth }, redirect_uri) => {
+export const getAnonymousAccessToken$ = ({ API_TIMEOUT=5000, ANONYMOUS_ACCESS_URL, oauth }, redirect_uri) => {
 	if (!oauth.key) {
 		throw new ReferenceError('OAuth consumer key is required');
 	}
@@ -167,7 +166,7 @@ export const getAnonymousAccessToken$ = ({ ANONYMOUS_ACCESS_URL, oauth }, redire
 
 			console.log(`Fetching anonymous access_token from ${ANONYMOUS_ACCESS_URL}`);
 			return Rx.Observable.fromPromise(fetch(url, requestOpts))
-				.timeout(AUTH_TIMEOUT)
+				.timeout(API_TIMEOUT)
 				.flatMap(tryJSON);
 		};
 	};

--- a/routes.js
+++ b/routes.js
@@ -48,6 +48,7 @@ const initTrackingCookie = (request, response) => {
 export default function getRoutes(
 	renderRequestMap,
 	{
+		API_TIMEOUT,
 		API_SERVER_ROOT_URL,
 		PHOTO_SCALER_SALT,
 	},
@@ -55,6 +56,7 @@ export default function getRoutes(
 
 	console.log(chalk.green(`Supported languages:\n${Object.keys(renderRequestMap).join('\n')}`));
 	const proxyApiRequest$ = apiProxyFn$({
+		API_TIMEOUT,
 		baseUrl: API_SERVER_ROOT_URL,
 		duotoneUrls: getDuotoneUrls(duotones, PHOTO_SCALER_SALT),
 	});

--- a/routes.js
+++ b/routes.js
@@ -118,8 +118,7 @@ export default function getRoutes(
 						response.state('refresh_token', refresh_token, { ttl: yearOfMilliseconds * 2 });
 						response.state('anonymous', anonymous.toString(), { ttl: yearOfMilliseconds * 2 });
 					}
-				},
-				(err) => { reply(Boom.badImplementation(err.message)); }
+				}
 			);
 		}
 	};

--- a/server.js
+++ b/server.js
@@ -59,7 +59,7 @@ export function onPreResponse(request, reply) {
 	);
 	error.message = `<!DOCTYPE html><html><body>${errorMarkup}</body></html>`;
 	error.reformat();
-	return reply(error).statusCode(500);
+	return reply(error).code(500);
 }
 
 /**

--- a/server.js
+++ b/server.js
@@ -1,5 +1,7 @@
 import https from 'https';
 import Hapi from 'hapi';
+import React from 'react';
+import ReactDOMServer from 'react-dom/server';
 
 import './util/globals';
 
@@ -42,13 +44,22 @@ export function configureEnv(config) {
 	return config;
 }
 
+/**
+ * This function provides global error handling when there is a 500 error
+ */
 export function onPreResponse(request, reply) {
 	const response = request.response;
 	if (!response.isBoom) {
 		return reply.continue();
 	}
 	const error = response;
-	return reply(`oh hell no ${error.stack}`);
+	const { RedBoxError } = require('redbox-react');
+	const errorMarkup = ReactDOMServer.renderToString(
+		React.createElement(RedBoxError, { error })
+	);
+	error.message = `<!DOCTYPE html><html><body>${errorMarkup}</body></html>`;
+	error.reformat();
+	return reply(error).statusCode(500);
 }
 
 /**

--- a/server.js
+++ b/server.js
@@ -57,9 +57,9 @@ export function onPreResponse(request, reply) {
 	const errorMarkup = ReactDOMServer.renderToString(
 		React.createElement(RedBoxError, { error })
 	);
-	error.message = `<!DOCTYPE html><html><body>${errorMarkup}</body></html>`;
-	error.reformat();
-	return reply(error).code(500);
+	const errorResponse = reply(`<!DOCTYPE html><html><body>${errorMarkup}</body></html>`);
+	errorResponse.code(error.output.statusCode);
+	return errorResponse;
 }
 
 /**

--- a/server.js
+++ b/server.js
@@ -42,6 +42,15 @@ export function configureEnv(config) {
 	return config;
 }
 
+export function onPreResponse(request, reply) {
+	const response = request.response;
+	if (!response.isBoom) {
+		return reply.continue();
+	}
+	const error = response;
+	return reply(`oh hell no ${error.stack}`);
+}
+
 /**
  * server-starting function
  */
@@ -50,6 +59,7 @@ export function server(routes, connection, plugins=[]) {
 
 	return server.connection(connection)
 		.register(plugins)
+		.then(() => server.ext('onPreResponse', onPreResponse))
 		.then(() => server.log(['start'], `${plugins.length} plugins registered, assigning routes...`))
 		.then(() => server.route(routes))
 		.then(() => server.log(['start'], `${routes.length} routes assigned, starting server...`))

--- a/util/fetchUtils.js
+++ b/util/fetchUtils.js
@@ -26,7 +26,7 @@ export const fetchQueries = (apiUrl, options) => queries => {
 		console.log('No access token provided');
 		if (!auth.refresh_token) {
 			console.log('No refresh_token - cannot fetch');
-			return Promise.reject('No auth info provided');
+			return Promise.reject(new Error('No auth info provided'));
 		}
 	}
 	const isPost = method.toLowerCase() === 'post';

--- a/util/fetchUtils.js
+++ b/util/fetchUtils.js
@@ -23,7 +23,11 @@ export const fetchQueries = (apiUrl, options) => queries => {
 	} = options;
 
 	if (!auth.oauth_token) {
-		console.log('No access token provided - hope there\'s a refresh token');
+		console.log('No access token provided');
+		if (!auth.refresh_token) {
+			console.log('No refresh_token - cannot fetch');
+			return Promise.reject('No auth info provided');
+		}
 	}
 	const isPost = method.toLowerCase() === 'post';
 

--- a/util/fetchUtils.test.js
+++ b/util/fetchUtils.test.js
@@ -40,6 +40,7 @@ describe('fetchQueries', () => {
 		spyOn(global, 'fetch');
 
 		return fetchUtils.fetchQueries(API_URL.toString(), { auth: {}, method: 'GET' })(queries)
+			.then(() => expect(true).toBe(false))  // should never be called!
 			.catch(err => {
 				expect(err).toEqual(jasmine.any(Error));
 				expect(global.fetch).not.toHaveBeenCalled();

--- a/util/fetchUtils.test.js
+++ b/util/fetchUtils.test.js
@@ -36,6 +36,15 @@ describe('fetchQueries', () => {
 				expect(response.responses).toEqual(jasmine.any(Array));
 			});
 	});
+	it('rejects with an Error without calling fetch when no oauth', () => {
+		spyOn(global, 'fetch');
+
+		return fetchUtils.fetchQueries(API_URL.toString(), { auth: {}, method: 'GET' })(queries)
+			.catch(err => {
+				expect(err).toEqual(jasmine.any(Error));
+				expect(global.fetch).not.toHaveBeenCalled();
+			});
+	});
 	describe('GET', () => {
 		it('calls fetch with API url with GET and querystring', () => {
 			spyOn(global, 'fetch').and.callFake(fakeSuccess);


### PR DESCRIPTION
This PR applies auth and API endpoint timeouts that will throw errors when external services don't respond in a reasonable amount of time. It also `catch`es these timeout errors and attempts to gracefully continue request execution. It is up to the consuming application to render errors appropriately.