### PR TITLE
WP 39 allow queries to inject 'mockResponse'

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,51 @@ From the client-side application's point of view, it will always send
 the `queries` and recieve the `queryResponses` for any data request -
 all the API-specific translations happen on the server.
 
+### Faking an API response
+
+Sometimes, during development, you might want to set up your consumer app to
+query data from an API endpoint that is not yet set up. In this case, you can
+add a `mockResponse` property to your `query` object that will be used as the
+return value for the API call (you _have_ defined the API return values,
+right?). When the API endpoint is ready, simply remove the `mockResponse` from
+the query and the platform will call the API as configured in
+`src/apiProxy/apiConfigCreators.js`.
+
+**Example**
+
+A new feature will use a new API `/:urlname/candy` endpoint - it returns a new
+`type` of data called `candy` with an `id` and `flavor` property.
+
+The query function in the consumer app would look like this:
+
+``` js
+function candyQuery({ params, location }) {
+  const urlname = params.urlname;
+  return {
+    type: 'candy',
+    params: { urlname },
+    ref: 'candystate',
+    mockResponse: {
+      id: 1234,
+      flavor: 'kiwi'
+  };
+}
+```
+
+the `apiConfigCreator` would need to be defined like this:
+
+``` js
+function candy(params) {
+  return {
+    endpoint: `${params.urlname}/candy`,
+    params
+  };
+}
+```
+
+Then, even if the API server isn't handling `/:urlname/candy` yet, the app will
+load the `mockResponse` into Redux state at `state.app.candystate.value`.
+
 ## Middleware/Epics
 
 The built-in middleware provides core functionality for interacting with

--- a/src/apiProxy/api-proxy.js
+++ b/src/apiProxy/api-proxy.js
@@ -280,7 +280,7 @@ const apiProxy$ = ({ API_TIMEOUT=5000, baseUrl, duotoneUrls }) => {
 			.map(apiConfigToRequestOptions)     // API-specific args for api request
 			.do(({ url }) => request.log(['api'], JSON.stringify(url)))  // logging
 			.zip(Rx.Observable.from(queries))   // zip the apiResponse with corresponding query
-			.flatMap(makeApiRequest$(request, API_TIMEOUT, duotoneUrls))  // parallel requests
+			.mergeMap(makeApiRequest$(request, API_TIMEOUT, duotoneUrls))  // parallel requests
 			.toArray()                         // group all responses into a single array - fan-in
 			.map(sortResponsesByQueryOrder(queries));
 	};

--- a/src/apiProxy/api-proxy.js
+++ b/src/apiProxy/api-proxy.js
@@ -220,10 +220,10 @@ export const apiResponseDuotoneSetter = duotoneUrls => {
 };
 
 const makeMockRequest = (requestOpts, mockResponse) =>
-	Rx.Observable.of(mockResponse)
+	Rx.Observable.of(JSON.stringify(mockResponse))
 		.do(() => console.log(`MOCKING response to ${requestOpts.url}`));
 
-export const makeApiRequest = (request, API_TIMEOUT, duotoneUrls) => {
+export const makeApiRequest$ = (request, API_TIMEOUT, duotoneUrls) => {
 	const setApiResponseDuotones = apiResponseDuotoneSetter(duotoneUrls);
 	const makeExternalApiRequest$ = requestOpts =>
 		externalRequest$(requestOpts)
@@ -280,7 +280,7 @@ const apiProxy$ = ({ API_TIMEOUT=5000, baseUrl, duotoneUrls }) => {
 			.map(apiConfigToRequestOptions)     // API-specific args for api request
 			.do(({ url }) => request.log(['api'], JSON.stringify(url)))  // logging
 			.zip(Rx.Observable.from(queries))   // zip the apiResponse with corresponding query
-			.flatMap(makeApiRequest(request, API_TIMEOUT, duotoneUrls))  // parallel requests
+			.flatMap(makeApiRequest$(request, API_TIMEOUT, duotoneUrls))  // parallel requests
 			.toArray()                         // group all responses into a single array - fan-in
 			.map(sortResponsesByQueryOrder(queries));
 	};

--- a/src/apiProxy/api-proxy.js
+++ b/src/apiProxy/api-proxy.js
@@ -238,9 +238,7 @@ export const makeApiRequest$ = (request, API_TIMEOUT, duotoneUrls) => {
 
 		return request$
 			.map(parseApiResponse)             // parse into plain object
-			.catch(error =>
-				Rx.Observable.of({ error: error.message })
-			)
+			.catch(error => Rx.Observable.of({ error: error.message }))
 			.map(apiResponseToQueryResponse(query))    // convert apiResponse to app-ready queryResponse
 			.map(setApiResponseDuotones);        // special duotone prop
 	};

--- a/src/apiProxy/api-proxy.js
+++ b/src/apiProxy/api-proxy.js
@@ -219,6 +219,10 @@ export const apiResponseDuotoneSetter = duotoneUrls => {
 	};
 };
 
+const makeMockRequest = (requestOpts, mockResponse) =>
+	Rx.Observable.of(mockResponse)
+		.do(() => console.log(`MOCKING response to ${requestOpts.url}`));
+
 export const makeApiRequest = (request, API_TIMEOUT, duotoneUrls) => {
 	const setApiResponseDuotones = apiResponseDuotoneSetter(duotoneUrls);
 	const makeExternalApiRequest$ = requestOpts =>
@@ -229,7 +233,7 @@ export const makeApiRequest = (request, API_TIMEOUT, duotoneUrls) => {
 
 	return ([requestOpts, query]) => {
 		const request$ = query.mockResponse ?
-			Rx.Observable.of(query.mockResponse) :
+			makeMockRequest(requestOpts, query.mockResponse) :
 			makeExternalApiRequest$(requestOpts);
 
 		return request$

--- a/src/apiProxy/api-proxy.test.js
+++ b/src/apiProxy/api-proxy.test.js
@@ -17,6 +17,7 @@ import {
 	apiResponseToQueryResponse,
 	apiResponseDuotoneSetter,
 	groupDuotoneSetter,
+	makeApiRequest$,
 } from './api-proxy';
 
 describe('parseRequest', () => {
@@ -166,3 +167,18 @@ describe('apiResponseDuotoneSetter', () => {
 	});
 });
 
+describe('makeApiRequest$', () => {
+	it('responds with query.mockResponse when set', () => {
+		const mockResponse = { foo: 'bar' };
+		const query = { ...mockQuery(MOCK_RENDERPROPS), mockResponse };
+		const expectedResponse = {
+			[query.ref]: {
+				type: query.type,
+				value: mockResponse,
+			}
+		};
+		return makeApiRequest$({ log: () => {} }, 5000, {})([{ url: '/foo' }, query])
+			.toPromise()
+			.then(response => expect(response).toEqual(expectedResponse));
+	});
+});


### PR DESCRIPTION
This update allows consumer apps to mock the expected response from the API _before_ the expected API endpoint is available.

Example:

A new feature will use a new API `/:urlname/candy` endpoint - it returns a new `type` of data called `candy` with an `id` and `flavor` property.

The query function would look like this:

``` js
function candyQuery({ params, location }) {
  const urlname = params.urlname;
  return {
    type: 'candy',
    params: { urlname },
    ref: 'candystate',
    mockResponse: {
      id: 1234,
      flavor: 'kiwi'
  };
}
```

the `apiConfigCreator` would need to be defined like this:

``` js
function candy(params) {
  return {
    endpoint: `${params.urlname}/candy`,
    params
  };
}
```

Then, even if the API server isn't handling `/:urlname/candy` yet, the app will load the `mockResponse` into Redux state at `state.app.candystate.value`.

When the API endpoint is ready, you just need to remove `mockResponse` from the query function.
