### PR TITLE
WP-51 beta versioning for PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ after_success:
   - >
     [ "${TRAVIS_BRANCH}" = "master" ] &&
     npm version $GIT_TAG -m "Version $GIT_TAG built by Travis CI - https://travis-ci.com/$TRAVIS_REPO_SLUG/builds/$TRAVIS_JOB_ID" &&
-    git push -q https://$GITHUB_USER:$GITHUB_TOKEN@github.com/$TRAVIS_REPO_SLUG --tags
+    git push -q https://$GITHUB_USER:$GITHUB_TOKEN@github.com/$TRAVIS_REPO_SLUG --tags &&
     npm publish --tag $NPM_TAG ||
     echo "skipping versioning"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,15 +30,17 @@ after_success:
   - git config --global user.name "Travis CI"
   - >
     [ "${TRAVIS_BRANCH}" = "master" ] && [ "${TRAVIS_PULL_REQUEST}" = "false" ] &&
-    export GIT_TAG=$(make version) ||
-    export GIT_TAG=$(make version)-beta
+    export GIT_TAG=$(make version) &&
+    export NPM_TAG=latest ||
+    export GIT_TAG=$(make version)-beta &&
+    export NPM_TAG=beta
   - echo "GIT_TAG=$GIT_TAG"
-  - echo ${TRAVIS_PULL_REQUEST}
+  - echo "NPM_TAG=$NPM_TAG"
   - >
     [ "${TRAVIS_BRANCH}" = "master" ] &&
     npm version $GIT_TAG -m "Version $GIT_TAG built by Travis CI - https://travis-ci.com/$TRAVIS_REPO_SLUG/builds/$TRAVIS_JOB_ID" &&
-    git push -q https://$GITHUB_USER:$GITHUB_TOKEN@github.com/$TRAVIS_REPO_SLUG --tags &&
-    npm publish ||
+    git push -q https://$GITHUB_USER:$GITHUB_TOKEN@github.com/$TRAVIS_REPO_SLUG --tags
+    npm publish --tag $NPM_TAG ||
     echo "skipping versioning"
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,19 +28,18 @@ after_success:
   - npm run coveralls
   - git config --global user.email "builds@travis-ci.com"
   - git config --global user.name "Travis CI"
-  - export GIT_TAG=$(make version)
+  - >
+    [ "${TRAVIS_BRANCH}" = "master" ] && [ "${TRAVIS_PULL_REQUEST}" = "false" ] &&
+    export GIT_TAG=$(make version) ||
+    export GIT_TAG=$(make version)-beta
   - echo "GIT_TAG=$GIT_TAG"
   - echo ${TRAVIS_PULL_REQUEST}
   - >
-    [ "${TRAVIS_BRANCH}" = "master" ] && [ "${TRAVIS_PULL_REQUEST}" = "false" ] &&
-    npm version $GIT_TAG -m "Version $GIT_TAG built by Travis CI - https://travis-ci.com/$TRAVIS_REPO_SLUG/builds/$TRAVIS_JOB_ID"
-    || echo "skipping versioning"
-  - >
-    [ "${TRAVIS_BRANCH}" = "master" ] && [ "${TRAVIS_PULL_REQUEST}" = "false" ] &&
-    git push -q https://$GITHUB_USER:$GITHUB_TOKEN@github.com/$TRAVIS_REPO_SLUG --tags || true
-  - >
-    [ "${TRAVIS_BRANCH}" = "master" ] && [ "${TRAVIS_PULL_REQUEST}" = "false" ] &&
-    npm publish
+    [ "${TRAVIS_BRANCH}" = "master" ] &&
+    npm version $GIT_TAG -m "Version $GIT_TAG built by Travis CI - https://travis-ci.com/$TRAVIS_REPO_SLUG/builds/$TRAVIS_JOB_ID" &&
+    git push -q https://$GITHUB_USER:$GITHUB_TOKEN@github.com/$TRAVIS_REPO_SLUG --tags &&
+    npm publish ||
+    echo "skipping versioning"
 
 notifications:
   # slack integration

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,11 @@ after_success:
   - git config --global user.name "Travis CI"
   - >
     [ "${TRAVIS_BRANCH}" = "master" ] && [ "${TRAVIS_PULL_REQUEST}" = "false" ] &&
-    export GIT_TAG=$(make version) &&
+    export GIT_TAG=$(make version) ||
+    export GIT_TAG=$(make version)-beta
+  - >
+    [ "${TRAVIS_BRANCH}" = "master" ] && [ "${TRAVIS_PULL_REQUEST}" = "false" ] &&
     export NPM_TAG=latest ||
-    export GIT_TAG=$(make version)-beta &&
     export NPM_TAG=beta
   - echo "GIT_TAG=$GIT_TAG"
   - echo "NPM_TAG=$NPM_TAG"


### PR DESCRIPTION
This update should make it so that Travis will publish a package with a `-beta` version suffix for every push to a branch in PR. When the branch merges to master, the current behavior of publishing a non-beta version should remain intact.

This will make it much easier to install a dev version of the platform when making dependent changes in consumer applications - no need for a git-url or `npm link`, which are broken/fragile.