### PR TITLE
WP-50 log tracking ids to stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,3 +205,14 @@ case.
 
 Use reducers to parse the response and update application state.
 
+## Tracking
+
+When starting the server, applications provide a `platform_agent` identifier,
+e.g. `'mup-web'` that is used to tag all of the automatically-generated
+tracking data produced by platform-related activity, including data requests,
+browser sessions and login/logout actions. Over time, this system will expand
+to include click tracking and other types of tracking defined by the Data team
+and implemented through platform-provided unique IDs.
+
+More info in Confluence [here](https://meetup.atlassian.net/wiki/display/WP/Tracking+data+needs)
+

--- a/src/actions/configActionCreators.js
+++ b/src/actions/configActionCreators.js
@@ -5,9 +5,3 @@ export function configureApiUrl(url) {
 	};
 }
 
-export function configureTrackingId(id) {
-	return {
-		type: 'CONFIGURE_TRACKING_ID',
-		payload: id
-	};
-}

--- a/src/epics/auth.js
+++ b/src/epics/auth.js
@@ -51,7 +51,7 @@ export const handleLogoutRequest = action$ =>
 				// a new token is provided by `LOGOUT_SUCESS` or a full refresh
 				Rx.Observable.of(configureAuth({ anonymous: true })),
 				Rx.Observable.fromPromise(
-					fetch(ANONYMOUS_AUTH_APP_PATH, { credentials: 'same-origin' })
+					fetch(ANONYMOUS_AUTH_APP_PATH, { credentials: 'same-origin' })  // response will set cookies
 						.then(response => response.json())
 				)
 				.map(logoutSuccess)

--- a/src/epics/auth.js
+++ b/src/epics/auth.js
@@ -51,7 +51,7 @@ export const handleLogoutRequest = action$ =>
 				// a new token is provided by `LOGOUT_SUCESS` or a full refresh
 				Rx.Observable.of(configureAuth({ anonymous: true })),
 				Rx.Observable.fromPromise(
-					fetch(ANONYMOUS_AUTH_APP_PATH)
+					fetch(ANONYMOUS_AUTH_APP_PATH, { credentials: 'same-origin' })
 						.then(response => response.json())
 				)
 				.map(logoutSuccess)

--- a/src/plugins/anonAuthPlugin.js
+++ b/src/plugins/anonAuthPlugin.js
@@ -239,7 +239,9 @@ export default function register(server, options, next) {
 			auth$(request).subscribe(
 				auth => {
 					const response = reply(JSON.stringify(auth)).type('application/json');
-					tracking('new anonymous user', response);
+					tracking('new anonymous user', response, {
+						newTrackId: true,
+					});
 				},
 				(err) => { reply(Boom.badImplementation(err.message)); }
 			);

--- a/src/plugins/anonAuthPlugin.js
+++ b/src/plugins/anonAuthPlugin.js
@@ -2,6 +2,8 @@ import Boom from 'boom';
 import chalk from 'chalk';
 import Rx from 'rxjs';
 
+import tracking from '../util/tracking';
+
 /**
  * @module anonAuthPlugin
  */
@@ -236,7 +238,8 @@ export default function register(server, options, next) {
 		handler: (request, reply) => {
 			auth$(request).subscribe(
 				auth => {
-					reply(JSON.stringify(auth)).type('application/json');
+					const response = reply(JSON.stringify(auth)).type('application/json');
+					tracking('new anonymous user', response);
 				},
 				(err) => { reply(Boom.badImplementation(err.message)); }
 			);

--- a/src/plugins/anonAuthPlugin.js
+++ b/src/plugins/anonAuthPlugin.js
@@ -2,7 +2,7 @@ import Boom from 'boom';
 import chalk from 'chalk';
 import Rx from 'rxjs';
 
-import tracking from '../util/tracking';
+import { trackLogout } from '../util/tracking';
 
 /**
  * @module anonAuthPlugin
@@ -239,9 +239,7 @@ export default function register(server, options, next) {
 			auth$(request).subscribe(
 				auth => {
 					const response = reply(JSON.stringify(auth)).type('application/json');
-					tracking('new anonymous user', response, {
-						newTrackId: true,
-					});
+					trackLogout(response);
 				},
 				(err) => { reply(Boom.badImplementation(err.message)); }
 			);

--- a/src/plugins/anonAuthPlugin.js
+++ b/src/plugins/anonAuthPlugin.js
@@ -236,9 +236,9 @@ export default function register(server, options, next) {
 		handler: (request, reply) => {
 			auth$(request).subscribe(
 				auth => {
-					reply(JSON.stringify(auth))
+					const response = reply(JSON.stringify(auth))
 						.type('application/json');
-					reply.track('logout');
+					reply.track(response, 'logout');
 				},
 				(err) => { reply(Boom.badImplementation(err.message)); }
 			);

--- a/src/plugins/anonAuthPlugin.js
+++ b/src/plugins/anonAuthPlugin.js
@@ -237,8 +237,8 @@ export default function register(server, options, next) {
 			auth$(request).subscribe(
 				auth => {
 					reply(JSON.stringify(auth))
-						.type('application/json')
-						.trackLogout();
+						.type('application/json');
+					reply.track('logout');
 				},
 				(err) => { reply(Boom.badImplementation(err.message)); }
 			);

--- a/src/plugins/anonAuthPlugin.js
+++ b/src/plugins/anonAuthPlugin.js
@@ -2,8 +2,6 @@ import Boom from 'boom';
 import chalk from 'chalk';
 import Rx from 'rxjs';
 
-import { trackLogout } from '../util/tracking';
-
 /**
  * @module anonAuthPlugin
  */
@@ -238,8 +236,9 @@ export default function register(server, options, next) {
 		handler: (request, reply) => {
 			auth$(request).subscribe(
 				auth => {
-					const response = reply(JSON.stringify(auth)).type('application/json');
-					trackLogout(response);
+					reply(JSON.stringify(auth))
+						.type('application/json')
+						.trackLogout();
 				},
 				(err) => { reply(Boom.badImplementation(err.message)); }
 			);

--- a/src/renderers/server-render.jsx
+++ b/src/renderers/server-render.jsx
@@ -17,7 +17,6 @@ import {
 
 import {
 	configureApiUrl,
-	configureTrackingId
 } from '../actions/configActionCreators';
 
 // Ensure global Intl for use with FormatJS
@@ -114,12 +113,11 @@ const getRouterRenderer = (store, clientFilename, assetPublicPath) =>
  * @param {Store} store Redux store for this request
  * @param {Object} config that initializes app (auth tokens, e.g. oauth_token)
  */
-const dispatchConfig = (store, { apiUrl, auth, sessionId }) => {
+const dispatchConfig = (store, { apiUrl, auth }) => {
 	console.log(chalk.green('Dispatching config'));
 
 	store.dispatch(configureAuth(auth, true));
 	store.dispatch(configureApiUrl(apiUrl));
-	store.dispatch(configureTrackingId(sessionId));
 };
 
 /**
@@ -160,7 +158,6 @@ const makeRenderer = (
 			refresh_token,
 			expires_in,
 			anonymous,
-			sessionId
 		}
 	} = request;
 
@@ -177,7 +174,7 @@ const makeRenderer = (
 	const store = createStore(routes, reducer, {}, middleware);
 
 	// load initial config
-	dispatchConfig(store, { apiUrl, auth, sessionId });
+	dispatchConfig(store, { apiUrl, auth });
 
 	// render skeleton if requested - the store is ready
 	if ('skeleton' in request.query) {

--- a/src/renderers/server-render.jsx
+++ b/src/renderers/server-render.jsx
@@ -114,12 +114,12 @@ const getRouterRenderer = (store, clientFilename, assetPublicPath) =>
  * @param {Store} store Redux store for this request
  * @param {Object} config that initializes app (auth tokens, e.g. oauth_token)
  */
-const dispatchConfig = (store, { apiUrl, auth, meetupTrack }) => {
+const dispatchConfig = (store, { apiUrl, auth, sessionId }) => {
 	console.log(chalk.green('Dispatching config'));
 
 	store.dispatch(configureAuth(auth, true));
 	store.dispatch(configureApiUrl(apiUrl));
-	store.dispatch(configureTrackingId(meetupTrack));
+	store.dispatch(configureTrackingId(sessionId));
 };
 
 /**
@@ -160,7 +160,7 @@ const makeRenderer = (
 			refresh_token,
 			expires_in,
 			anonymous,
-			meetupTrack
+			sessionId
 		}
 	} = request;
 
@@ -177,7 +177,7 @@ const makeRenderer = (
 	const store = createStore(routes, reducer, {}, middleware);
 
 	// load initial config
-	dispatchConfig(store, { apiUrl, auth, meetupTrack });
+	dispatchConfig(store, { apiUrl, auth, sessionId });
 
 	// render skeleton if requested - the store is ready
 	if ('skeleton' in request.query) {

--- a/src/routes.js
+++ b/src/routes.js
@@ -42,14 +42,14 @@ export default function getRoutes(
 			const queryResponses$ = proxyApiRequest$(request);
 			queryResponses$.subscribe(
 				queryResponses => {
-					reply(JSON.stringify(queryResponses))
+					const response = reply(JSON.stringify(queryResponses))
 						.type('application/json');
 
 					// special case - login requests need to be tracked
 					const loginResponse = queryResponses.find(r => r.login);
 					if (loginResponse) {
 						const member_id = JSON.stringify(loginResponse.login.value.member.id);
-						reply.track('login', member_id);
+						reply.track(response, 'login', member_id);
 					}
 				},
 				(err) => { reply(Boom.badImplementation(err.message)); }
@@ -77,7 +77,7 @@ export default function getRoutes(
 					// response is sent when this function returns (`nextTick`)
 					const response = reply(result)
 						.code(statusCode);
-					reply.track('session');
+					reply.track(response, 'session');
 
 					if (reply.request.app.setCookies) {
 						// when auth cookies are generated on the server rather than the

--- a/src/routes.js
+++ b/src/routes.js
@@ -44,13 +44,7 @@ export default function getRoutes(
 				queryResponses => {
 					const response = reply(JSON.stringify(queryResponses))
 						.type('application/json');
-
-					// special case - login requests need to be tracked
-					const loginResponse = queryResponses.find(r => r.login);
-					if (loginResponse) {
-						const member_id = JSON.stringify(loginResponse.login.value.member.id);
-						reply.track(response, 'login', member_id);
-					}
+					reply.track(response, 'api', queryResponses);
 				},
 				(err) => { reply(Boom.badImplementation(err.message)); }
 			);

--- a/src/routes.js
+++ b/src/routes.js
@@ -47,7 +47,7 @@ export default function getRoutes(
 					// special case - login requests need to be tracked
 					const loginResponse = queryResponses.find(r => r.login);
 					if (loginResponse) {
-						trackLogin(response, loginResponse.value.member.id);
+						trackLogin(response, loginResponse.login.value.member.id);
 					}
 				},
 				(err) => { reply(Boom.badImplementation(err.message)); }

--- a/src/routes.js
+++ b/src/routes.js
@@ -47,7 +47,7 @@ export default function getRoutes(
 					// special case - login requests need to be tracked
 					const loginResponse = queryResponses.find(r => r.login);
 					if (loginResponse) {
-						trackLogin(response, loginResponse.member.id);
+						trackLogin(response, loginResponse.value.member.id);
 					}
 				},
 				(err) => { reply(Boom.badImplementation(err.message)); }

--- a/src/routes.js
+++ b/src/routes.js
@@ -44,7 +44,7 @@ export default function getRoutes(
 			queryResponses$.subscribe(
 				queryResponses => {
 					const response = reply(JSON.stringify(queryResponses)).type('application/json');
-					if (queryResponses.find(r => r.type === 'login').length) {
+					if (queryResponses.find(r => r.type === 'login')) {
 						trackLogin(response);
 					}
 				},

--- a/src/routes.js
+++ b/src/routes.js
@@ -43,11 +43,15 @@ export default function getRoutes(
 			const queryResponses$ = proxyApiRequest$(request);
 			queryResponses$.subscribe(
 				queryResponses => {
-					const response = reply(JSON.stringify(queryResponses)).type('application/json');
+					const response = reply(JSON.stringify(queryResponses))
+						.type('application/json');
 					// special case - login requests need to be tracked
 					const loginResponse = queryResponses.find(r => r.login);
 					if (loginResponse) {
-						trackLogin(response, loginResponse.login.value.member.id);
+						trackLogin(
+							response,
+							JSON.stringify(loginResponse.login.value.member.id)
+						);
 					}
 				},
 				(err) => { reply(Boom.badImplementation(err.message)); }

--- a/src/routes.js
+++ b/src/routes.js
@@ -3,7 +3,7 @@ import Boom from 'boom';
 import chalk from 'chalk';
 
 import apiProxy$ from './apiProxy/api-proxy';
-import tracking, { trackLogin } from './util/tracking';
+import { trackSession, trackLogin } from './util/tracking';
 
 import {
 	duotones,
@@ -44,7 +44,9 @@ export default function getRoutes(
 			queryResponses$.subscribe(
 				queryResponses => {
 					const response = reply(JSON.stringify(queryResponses)).type('application/json');
-					trackLogin(queryResponses, response);
+					if (queryResponses.find(r => r.type === 'login').length) {
+						trackLogin(response);
+					}
 				},
 				(err) => { reply(Boom.badImplementation(err.message)); }
 			);
@@ -70,8 +72,7 @@ export default function getRoutes(
 				({ result, statusCode }) => {
 					// response is sent when this function returns (`nextTick`)
 					const response = reply(result).code(statusCode);
-
-					tracking('new session', response);
+					trackSession(response);
 
 					if (reply.request.app.setCookies) {
 						// when auth cookies are generated on the server rather than the

--- a/src/routes.js
+++ b/src/routes.js
@@ -70,7 +70,7 @@ export default function getRoutes(
 					// response is sent when this function returns (`nextTick`)
 					const response = reply(result).code(statusCode);
 
-					tracking(response);
+					tracking('new session', response);
 
 					if (reply.request.app.setCookies) {
 						// when auth cookies are generated on the server rather than the

--- a/src/routes.js
+++ b/src/routes.js
@@ -44,7 +44,7 @@ export default function getRoutes(
 			queryResponses$.subscribe(
 				queryResponses => {
 					const response = reply(JSON.stringify(queryResponses)).type('application/json');
-					if (queryResponses.find(r => r.type === 'login')) {
+					if (queryResponses.find(r => r.login)) {
 						trackLogin(response);
 					}
 				},
@@ -85,10 +85,11 @@ export default function getRoutes(
 							anonymous,
 						} = reply.request.state;
 
+						const path = '/';
 						request.log(['info'], chalk.green(`Setting cookies ${Object.keys(reply.request.state)}`));
-						response.state('oauth_token', oauth_token, { ttl: expires_in * 1000 });
-						response.state('refresh_token', refresh_token, { ttl: YEAR_IN_MS * 2 });
-						response.state('anonymous', anonymous.toString(), { ttl: YEAR_IN_MS * 2 });
+						response.state('oauth_token', oauth_token, { path, ttl: expires_in * 1000 });
+						response.state('refresh_token', refresh_token, { path, ttl: YEAR_IN_MS * 2 });
+						response.state('anonymous', anonymous.toString(), { path, ttl: YEAR_IN_MS * 2 });
 					}
 				}
 			);

--- a/src/routes.js
+++ b/src/routes.js
@@ -44,8 +44,10 @@ export default function getRoutes(
 			queryResponses$.subscribe(
 				queryResponses => {
 					const response = reply(JSON.stringify(queryResponses)).type('application/json');
-					if (queryResponses.find(r => r.login)) {
-						trackLogin(response);
+					// special case - login requests need to be tracked
+					const loginResponse = queryResponses.find(r => r.login);
+					if (loginResponse) {
+						trackLogin(response, loginResponse.member.id);
 					}
 				},
 				(err) => { reply(Boom.badImplementation(err.message)); }

--- a/src/routes.js
+++ b/src/routes.js
@@ -49,7 +49,7 @@ export default function getRoutes(
 					const loginResponse = queryResponses.find(r => r.login);
 					if (loginResponse) {
 						const member_id = JSON.stringify(loginResponse.login.value.member.id);
-						reply.trackLogin(member_id);
+						reply.track('login', member_id);
 					}
 				},
 				(err) => { reply(Boom.badImplementation(err.message)); }
@@ -76,8 +76,8 @@ export default function getRoutes(
 				({ result, statusCode }) => {
 					// response is sent when this function returns (`nextTick`)
 					const response = reply(result)
-						.code(statusCode)
-						.trackSession();
+						.code(statusCode);
+					reply.track('session');
 
 					if (reply.request.app.setCookies) {
 						// when auth cookies are generated on the server rather than the

--- a/src/routes.js
+++ b/src/routes.js
@@ -3,7 +3,7 @@ import Boom from 'boom';
 import chalk from 'chalk';
 
 import apiProxy$ from './apiProxy/api-proxy';
-import tracking from './util/tracking';
+import tracking, { trackLogin } from './util/tracking';
 
 import {
 	duotones,
@@ -43,7 +43,8 @@ export default function getRoutes(
 			const queryResponses$ = proxyApiRequest$(request);
 			queryResponses$.subscribe(
 				queryResponses => {
-					reply(JSON.stringify(queryResponses)).type('application/json');
+					const response = reply(JSON.stringify(queryResponses)).type('application/json');
+					trackLogin(queryResponses, response);
 				},
 				(err) => { reply(Boom.badImplementation(err.message)); }
 			);

--- a/src/routes.test.js
+++ b/src/routes.test.js
@@ -56,8 +56,8 @@ describe('routes', () => {
 				expect(cookieHeader).not.toBeNull();
 
 				const cookies = parseCookieHeader(cookieHeader);
-				expect(cookies.meetupTrack).not.toBeNull();
-				expect(UUID_V4_REGEX.test(cookies.meetupTrack)).toBe(true);
+				expect(cookies.sessionId).not.toBeNull();
+				expect(UUID_V4_REGEX.test(cookies.sessionId)).toBe(true);
 			})
 	);
 });

--- a/src/routes.test.js
+++ b/src/routes.test.js
@@ -13,9 +13,6 @@ import {
 	getServer,
 } from './util/testUtils';
 
-// RegEx to verify UUID
-const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-
 function getResponse(injectRequest, server=getServer()) {
 	// a Promise that returns the server instance after it has been
 	// configured with the routes being tested
@@ -47,17 +44,6 @@ describe('routes', () => {
 				expect(cookies.oauth_token).toBe(MOCK_OAUTH_COOKIES.oauth_token);
 				expect(cookies.refresh_token).toBe(MOCK_OAUTH_COOKIES.refresh_token);
 				expect(cookies.anonymous).toBe(MOCK_OAUTH_COOKIES.anonymous.toString());
-			})
-	);
-	it('sets tracking cookie in response', () =>
-		getResponse({ url: '/' })
-			.then(response => {
-				const cookieHeader = response.headers['set-cookie'];
-				expect(cookieHeader).not.toBeNull();
-
-				const cookies = parseCookieHeader(cookieHeader);
-				expect(cookies.track_id).not.toBeNull();
-				expect(UUID_V4_REGEX.test(cookies.track_id)).toBe(true);
 			})
 	);
 });

--- a/src/routes.test.js
+++ b/src/routes.test.js
@@ -56,8 +56,8 @@ describe('routes', () => {
 				expect(cookieHeader).not.toBeNull();
 
 				const cookies = parseCookieHeader(cookieHeader);
-				expect(cookies.sessionId).not.toBeNull();
-				expect(UUID_V4_REGEX.test(cookies.sessionId)).toBe(true);
+				expect(cookies.track_id).not.toBeNull();
+				expect(UUID_V4_REGEX.test(cookies.track_id)).toBe(true);
 			})
 	);
 });

--- a/src/server.js
+++ b/src/server.js
@@ -6,6 +6,11 @@ import ReactDOMServer from 'react-dom/server';
 import './util/globals';
 
 import getConfig from './util/config';
+import {
+	trackLogin,
+	trackLogout,
+	trackSession,
+} from './util/tracking';
 import getPlugins from './plugins';
 import getRoutes from './routes';
 
@@ -67,6 +72,10 @@ export function onPreResponse(request, reply) {
  */
 export function server(routes, connection, plugins=[]) {
 	const server = new Hapi.Server();
+
+	server.decorate('reply', 'trackLogin', trackLogin);
+	server.decorate('reply', 'trackLogout', trackLogout);
+	server.decorate('reply', 'trackSession', trackSession);
 
 	return server.connection(connection)
 		.register(plugins)

--- a/src/server.js
+++ b/src/server.js
@@ -6,11 +6,7 @@ import ReactDOMServer from 'react-dom/server';
 import './util/globals';
 
 import getConfig from './util/config';
-import {
-	trackLogin,
-	trackLogout,
-	trackSession,
-} from './util/tracking';
+import track from './util/tracking';
 import getPlugins from './plugins';
 import getRoutes from './routes';
 
@@ -73,9 +69,7 @@ export function onPreResponse(request, reply) {
 export function server(routes, connection, plugins=[]) {
 	const server = new Hapi.Server();
 
-	server.decorate('reply', 'trackLogin', trackLogin);
-	server.decorate('reply', 'trackLogout', trackLogout);
-	server.decorate('reply', 'trackSession', trackSession);
+	server.decorate('reply', 'track', track);
 
 	return server.connection(connection)
 		.register(plugins)

--- a/src/server.js
+++ b/src/server.js
@@ -66,10 +66,10 @@ export function onPreResponse(request, reply) {
 /**
  * server-starting function
  */
-export function server(routes, connection, plugins=[]) {
+export function server(routes, connection, plugins=[], platform_agent) {
 	const server = new Hapi.Server();
 
-	server.decorate('reply', 'track', track);
+	server.decorate('reply', 'track', track(platform_agent));
 
 	return server.connection(connection)
 		.register(plugins)
@@ -97,7 +97,7 @@ export function server(routes, connection, plugins=[]) {
  */
 export default function start(
 	renderRequestMap,
-	{ routes=[], plugins=[] },
+	{ routes=[], plugins=[], platform_agent='consumer_name' },
 	config=getConfig
 ) {
 	// source maps make for better stack traces - we might not want this in
@@ -118,7 +118,7 @@ export default function start(
 
 			const finalPlugins = [ ...plugins, ...getPlugins(config) ];
 
-			return server(finalRoutes, connection, finalPlugins);
+			return server(finalRoutes, connection, finalPlugins, platform_agent);
 		});
 }
 

--- a/src/util/fetchUtils.js
+++ b/src/util/fetchUtils.js
@@ -41,7 +41,7 @@ export const fetchQueries = (apiUrl, options) => queries => {
 			Authorization: `Bearer ${auth.oauth_token}`,
 			'content-type': isPost ? 'application/x-www-form-urlencoded' : 'text/plain',
 		},
-		credentials: 'same-origin'
+		credentials: 'same-origin'  // allow response to set-cookies
 	};
 	if (isPost) {
 		fetchConfig.body = params;

--- a/src/util/fetchUtils.js
+++ b/src/util/fetchUtils.js
@@ -40,7 +40,8 @@ export const fetchQueries = (apiUrl, options) => queries => {
 		headers: {
 			Authorization: `Bearer ${auth.oauth_token}`,
 			'content-type': isPost ? 'application/x-www-form-urlencoded' : 'text/plain',
-		}
+		},
+		credentials: 'same-origin'
 	};
 	if (isPost) {
 		fetchConfig.body = params;

--- a/src/util/testUtils.js
+++ b/src/util/testUtils.js
@@ -52,6 +52,7 @@ export const getServer = connection => {
 		request => () => Observable.of(request),
 		{ apply: true }
 	);
+	server.decorate('reply', 'track', function() { return this; });
 	return server;
 };
 

--- a/src/util/testUtils.js
+++ b/src/util/testUtils.js
@@ -52,7 +52,7 @@ export const getServer = connection => {
 		request => () => Observable.of(request),
 		{ apply: true }
 	);
-	server.decorate('reply', 'track', function() { return this; });
+	server.decorate('reply', 'track', () => ({}));
 	return server;
 };
 

--- a/src/util/tracking.js
+++ b/src/util/tracking.js
@@ -128,6 +128,7 @@ export const logTrack = platform_agent => (response, trackInfo) => {
 	};
 	// response.request.log will provide timestaemp
 	response.request.log(['tracking'], JSON.stringify(trackLog, null, 2));
+	return trackLog;
 };
 
 export default function track(platform_agent) {
@@ -141,8 +142,7 @@ export default function track(platform_agent) {
 		session,
 	};
 	return function(type, ...args) {
-		trackers[type](this.response, ...args);
-		return this;
+		return trackers[type](this.response, ...args);
 	};
 }
 

--- a/src/util/tracking.js
+++ b/src/util/tracking.js
@@ -17,6 +17,7 @@ export const setSessionId = (request, response) => {
 		sessionId,
 		{ encoding: 'none' }
 	);
+	return sessionId;
 };
 
 /**

--- a/src/util/tracking.js
+++ b/src/util/tracking.js
@@ -141,8 +141,8 @@ export default function decorateTrack(platform_agent) {
 		logout,
 		session,
 	};
-	return function(type, ...args) {
-		return trackers[type](this.request.response, ...args);
+	return function(response, trackType, ...args) {
+		return trackers[trackType](response, ...args);
 	};
 }
 

--- a/src/util/tracking.js
+++ b/src/util/tracking.js
@@ -3,23 +3,27 @@ import uuid from 'node-uuid';
 const YEAR_IN_MS = 1000 * 60 * 60 * 24 * 365;
 
 /**
- * @method setSessionId
+ * @method updateSessionId
  *
  * simple tracking id for the browser session
  *
  * @param {Object} hapi response object
  */
-export const setSessionId = response => {
-	const sessionId = uuid.v4();
-	response.state(
-		'session_id',
-		sessionId,
-		{
-			ttl: null,  // this explicitly a browser session cookie
-			encoding: 'none',
-			isHttpOnly: true,  // client doesn't need to access this one
-		}
-	);
+export const updateSessionId = response => {
+	let sessionId = response.request.state.session_id;
+
+	if (!sessionId) {
+		sessionId = uuid.v4();
+		response.state(
+			'session_id',
+			sessionId,
+			{
+				ttl: null,  // this explicitly a browser session cookie
+				encoding: 'none',
+				isHttpOnly: true,  // client doesn't need to access this one
+			}
+		);
+	}
 	return sessionId;
 };
 
@@ -53,11 +57,11 @@ export const updateTrackId = response => {
 	return trackId;
 };
 
-export default function trackingManager(response) {
+export default function trackingManager(description, response) {
 	const trackInfo = {
-		description: 'new session',
+		description,
 		trackId: updateTrackId(response),
-		sessionId: setSessionId(response),
+		sessionId: updateSessionId(response),
 	};
 	response.request.log(['tracking'], JSON.stringify(trackInfo, null, 2));
 	return trackInfo;

--- a/src/util/tracking.js
+++ b/src/util/tracking.js
@@ -84,10 +84,10 @@ export const trackLogout = log => response =>
 		response,
 		{
 			description: 'logout',
-			member_id: updateMemberId(this.response),
-			track_id_from: this.response.request.state.track_id,
-			track_id: updateTrackId(this.response, true),
-			session_id: this.response.request.state.session_id,
+			member_id: updateMemberId(response),
+			track_id_from: response.request.state.track_id,
+			track_id: updateTrackId(response, true),
+			session_id: response.request.state.session_id,
 		}
 	);
 
@@ -96,10 +96,10 @@ export const trackLogin = log => (response, member_id) =>
 		response,
 		{
 			description: 'login',
-			member_id: updateMemberId(this.response, member_id),
-			track_id_from: this.response.request.state.track_id,
-			track_id: updateTrackId(this.response, true),
-			session_id: this.response.request.state.session_id,
+			member_id: updateMemberId(response, member_id),
+			track_id_from: response.request.state.track_id,
+			track_id: updateTrackId(response, true),
+			session_id: response.request.state.session_id,
 		}
 	);
 
@@ -108,9 +108,9 @@ export const trackSession = log => response =>
 		response,
 		{
 			description: 'new session',
-			member_id: this.response.request.state.member_id,
-			track_id: updateTrackId(this.response),
-			session_id: updateSessionId(this.response),
+			member_id: response.request.state.member_id,
+			track_id: updateTrackId(response),
+			session_id: updateSessionId(response),
 		}
 	);
 

--- a/src/util/tracking.js
+++ b/src/util/tracking.js
@@ -109,7 +109,7 @@ export const trackSession = log => response =>
 	log(
 		response,
 		{
-			description: 'new session',
+			description: 'session',
 			member_id: response.request.state.member_id,
 			track_id: updateTrackId(response),
 			session_id: updateSessionId(response),

--- a/src/util/tracking.js
+++ b/src/util/tracking.js
@@ -131,7 +131,7 @@ export const logTrack = platform_agent => (response, trackInfo) => {
 	return trackLog;
 };
 
-export default function track(platform_agent) {
+export default function decorateTrack(platform_agent) {
 	const log = logTrack(platform_agent);
 	const login = trackLogin(log);
 	const logout = trackLogout(log);
@@ -142,7 +142,7 @@ export default function track(platform_agent) {
 		session,
 	};
 	return function(type, ...args) {
-		return trackers[type](this.response, ...args);
+		return trackers[type](this.request.response, ...args);
 	};
 }
 

--- a/src/util/tracking.js
+++ b/src/util/tracking.js
@@ -21,6 +21,7 @@ export const updateSessionId = response => {
 				ttl: null,  // this explicitly a browser session cookie
 				encoding: 'none',
 				isHttpOnly: true,  // client doesn't need to access this one
+				path: '/',
 			}
 		);
 	}
@@ -51,6 +52,7 @@ export const updateTrackId = response => {
 			{
 				ttl: YEAR_IN_MS * 20,
 				encoding: 'none',
+				path: '/',
 			}
 		);
 	}

--- a/src/util/tracking.js
+++ b/src/util/tracking.js
@@ -40,10 +40,10 @@ export const updateSessionId = response => {
  *
  * @param {Object} hapi response object
  */
-export const updateTrackId = response => {
+export const updateTrackId = (response, doUpdate) => {
 	let trackId = response.request.state.track_id;
 
-	if (!trackId) {
+	if (!trackId || doUpdate) {
 		// Generate a new track_id cookie
 		trackId = uuid.v4();
 		response.state(
@@ -59,10 +59,20 @@ export const updateTrackId = response => {
 	return trackId;
 };
 
-export default function trackingManager(description, response) {
+export const trackLogin = (queryResponses, response) => {
+	const loginResponse = queryResponses.find(r => r.type === 'login');
+	if (!loginResponse.length) {
+		return {};
+	}
+	return trackingManager('new login', response, {
+		newTrackId: true
+	});
+};
+
+export default function trackingManager(description, response, options={}) {
 	const trackInfo = {
 		description,
-		trackId: updateTrackId(response),
+		trackId: updateTrackId(response, options.newTrackId),
 		sessionId: updateSessionId(response),
 	};
 	response.request.log(['tracking'], JSON.stringify(trackInfo, null, 2));

--- a/src/util/tracking.js
+++ b/src/util/tracking.js
@@ -79,40 +79,49 @@ export const updateTrackId = (response, doRefresh) => {
 	return track_id;
 };
 
-export const trackLogout = response =>
+export function trackLogout(platform_agent) {
 	logTrack(
-		response,
+		this.response,
 		{
+			platform_agent,
 			description: 'logout',
-			member_id: updateMemberId(response),
-			track_id_from: response.request.state.track_id,
-			track_id: updateTrackId(response, true),
-			session_id: response.request.state.session_id,
+			member_id: updateMemberId(this.response),
+			track_id_from: this.response.request.state.track_id,
+			track_id: updateTrackId(this.response, true),
+			session_id: this.response.request.state.session_id,
 		}
 	);
+	return this;
+}
 
-export const trackLogin = (response, member_id) =>
+export function trackLogin(platform_agent, member_id) {
 	logTrack(
-		response,
+		this.response,
 		{
+			platform_agent,
 			description: 'login',
-			member_id: updateMemberId(response, member_id),
-			track_id_from: response.request.state.track_id,
-			track_id: updateTrackId(response, true),
-			session_id: response.request.state.session_id,
+			member_id: updateMemberId(this.response, member_id),
+			track_id_from: this.response.request.state.track_id,
+			track_id: updateTrackId(this.response, true),
+			session_id: this.response.request.state.session_id,
 		}
 	);
+	return this;
+}
 
-export const trackSession = response =>
+export function trackSession(platform_agent) {
 	logTrack(
-		response,
+		this.response,
 		{
+			platform_agent,
 			description: 'new session',
-			member_id: response.request.state.member_id,
-			track_id: updateTrackId(response),
-			session_id: updateSessionId(response),
+			member_id: this.response.request.state.member_id,
+			track_id: updateTrackId(this.response),
+			session_id: updateSessionId(this.response),
 		}
 	);
+	return this;
+}
 
 export function logTrack(response, trackInfo) {
 	const requestHeaders = response.request.headers;
@@ -123,7 +132,7 @@ export function logTrack(response, trackInfo) {
 		referrer: 'this will be handled in a special way for navigation actions',
 		ip: requestHeaders['remote-addr'],
 		agent: requestHeaders['user-agent'],
-		platform: 'something something',
+		platform: 'meetup-web-platform',
 		platform_agent: 'something something',
 	};
 	// response.request.log will provide timestaemp

--- a/src/util/tracking.js
+++ b/src/util/tracking.js
@@ -40,10 +40,10 @@ export const updateSessionId = response => {
  *
  * @param {Object} hapi response object
  */
-export const updateTrackId = (response, doUpdate) => {
+export const updateTrackId = (response, doRefresh) => {
 	let trackId = response.request.state.track_id;
 
-	if (!trackId || doUpdate) {
+	if (!trackId || doRefresh) {
 		// Generate a new track_id cookie
 		trackId = uuid.v4();
 		response.state(
@@ -59,20 +59,23 @@ export const updateTrackId = (response, doUpdate) => {
 	return trackId;
 };
 
-export const trackLogin = (queryResponses, response) => {
-	const loginResponse = queryResponses.find(r => r.type === 'login');
-	if (!loginResponse.length) {
-		return {};
-	}
-	return trackingManager('new login', response, {
-		newTrackId: true
+export const trackLogout = response =>
+	trackingManager('new anonymous user', response, {
+		refreshTrackId: true,
 	});
-};
+
+export const trackLogin = response =>
+	trackingManager('new login', response, {
+		refreshTrackId: true
+	});
+
+export const trackSession = response =>
+	trackingManager('new session', response);
 
 export default function trackingManager(description, response, options={}) {
 	const trackInfo = {
 		description,
-		trackId: updateTrackId(response, options.newTrackId),
+		trackId: updateTrackId(response, options.refreshTrackId),
 		sessionId: updateSessionId(response),
 	};
 	response.request.log(['tracking'], JSON.stringify(trackInfo, null, 2));

--- a/src/util/tracking.js
+++ b/src/util/tracking.js
@@ -1,0 +1,52 @@
+import uuid from 'node-uuid';
+
+const YEAR_IN_MS = 1000 * 60 * 60 * 24 * 365;
+
+/**
+ * @method setSessionId
+ *
+ * simple tracking id for the browser session
+ *
+ * @param {Object} hapi request object
+ * @param {Object} hapi response object
+ */
+export const setSessionId = (request, response) => {
+	const sessionId = uuid.v4();
+	response.state(
+		'session_id',
+		sessionId,
+		{ encoding: 'none' }
+	);
+};
+
+/**
+ * @method updateTrackId
+ *
+ * Initialize the trackId for member or anonymous user - the longest-living id
+ * we can assigned to a user. Stays in place until login or logout, when it is
+ * exchanged for a new trackId
+ *
+ *  - If the user has a tracking cookie already set, do nothing.
+ *  - Otherwise, generate a new uuid and set a tracking cookie.
+ *
+ * @param {Object} hapi request object
+ * @param {Object} hapi response object
+ */
+export const updateTrackId = (request, response) => {
+	let trackId = request.state.track_id;
+
+	if (!trackId) {
+		// Generate a new track_id cookie
+		trackId = uuid.v4();
+		response.state(
+			'track_id',
+			trackId,
+			{
+				ttl: YEAR_IN_MS * 20,
+				encoding: 'none'
+			}
+		);
+	}
+	return trackId;
+};
+

--- a/src/util/tracking.js
+++ b/src/util/tracking.js
@@ -115,13 +115,14 @@ export const trackSession = response =>
 	);
 
 export function logTrack(response, trackInfo) {
+	const requestHeaders = response.request.headers;
 	const trackLog = {
 		...trackInfo,
 		request_id: uuid.v4(),
-		url: '',
-		referrer: '',
-		ip: response.request.headers['remote-addr'],
-		agent: response.request.headers['user-agent'],
+		url: requestHeaders.referer,
+		referrer: 'this will be handled in a special way for navigation actions',
+		ip: requestHeaders['remote-addr'],
+		agent: requestHeaders['user-agent'],
 		platform: 'something something',
 		platform_agent: 'something something',
 	};

--- a/src/util/tracking.js
+++ b/src/util/tracking.js
@@ -88,6 +88,7 @@ export const trackLogout = log => response =>
 			track_id_from: response.request.state.track_id,
 			track_id: updateTrackId(response, true),
 			session_id: response.request.state.session_id,
+			url: response.request.info.referrer,
 		}
 	);
 
@@ -100,6 +101,7 @@ export const trackLogin = log => (response, member_id) =>
 			track_id_from: response.request.state.track_id,
 			track_id: updateTrackId(response, true),
 			session_id: response.request.state.session_id,
+			url: response.request.info.referrer,
 		}
 	);
 
@@ -111,20 +113,20 @@ export const trackSession = log => response =>
 			member_id: response.request.state.member_id,
 			track_id: updateTrackId(response),
 			session_id: updateSessionId(response),
+			url: response.request.url.path,
 		}
 	);
 
 export const logTrack = platform_agent => (response, trackInfo) => {
 	const requestHeaders = response.request.headers;
 	const trackLog = {
-		...trackInfo,
 		request_id: uuid.v4(),
-		url: requestHeaders.referer,
 		referrer: 'this will be handled in a special way for navigation actions',
 		ip: requestHeaders['remote-addr'],
 		agent: requestHeaders['user-agent'],
 		platform: 'meetup-web-platform',
 		platform_agent,
+		...trackInfo,
 	};
 	// response.request.log will provide timestaemp
 	response.request.log(['tracking'], JSON.stringify(trackLog, null, 2));

--- a/src/util/tracking.js
+++ b/src/util/tracking.js
@@ -92,6 +92,15 @@ export const trackLogout = log => response =>
 		}
 	);
 
+export const trackApi = log => (response, queryResponses) => {
+	// special case - login requests need to be tracked
+	const loginResponse = queryResponses.find(r => r.login);
+	if (loginResponse) {
+		const member_id = JSON.stringify(loginResponse.login.value.member.id);
+		return trackLogin(log)(response, member_id);
+	}
+};
+
 export const trackLogin = log => (response, member_id) =>
 	log(
 		response,
@@ -135,10 +144,12 @@ export const logTrack = platform_agent => (response, trackInfo) => {
 
 export default function decorateTrack(platform_agent) {
 	const log = logTrack(platform_agent);
+	const api = trackApi(log);
 	const login = trackLogin(log);
 	const logout = trackLogout(log);
 	const session = trackSession(log);
 	const trackers = {
+		api,
 		login,
 		logout,
 		session,

--- a/src/util/tracking.js
+++ b/src/util/tracking.js
@@ -120,7 +120,7 @@ export function logTrack(response, trackInfo) {
 		request_id: uuid.v4(),
 		url: '',
 		referrer: '',
-		ip: response.request.headers['remote_addr'],
+		ip: response.request.headers['remote-addr'],
 		agent: response.request.headers['user-agent'],
 		platform: 'something something',
 		platform_agent: 'something something',

--- a/src/util/tracking.js
+++ b/src/util/tracking.js
@@ -60,24 +60,36 @@ export const updateTrackId = (response, doRefresh) => {
 };
 
 export const trackLogout = response =>
-	trackingManager('new anonymous user', response, {
-		refreshTrackId: true,
-	});
+	logTrack(
+		response,
+		{
+			description: 'new anonymous user',
+			trackId: updateTrackId(response, true),
+			sessionId: response.request.state.session_id,
+		}
+	);
 
 export const trackLogin = response =>
-	trackingManager('new login', response, {
-		refreshTrackId: true
-	});
+	logTrack(
+		response,
+		{
+			description: 'new session',
+			trackId: updateTrackId(response, true),
+			sessionId: response.request.state.session_id,
+		}
+	);
 
 export const trackSession = response =>
-	trackingManager('new session', response);
+	logTrack(
+		response,
+		{
+			description: 'new session',
+			trackId: updateTrackId(response),
+			sessionId: updateSessionId(response),
+		}
+	);
 
-export default function trackingManager(description, response, options={}) {
-	const trackInfo = {
-		description,
-		trackId: updateTrackId(response, options.refreshTrackId),
-		sessionId: updateSessionId(response),
-	};
+export function logTrack(response, trackInfo) {
 	response.request.log(['tracking'], JSON.stringify(trackInfo, null, 2));
 	return trackInfo;
 }

--- a/src/util/tracking.test.js
+++ b/src/util/tracking.test.js
@@ -2,6 +2,7 @@ import {
 	updateSessionId,
 	updateTrackId,
 	updateMemberId,
+	trackApi,
 	trackLogout,
 	trackLogin,
 	trackSession,
@@ -177,6 +178,26 @@ describe('tracking loggers', () => {
 		expect(trackInfo.track_id_from).toBeDefined();
 		expect(trackInfo.track_id_from).toEqual(request.state.track_id);
 		expect(trackInfo.session_id).toEqual(request.state.session_id);
+	});
+	it('trackApi: calls logger with "login" when login in queryResponses', () => {
+		spyOn(spyable, 'log').and.callThrough();
+		const request = {
+			state: {
+				track_id: 'foo',
+				session_id: 'bar',
+			},
+			info: { referrer: 'baz' }
+		};
+		const loginResponse = {
+			...MOCK_HAPI_RESPONSE,
+			request
+		};
+		const trackInfo = trackApi(spyable.log)(
+			loginResponse,
+			[{ login: { type: 'login', value: { member: { id: 1234 } } } }]
+		);
+		expect(spyable.log).toHaveBeenCalled();
+		expect(trackInfo.description).toEqual('login');  // this may change, but need to ensure tag is always correct
 	});
 	it('trackSession: calls logger with "session", new session_id, old track_id & member_id', () => {
 		spyOn(spyable, 'log').and.callThrough();

--- a/src/util/tracking.test.js
+++ b/src/util/tracking.test.js
@@ -1,0 +1,9 @@
+// RegEx to verify UUID
+const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+describe('trackLogin', () => {
+	it('calls the log function with stuff', () => {
+		expect(UUID_V4_REGEX).toBe(UUID_V4_REGEX);
+	});
+});
+

--- a/src/util/tracking.test.js
+++ b/src/util/tracking.test.js
@@ -1,9 +1,206 @@
+import {
+	updateSessionId,
+	updateTrackId,
+	updateMemberId,
+	trackLogout,
+	trackLogin,
+	trackSession,
+} from './tracking';
 // RegEx to verify UUID
 const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
-describe('trackLogin', () => {
-	it('calls the log function with stuff', () => {
-		expect(UUID_V4_REGEX).toBe(UUID_V4_REGEX);
+const MOCK_HAPI_RESPONSE = {
+	state: (name, value, opts) => {},
+	unstate: name => {},
+	request: {
+		state: {}
+	}
+};
+
+describe('tracking state setters', () => {
+	it('sets session id if not set', () => {
+		const responseWithoutSessionId = MOCK_HAPI_RESPONSE;
+		spyOn(responseWithoutSessionId, 'state');
+		const session_id = updateSessionId(responseWithoutSessionId);
+		expect(UUID_V4_REGEX.test(session_id)).toBe(true);
+		expect(responseWithoutSessionId.state)
+			.toHaveBeenCalledWith('session_id', session_id, jasmine.any(Object));
+	});
+	it('does not set session id if already set', () => {
+		const session_id = 'foo';
+		const request = { state: { session_id } };
+		const responseWithSessionId = {
+			...MOCK_HAPI_RESPONSE,
+			request,
+		};
+		spyOn(responseWithSessionId, 'state');
+		const new_session_id = updateSessionId(responseWithSessionId);
+		expect(new_session_id).toBe(session_id);
+		expect(responseWithSessionId.state).not.toHaveBeenCalled();
+	});
+	it('sets track id if not set', () => {
+		const responseWithoutTrackId = MOCK_HAPI_RESPONSE;
+		spyOn(responseWithoutTrackId, 'state');
+		const track_id = updateTrackId(responseWithoutTrackId);
+		expect(UUID_V4_REGEX.test(track_id)).toBe(true);
+		expect(responseWithoutTrackId.state)
+			.toHaveBeenCalledWith('track_id', track_id, jasmine.any(Object));
+	});
+	it('does not set track id if already set', () => {
+		const track_id = 'foo';
+		const request = { state: { track_id } };
+		const responseWithTrackId = {
+			...MOCK_HAPI_RESPONSE,
+			request,
+		};
+		spyOn(responseWithTrackId, 'state');
+		expect(responseWithTrackId.state).not.toHaveBeenCalled();
+	});
+	it('sets new track id if doRefresh is true', () => {
+		const track_id = 'foo';
+		const doRefresh = true;
+		const request = { state: { track_id } };
+		const responseWithTrackId = {
+			...MOCK_HAPI_RESPONSE,
+			request,
+		};
+		spyOn(responseWithTrackId, 'state');
+		const new_track_id = updateTrackId(responseWithTrackId, doRefresh);
+		expect(new_track_id).not.toBe(track_id);
+		expect(responseWithTrackId.state)
+			.toHaveBeenCalledWith('track_id', new_track_id, jasmine.any(Object));
+	});
+	it('always sets member_id to passed-in value', () => {
+		const member_id = 1234;
+		spyOn(MOCK_HAPI_RESPONSE, 'state');
+		const new_member_id = updateMemberId(MOCK_HAPI_RESPONSE, member_id);
+		expect(new_member_id).toBe(member_id);
+		expect(MOCK_HAPI_RESPONSE.state)
+			.toHaveBeenCalledWith('member_id', member_id, jasmine.any(Object));
+
+	});
+	it('overrides request\'s member_id', () => {
+		const member_id = 'foo';
+		const request = { state: { member_id } };
+		const responseWithMemberIdRequest = {
+			...MOCK_HAPI_RESPONSE,
+			request
+		};
+		spyOn(responseWithMemberIdRequest, 'state');
+		const new_member_id = 'bar';
+		const returned_member_id = updateMemberId(responseWithMemberIdRequest, new_member_id);
+		expect(returned_member_id).toBe(new_member_id);
+		expect(responseWithMemberIdRequest.state)
+			.toHaveBeenCalledWith('member_id', new_member_id, jasmine.any(Object));
+	});
+	it('unsets member_id if none passed in', () => {
+		spyOn(MOCK_HAPI_RESPONSE, 'unstate');
+		spyOn(MOCK_HAPI_RESPONSE, 'state');
+		updateMemberId(MOCK_HAPI_RESPONSE);
+		expect(MOCK_HAPI_RESPONSE.unstate).toHaveBeenCalledWith('member_id');
+		expect(MOCK_HAPI_RESPONSE.state).not.toHaveBeenCalled();
+	});
+	it('returns request\'s member_id, if present, when un-setting', () => {
+		const member_id = 'foo';
+		const request = { state: { member_id } };
+		const responseWithMemberIdRequest = {
+			...MOCK_HAPI_RESPONSE,
+			request
+		};
+		const request_member_id = updateMemberId(responseWithMemberIdRequest);
+		expect(request_member_id).toBe(member_id);
+		const no_request_member_id = updateMemberId(MOCK_HAPI_RESPONSE);
+		expect(no_request_member_id).toBeUndefined();
 	});
 });
 
+describe('tracking loggers', () => {
+	const spyable = {
+		log: (response, info) => info,
+	};
+	/*
+		description: 'login',
+		member_id: updateMemberId(response, member_id),
+		track_id_from: response.request.state.track_id,
+		track_id: updateTrackId(response, true),
+		session_id: response.request.state.session_id,
+		url: response.request.info.referrer,
+	*/
+	it('trackLogout: calls logger with "logout", new track_id, old session_id, member_id, track_id_from', () => {
+		spyOn(spyable, 'log').and.callThrough();
+		const request = {
+			state: {
+				member_id: 'dr moose',
+				track_id: 'foo',
+				session_id: 'bar',
+			},
+			info: { referrer: 'baz' }
+		};
+		const loginResponse = {
+			...MOCK_HAPI_RESPONSE,
+			request
+		};
+		const trackInfo = trackLogout(spyable.log)(loginResponse);
+		expect(spyable.log).toHaveBeenCalled();
+		expect(trackInfo.description).toEqual('logout');  // this may change, but need to ensure tag is always correct
+		// new
+		expect(trackInfo.track_id).toBeDefined();
+		expect(trackInfo.track_id).not.toEqual(request.state.track_id);
+		// old
+		expect(trackInfo.track_id_from).toBeDefined();
+		expect(trackInfo.track_id_from).toEqual(request.state.track_id);
+		expect(trackInfo.session_id).toEqual(request.state.session_id);
+		expect(trackInfo.member_id).toEqual(request.state.member_id);
+	});
+	it('trackLogin: calls logger with "login", new member_id & track_id, old session_id', () => {
+		spyOn(spyable, 'log').and.callThrough();
+		const request = {
+			state: {
+				track_id: 'foo',
+				session_id: 'bar',
+			},
+			info: { referrer: 'baz' }
+		};
+		const loginResponse = {
+			...MOCK_HAPI_RESPONSE,
+			request
+		};
+		const member_id = 1234;
+		const trackInfo = trackLogin(spyable.log)(loginResponse, member_id);
+		expect(spyable.log).toHaveBeenCalled();
+		expect(trackInfo.description).toEqual('login');  // this may change, but need to ensure tag is always correct
+		// new
+		expect(trackInfo.track_id).toBeDefined();
+		expect(trackInfo.track_id).not.toEqual(request.state.track_id);
+		expect(trackInfo.member_id).toEqual(member_id);
+		// old
+		expect(trackInfo.track_id_from).toBeDefined();
+		expect(trackInfo.track_id_from).toEqual(request.state.track_id);
+		expect(trackInfo.session_id).toEqual(request.state.session_id);
+	});
+	it('trackSession: calls logger with "session", new session_id, old track_id & member_id', () => {
+		spyOn(spyable, 'log').and.callThrough();
+		const request = {
+			state: {
+				member_id: 1234,
+				track_id: 'foo',
+			},
+			info: { referrer: 'baz' },
+			url: { path: 'afogato' },
+		};
+		const loginResponse = {
+			...MOCK_HAPI_RESPONSE,
+			request
+		};
+		const trackInfo = trackSession(spyable.log)(loginResponse);
+		expect(spyable.log).toHaveBeenCalled();
+		expect(trackInfo.description).toEqual('session');  // this may change, but need to ensure tag is always correct
+		// new
+		expect(trackInfo.session_id).toBeDefined();
+		expect(trackInfo.session_id).not.toEqual(request.state.session_id);
+		// old
+		expect(trackInfo.track_id).toBeDefined();
+		expect(trackInfo.track_id).toEqual(request.state.track_id);
+		expect(trackInfo.member_id).toEqual(request.state.member_id);
+	});
+});


### PR DESCRIPTION
This update has 2 parts:

1. a dedicated module for logging tracking information and setting server response cookies (`src/util/tracking.js`) - the default export provides an interface that is used to "decorate" the `reply` interface of the Hapi server so that you can call `reply.track(response, <tracking type>, ...args)` wherever a response needs tracking cookies to be managed.
2. Add more unique ids to the tracking system
    1. `track_id` (mostly implemented in a previous ticket - might end up being `user_id` or similar)
    2. `session_id` (new)
    3. `member_id` (when known)
    4. `request_id` - still not 100% of the definition of this, but currently just a unique id for each tracked action
    5. metadata from https://meetup.atlassian.net/wiki/display/WP/Tracking+data+needs

### Example output

**new browser session**

```
2016-11-02 03:16:35.995, [request,tracking] data: {
  "description": "session",
  "track_id": "6ac3895e-23b7-46d4-994b-69a5e9a66ed4",
  "session_id": "70441e49-7446-4d46-b7dc-49e3fa150bcc",
  "request_id": "8aef1f5c-b6fa-430c-83ca-452ad298fdcc",
  "referrer": "this will be handled in a special way for navigation actions",
  "agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.71 Safari/537.36",
  "platform": "meetup-web-platform",
  "platform_agent": "mup-web"
}
```

**login**

note `track_id_from` is the `track_id` from the `"new session"` log

```
2016-11-02 03:17:24.750, [request,tracking] data: {
  "description": "login",
  "member_id": "89499392",
  "track_id_from": "6ac3895e-23b7-46d4-994b-69a5e9a66ed4",
  "track_id": "b94f6159-1711-4fe8-8363-c0f320584074",
  "session_id": "70441e49-7446-4d46-b7dc-49e3fa150bcc",
  "request_id": "38bf938b-a81f-4e9c-923a-c499182ccf7e",
  "url": "http://localhost:8000/login/",
  "referrer": "this will be handled in a special way for navigation actions",
  "agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.71 Safari/537.36",
  "platform": "meetup-web-platform",
  "platform_agent": "mup-web"
}
```

**logout**

note `track_id_from` is the `track_id` from the `"login"` log

```
2016-11-02 03:18:00.550, [request,tracking] data: {
  "description": "logout",
  "member_id": "89499392",
  "track_id_from": "b94f6159-1711-4fe8-8363-c0f320584074",
  "track_id": "49609c17-aaea-415d-a033-aa758a92cd61",
  "session_id": "70441e49-7446-4d46-b7dc-49e3fa150bcc",
  "request_id": "717f0f32-23c7-4e46-a1f4-a815922c4471",
  "url": "http://localhost:8000/login/",
  "referrer": "this will be handled in a special way for navigation actions",
  "agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.71 Safari/537.36",
  "platform": "meetup-web-platform",
  "platform_agent": "mup-web"
}
```