### PR TITLE
Unit test for server start

### DIFF
--- a/server.js
+++ b/server.js
@@ -54,7 +54,8 @@ export function server(routes, connection, plugins=[]) {
 		.then(() => server.route(routes))
 		.then(() => server.log(['start'], `${routes.length} routes assigned, starting server...`))
 		.then(() => server.start())
-		.then(() => server.log(['start'], `Dev server is listening at ${server.info.uri}`));
+		.then(() => server.log(['start'], `Dev server is listening at ${server.info.uri}`))
+		.then(() => server);
 }
 
 /**
@@ -70,11 +71,11 @@ export function server(routes, connection, plugins=[]) {
  *   features in the additional routes
  * @return {Promise} the Promise returned by Hapi's `server.connection` method
  */
-export default function start(renderRequestMap, options) {
-	const {
-		routes,
-		plugins,
-	} = options;
+export default function start(
+	renderRequestMap,
+	{ routes=[], plugins=[] },
+	config=getConfig
+) {
 	// source maps make for better stack traces - we might not want this in
 	// production if it makes anything slower, though
 	// (process.env.NODE_ENV === 'production')

--- a/server.test.js
+++ b/server.test.js
@@ -1,5 +1,5 @@
 import https from 'https';
-import {
+import start, {
 	checkForDevUrl,
 	configureEnv,
 } from './server';
@@ -40,5 +40,11 @@ describe('configureEnv', function() {
 		configureEnv({ url: 'www.meetup.com' });
 		expect(https.globalAgent.options.rejectUnauthorized).toBe(true);
 	});
+});
+
+describe('server', () => {
+	it('starts', () =>
+		start({}, {}).then(server => server.stop()).then(() => expect(true).toBe(true))
+	);
 });
 

--- a/server.test.js
+++ b/server.test.js
@@ -46,5 +46,16 @@ describe('server', () => {
 	it('starts', () =>
 		start({}, {}).then(server => server.stop()).then(() => expect(true).toBe(true))
 	);
+	it('applies passed-in routes', () => {
+		const routes = [
+			{ method: 'GET', path: '/', config: { id: 'root' }, handler: () => {} },
+			{ method: 'GET', path: '/sub', config: { id: 'sub' }, handler: () => {} },
+		];
+		return start({}, { routes }).then(server => {
+			expect(server.lookup('root').path).toBe('/');
+			expect(server.lookup('sub').path).toBe('/sub');
+			server.stop();
+		});
+	});
 });
 


### PR DESCRIPTION
This PR adds coverage for the server start function - we mainly want to make sure that it can execute, but it also adds a test to see if passed-in routes get assigned correctly to the Hapi server