### PR TITLE
New testUtil: routeRenderer

### DIFF
--- a/src/util/testUtils.js
+++ b/src/util/testUtils.js
@@ -1,8 +1,13 @@
+import React from 'react';
 import { Observable } from 'rxjs';
 import { ActionsObservable } from 'redux-observable';
 import Hapi from 'hapi';
 import Cookie from 'tough-cookie';
 import TestUtils from 'react-addons-test-utils';
+import RouterContext from 'react-router/lib/RouterContext';
+import match from 'react-router/lib/match';
+import { IntlProvider } from 'react-intl';
+import { Provider } from 'react-redux';
 import {
 	MOCK_MEANINGLESS_ACTION,
 	MOCK_APP_STATE
@@ -65,3 +70,32 @@ export const epicIgnoreAction = (epic, action=MOCK_MEANINGLESS_ACTION, store=cre
 		.do(spyable.notCalled, null, expect(spyable.notCalled).not.toHaveBeenCalled())
 		.toPromise();
 };
+
+/**
+ * Curry a function that takes a set of React Router routes and a location to
+ * render, and return a Promise that resolves with the rendered React app
+ *
+ * @example
+ * ```
+ * const renderLocation = routeRenderer(routes);
+ * renderLocation('/').then(app => ...);
+ * renderLocation('/foo').then(app => ...);
+ * ```
+ */
+export const routeRenderer = routes => {
+	const FAKE_STORE = createFakeStore(MOCK_APP_STATE);
+	return location =>
+		new Promise((resolve, reject) => {
+			match({ location, routes }, (err, redirectLocation, renderProps) => {
+				const app = TestUtils.renderIntoDocument(
+					<IntlProvider locale='en'>
+						<Provider store={FAKE_STORE}>
+							<RouterContext {...renderProps} />
+						</Provider>
+					</IntlProvider>
+				);
+				resolve(app);
+			});
+		});
+};
+

--- a/src/util/testUtils.js
+++ b/src/util/testUtils.js
@@ -83,9 +83,9 @@ export const epicIgnoreAction = (epic, action=MOCK_MEANINGLESS_ACTION, store=cre
  * ```
  */
 export const routeRenderer = routes => {
-	const FAKE_STORE = createFakeStore(MOCK_APP_STATE);
-	return location =>
-		new Promise((resolve, reject) => {
+	return (location, state=MOCK_APP_STATE) => {
+		const FAKE_STORE = createFakeStore(state);
+		return new Promise((resolve, reject) => {
 			match({ location, routes }, (err, redirectLocation, renderProps) => {
 				const app = TestUtils.renderIntoDocument(
 					<IntlProvider locale='en'>
@@ -97,5 +97,6 @@ export const routeRenderer = routes => {
 				resolve(app);
 			});
 		});
+	};
 };
 

--- a/src/util/testUtils.js
+++ b/src/util/testUtils.js
@@ -82,21 +82,18 @@ export const epicIgnoreAction = (epic, action=MOCK_MEANINGLESS_ACTION, store=cre
  * renderLocation('/foo').then(app => ...);
  * ```
  */
-export const routeRenderer = routes => {
-	return (location, state=MOCK_APP_STATE) => {
-		const FAKE_STORE = createFakeStore(state);
-		return new Promise((resolve, reject) => {
-			match({ location, routes }, (err, redirectLocation, renderProps) => {
-				const app = TestUtils.renderIntoDocument(
-					<IntlProvider locale='en'>
-						<Provider store={FAKE_STORE}>
-							<RouterContext {...renderProps} />
-						</Provider>
-					</IntlProvider>
-				);
-				resolve(app);
-			});
-		});
-	};
-};
+export const routeRenderer = routes => (location, state=MOCK_APP_STATE) =>
+	new Promise((resolve, reject) =>
+		match({ location, routes }, (err, redirectLocation, renderProps) => {
+			const FAKE_STORE = createFakeStore(state);
+			const app = TestUtils.renderIntoDocument(
+				<IntlProvider locale='en'>
+					<Provider store={FAKE_STORE}>
+						<RouterContext {...renderProps} />
+					</Provider>
+				</IntlProvider>
+			);
+			resolve(app);
+		})
+	);
 


### PR DESCRIPTION
Testing application routes requires a fair amount of boilerplate to set up, and all of the dependencies are already part of the platform, so it makes sense to provide a simpler interface for rendering a route in an app's unit tests.

This PR adds `util/testUtils.js:routeRenderer` - a function that takes an app's `routes` and returns a function that renders a particular location (url) and returns a promise that resolves with the rendered React app. This function can then be called repeatedly with different locations across multiple unit tests. I'll set up a PR for mup-web that demonstrates how much it simplifies the route testing.