### PR TITLE
WP-54 Actually make API requests in parallel

### DIFF
--- a/src/apiProxy/api-proxy.js
+++ b/src/apiProxy/api-proxy.js
@@ -122,7 +122,7 @@ export const buildRequestArgs = externalRequestOpts => ({ endpoint, params }) =>
  *
  * @param {Object} apiResponse JSON-parsed api response data
  */
-export const apiResponseToQueryResponse = ([response, query]) => ({
+export const apiResponseToQueryResponse = query => response => ({
 	[query.ref]: {
 		type: query.type,
 		value: response,
@@ -219,6 +219,25 @@ export const apiResponseDuotoneSetter = duotoneUrls => {
 	};
 };
 
+export const makeApiRequest = (request, API_TIMEOUT, duotoneUrls) => {
+	const setApiResponseDuotones = apiResponseDuotoneSetter(duotoneUrls);
+
+	return ([requestOpts, query]) =>
+		externalRequest$(requestOpts)
+			.timeout(API_TIMEOUT, new Error('API response timeout'))
+			.do(([response]) => request.log(['api'], `${response.elapsedTime}ms - ${response.request.uri.path}`)) // log api response time
+			.map(([response, body]) => body)    // ignore Response object, just process body string
+			.map(parseApiResponse)             // parse into plain object
+			.catch(error =>
+				Rx.Observable.of({ error: error.message })
+			)
+			.map(apiResponseToQueryResponse(query))    // convert apiResponse to app-ready queryResponse
+			.map(setApiResponseDuotones);        // special duotone prop
+};
+
+const sortResponsesByQueryOrder = queries => responses =>
+	queries.map(({ ref }) => responses.find(response => response[ref]));
+
 /**
  * This function transforms a single request to the application server into a
  * parallel array of requests to the API server, and then re-assembles the
@@ -235,7 +254,6 @@ export const apiResponseDuotoneSetter = duotoneUrls => {
  * @return Array$ contains all API responses corresponding to the provided queries
  */
 const apiProxy$ = ({ API_TIMEOUT=5000, baseUrl, duotoneUrls }) => {
-	const setApiResponseDuotones = apiResponseDuotoneSetter(duotoneUrls);
 
 	return request => {
 
@@ -249,27 +267,11 @@ const apiProxy$ = ({ API_TIMEOUT=5000, baseUrl, duotoneUrls }) => {
 		return Rx.Observable.from(queries)    // create stream of query objects - fan-out
 			.map(queryToApiConfig)              // convert query to API-specific config
 			.map(apiConfigToRequestOptions)     // API-specific args for api request
-			.do(externalRequestOpts => request.log(['api'], JSON.stringify(externalRequestOpts.url)))  // logging
-			.concatMap(externalRequestOpts =>  // make the API calls - keep order
-				externalRequest$(externalRequestOpts)
-					.timeout(API_TIMEOUT, new Error('API response timeout'))
-					.catch(error =>
-						Rx.Observable.of(
-							[null, JSON.stringify({ error: error.message})]
-						)
-					)
-			)
-			.do(([response]) => request.log(['api'], `${response.elapsedTime}ms - ${response.request.uri.path}`)) // log api response time
-			.map(([response, body]) => body)    // ignore Response object, just process body string
-			.map(parseApiResponse)              // parse into plain object
-			.catch(error =>  // if there has been an error, all 'responses' need to be the error
-				Rx.Observable.of({ error: error.message })
-					.repeat(queries.length)
-			)
+			.do(({ url }) => request.log(['api'], JSON.stringify(url)))  // logging
 			.zip(Rx.Observable.from(queries))   // zip the apiResponse with corresponding query
-			.map(apiResponseToQueryResponse)    // convert apiResponse to app-ready queryResponse
-			.map(setApiResponseDuotones)        // special duotone prop
-			.toArray();                         // group all responses into a single array - fan-in
+			.flatMap(makeApiRequest(request, API_TIMEOUT, duotoneUrls))  // parallel requests
+			.toArray()                         // group all responses into a single array - fan-in
+			.map(sortResponsesByQueryOrder(queries));
 	};
 };
 

--- a/src/apiProxy/api-proxy.test.js
+++ b/src/apiProxy/api-proxy.test.js
@@ -107,7 +107,7 @@ describe('apiResponseToQueryResponse', () => {
 
 	it('transforms an API response object to an object for State consumption', function() {
 		this.MOCK_API_RESPONSES
-			.map((apiResponse, i) => apiResponseToQueryResponse([apiResponse, this.queries[i]]))
+			.map((apiResponse, i) => apiResponseToQueryResponse(this.queries[i])(apiResponse))
 			.forEach((queryResponse, i)=> {
 				expect(queryResponse).toEqual(jasmine.any(Object));
 				expect(queryResponse[this.refs[i]]).toEqual(jasmine.any(Object));


### PR DESCRIPTION
The current code uses `concatMap` to make sure that API requests are returned in the order of their corresponding queries from the app. However, `concatMap` keeps order by making the requests serially rather than in parallel, which is not what we want. Although RxJava has `concatMapEager` that has the behavior we want, RxJS does not, so we have to use `flatMap` to make the calls in parallel and then sort the responses after they all return.

This should significantly improve time to first byte, particularly for deeply-nested routes. I'll try to get numbers from mup-web

for [this event url](http://localhost:8000/nyc-kanban/events/fkswhlyvpbxb):

- Previous TTFB: 2.4s (same for client-side API request)
- This branch TTFB: **0.8s**
