### PR TITLE
use zip rather than flatmap + sort

### DIFF
--- a/src/apiProxy/api-proxy.js
+++ b/src/apiProxy/api-proxy.js
@@ -263,12 +263,15 @@ const apiProxy$ = ({ API_TIMEOUT=5000, baseUrl, duotoneUrls }) => {
 		// to build the query-specific API request options object
 		const apiConfigToRequestOptions = buildRequestArgs(externalRequestOpts);
 
-		return Rx.Observable.zip(
-			...queries
-				.map(queryToApiConfig)
-				.map(apiConfigToRequestOptions)
-				.map((opts, i) => makeApiRequest(request, API_TIMEOUT, duotoneUrls)([opts, queries[i]]))
-		);
+		// 3. map the queries onto an array of api request observables
+		const apiRequests$ = queries
+			.map(queryToApiConfig)
+			.map(apiConfigToRequestOptions)
+			.map((opts, i) => ([opts, queries[i]]))  // zip the query back into the opts
+			.map(makeApiRequest(request, API_TIMEOUT, duotoneUrls));
+
+		// 4. zip them together to send them parallel and receive them in order
+		return Rx.Observable.zip(...apiRequests$);
 	};
 };
 

--- a/src/apiProxy/api-proxy.js
+++ b/src/apiProxy/api-proxy.js
@@ -222,8 +222,9 @@ export const apiResponseDuotoneSetter = duotoneUrls => {
 export const makeApiRequest = (request, API_TIMEOUT, duotoneUrls) => {
 	const setApiResponseDuotones = apiResponseDuotoneSetter(duotoneUrls);
 
-	return ([requestOpts, query]) =>
-		externalRequest$(requestOpts)
+	return ([requestOpts, query]) => {
+		request.log(['api'], JSON.stringify(requestOpts.url));
+		return externalRequest$(requestOpts)
 			.timeout(API_TIMEOUT, new Error('API response timeout'))
 			.do(([response]) => request.log(['api'], `${response.elapsedTime}ms - ${response.request.uri.path}`)) // log api response time
 			.map(([response, body]) => body)    // ignore Response object, just process body string
@@ -233,6 +234,7 @@ export const makeApiRequest = (request, API_TIMEOUT, duotoneUrls) => {
 			)
 			.map(apiResponseToQueryResponse(query))    // convert apiResponse to app-ready queryResponse
 			.map(setApiResponseDuotones);        // special duotone prop
+	};
 };
 
 /**


### PR DESCRIPTION
`Observable.zip` is designed to subscribe to an array of observables all at once (parallel execution) and return their corresponding emissions as a single, ordered array (serial return), which is exactly what we want with our API calls.