### PR TITLE
WP-49 - request/parse feature flags from the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,24 @@ server routes and plugins. See the code comments for usage details.
 
 ## API Adapter
 
+### Query
+
+The app server expects API requests to be provided in the form of `query`
+objects in the payload of a single request to the app server at the `/api`
+endpoint. A query takes the following shape:
+
+```js
+{
+	type: <string>,
+	params: {
+		<string>: <string>,
+		...
+	},
+	ref: <string>,
+	flags: [<string>, ...],
+}
+```
+
 When the application server receives the JSON-encoded array of queries,
 it uses an API adapter module to translate those into the configuration
 needed to fetch data from an external API. The application server is
@@ -96,6 +114,15 @@ This adapter is used to proxy all requests to `/api`.
 From the client-side application's point of view, it will always send
 the `queries` and recieve the `queryResponses` for any data request -
 all the API-specific translations happen on the server.
+
+### Feature flags
+
+The API adapter provides an interface into feature flag values - just pass
+an array of feature flag names in the `flags` array of your query, and the
+response from the API adapter will return an object mapping the flag names to
+their true/false valuse in the `flags` property of the response. Your
+application will probably add these flag values directly to the Redux `state`,
+where they can be consumed by components to affect the UI.
 
 ## Middleware/Epics
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ endpoint. A query takes the following shape:
 		...
 	},
 	ref: <string>,
-	flags: [<string>, ...],
+	flags?: [<string>, ...],
 }
 ```
 
@@ -114,6 +114,21 @@ This adapter is used to proxy all requests to `/api`.
 From the client-side application's point of view, it will always send
 the `queries` and recieve the `queryResponses` for any data request -
 all the API-specific translations happen on the server.
+
+A `queryResponse` takes the following shape:
+
+```js
+{
+	<string (ref)>: {
+		value?: <parsed API response JSON>
+		flags?: {
+			<string>: <Boolean>
+			...
+		},
+		error?: <string>
+	}
+}
+```
 
 ### Feature flags
 

--- a/src/apiProxy/api-proxy.js
+++ b/src/apiProxy/api-proxy.js
@@ -41,9 +41,9 @@ export const parseApiResponse = ([response, body]) => {
 	let value;
 	const flags = parseResponseFlags(response);
 
-	if ((response.status || response.statusCode) > 299) {
+	if (response.statusCode > 299) {
 		return {
-			value: { error: response.statusText },
+			value: { error: response.statusMessage },
 			flags,
 		};
 	}
@@ -248,9 +248,9 @@ export const apiResponseDuotoneSetter = duotoneUrls => {
 	};
 };
 
-const MOCK_RESPONSE_OK = {
-	ok: true,
-	status: 200,
+const MOCK_RESPONSE_OK = {  // minimal representation of http.IncomingMessage
+	statusCode: 200,
+	statusMessage: 'OK',
 	headers: {},
 };
 /**

--- a/src/apiProxy/api-proxy.js
+++ b/src/apiProxy/api-proxy.js
@@ -248,11 +248,16 @@ export const apiResponseDuotoneSetter = duotoneUrls => {
 	};
 };
 
+const MOCK_RESPONSE_OK = {
+	ok: true,
+	status: 200,
+	headers: {},
+};
 /**
  * Fake an API request and directly return the stringified mockResponse
  */
 const makeMockRequest = mockResponse => requestOpts =>
-	Rx.Observable.of(JSON.stringify(mockResponse))
+	Rx.Observable.of([MOCK_RESPONSE_OK, JSON.stringify(mockResponse)])
 		.do(() => console.log(`MOCKING response to ${requestOpts.url}`));
 
 const logResponseTime = log => ([response, body]) =>
@@ -264,8 +269,7 @@ const logResponseTime = log => ([response, body]) =>
 const makeExternalApiRequest = (request, API_TIMEOUT) => requestOpts =>
 	externalRequest$(requestOpts)
 		.timeout(API_TIMEOUT, new Error('API response timeout'))
-		.do(logResponseTime(request.log.bind(request)))
-		.map(([response, body]) => body);    // ignore Response object, just process body string
+		.do(logResponseTime(request.log.bind(request)));
 
 /**
  * Make an API request and parse the response into the expected `response`

--- a/src/apiProxy/api-proxy.js
+++ b/src/apiProxy/api-proxy.js
@@ -10,7 +10,7 @@ const parseResponseFlags = ({ headers }) =>
 		.split(',')
 		.map(pair => pair.split('='))
 		.reduce((flags, [key, val]) => {
-			flags[key] = val;
+			flags[key] = val === 'true';
 			return flags;
 		}, {});
 

--- a/src/apiProxy/api-proxy.js
+++ b/src/apiProxy/api-proxy.js
@@ -121,7 +121,8 @@ function urlFormatParams(params, doEncode) {
 export const buildRequestArgs = externalRequestOpts =>
 	({ endpoint, params, flags }) => {
 
-		const opts = { ...externalRequestOpts };
+		// cheap, brute-force object clone, acceptable for serializable object
+		const opts = JSON.parse(JSON.stringify(externalRequestOpts));
 		opts.url = `/${endpoint}`;
 
 		const formattedParams = urlFormatParams(params, opts.method === 'get');

--- a/src/apiProxy/api-proxy.js
+++ b/src/apiProxy/api-proxy.js
@@ -6,7 +6,7 @@ import * as apiConfigCreators from './apiConfigCreators';
 import { duotoneRef } from '../util/duotone';
 
 const parseResponseFlags = ({ headers }) =>
-	(headers['X-Meetup-Flags'] || '')
+	(headers['x-meetup-flags'] || '')
 		.split(',')
 		.filter(pair => pair)
 		.map(pair => pair.split('='))

--- a/src/apiProxy/api-proxy.js
+++ b/src/apiProxy/api-proxy.js
@@ -41,7 +41,7 @@ export const parseApiResponse = ([response, body]) => {
 	let value;
 	const flags = parseResponseFlags(response);
 
-	if (!response.ok) {
+	if (response.statusCode > 299) {
 		return {
 			value: { error: response.statusText },
 			flags,

--- a/src/apiProxy/api-proxy.js
+++ b/src/apiProxy/api-proxy.js
@@ -41,7 +41,7 @@ export const parseApiResponse = ([response, body]) => {
 	let value;
 	const flags = parseResponseFlags(response);
 
-	if (response.statusCode > 299) {
+	if ((response.status || response.statusCode) > 299) {
 		return {
 			value: { error: response.statusText },
 			flags,

--- a/src/apiProxy/api-proxy.js
+++ b/src/apiProxy/api-proxy.js
@@ -8,9 +8,10 @@ import { duotoneRef } from '../util/duotone';
 const parseResponseFlags = ({ headers }) =>
 	(headers['X-Meetup-Flags'] || '')
 		.split(',')
+		.filter(pair => pair)
 		.map(pair => pair.split('='))
 		.reduce((flags, [key, val]) => {
-			flags[key] = val === 'true';
+			flags[key] = val === '1';
 			return flags;
 		}, {});
 
@@ -78,7 +79,10 @@ export function queryToApiConfig({ type, params, flags }) {
 	if (!configCreator) {
 		throw new ReferenceError(`No API specified for query type ${type}`);
 	}
-	return configCreator(params);
+	return {
+		...configCreator(params),  // endpoint, params
+		flags,
+	};
 }
 
 /**
@@ -145,7 +149,7 @@ export const buildRequestArgs = externalRequestOpts =>
  *
  * @param {Object} apiResponse JSON-parsed api response data
  */
-export const apiResponseToQueryResponse = query => ({ flags, value }) => ({
+export const apiResponseToQueryResponse = query => ({ value, flags }) => ({
 	[query.ref]: {
 		type: query.type,
 		value,

--- a/src/apiProxy/api-proxy.js
+++ b/src/apiProxy/api-proxy.js
@@ -11,7 +11,7 @@ const parseResponseFlags = ({ headers }) =>
 		.filter(pair => pair)
 		.map(pair => pair.split('='))
 		.reduce((flags, [key, val]) => {
-			flags[key] = val === '1';
+			flags[key] = val === 'true';
 			return flags;
 		}, {});
 

--- a/src/apiProxy/api-proxy.test.js
+++ b/src/apiProxy/api-proxy.test.js
@@ -68,6 +68,14 @@ describe('parseApiResponse', () => {
 		const nonOkReponse = { ...MOCK_RESPONSE, ...badStatus };
 		expect(parseApiResponse([nonOkReponse, '{}']).value.error).toEqual(badStatus.statusText);
 	});
+	it('returns the flags set in the X-Meetup-Flags header', () => {
+		const headers = {
+			'X-Meetup-Flags': 'foo=true,bar=false',
+		};
+		const flaggedResponse = { ...MOCK_RESPONSE, headers };
+		expect(parseApiResponse([flaggedResponse, '{}']).flags.foo).toBe(true);
+		expect(parseApiResponse([flaggedResponse, '{}']).flags.bar).toBe(false);
+	});
 });
 
 describe('queryToApiConfig', () => {

--- a/src/apiProxy/api-proxy.test.js
+++ b/src/apiProxy/api-proxy.test.js
@@ -195,6 +195,7 @@ describe('makeApiRequest$', () => {
 		const query = { ...mockQuery(MOCK_RENDERPROPS), mockResponse };
 		const expectedResponse = {
 			[query.ref]: {
+				flags: {},
 				type: query.type,
 				value: mockResponse,
 			}

--- a/src/apiProxy/api-proxy.test.js
+++ b/src/apiProxy/api-proxy.test.js
@@ -44,7 +44,6 @@ describe('parseRequest', () => {
 describe('parseApiResponse', () => {
 	const MOCK_RESPONSE = {
 		headers: {},
-		ok: true,
 		statusCode: 200
 	};
 	it('converts valid JSON into an equivalent object', () => {
@@ -63,11 +62,11 @@ describe('parseApiResponse', () => {
 	it('returns an object with a string "error" value for a not-ok response', () => {
 		const badStatus = {
 			ok: false,
-			status: 500,
-			statusText: 'Problems',
+			statusCode: 500,
+			statusMessage: 'Problems',
 		};
 		const nonOkReponse = { ...MOCK_RESPONSE, ...badStatus };
-		expect(parseApiResponse([nonOkReponse, '{}']).value.error).toEqual(badStatus.statusText);
+		expect(parseApiResponse([nonOkReponse, '{}']).value.error).toEqual(badStatus.statusMessage);
 	});
 	it('returns the flags set in the X-Meetup-Flags header', () => {
 		const headers = {

--- a/src/apiProxy/api-proxy.test.js
+++ b/src/apiProxy/api-proxy.test.js
@@ -41,18 +41,32 @@ describe('parseRequest', () => {
 });
 
 describe('parseApiResponse', () => {
+	const MOCK_RESPONSE = {
+		headers: {},
+		ok: true,
+		status: 200
+	};
 	it('converts valid JSON into an equivalent object', () => {
 		const validJSON = JSON.stringify(MOCK_GROUP);
-		expect(parseApiResponse(validJSON)).toEqual(jasmine.any(Object));
-		expect(parseApiResponse(validJSON)).toEqual(MOCK_GROUP);
+		expect(parseApiResponse([MOCK_RESPONSE, validJSON]).value).toEqual(jasmine.any(Object));
+		expect(parseApiResponse([MOCK_RESPONSE, validJSON]).value).toEqual(MOCK_GROUP);
 	});
 	it('returns an object with a string "error" value for invalid JSON', () => {
 		const invalidJSON = 'not valid';
-		expect(parseApiResponse(invalidJSON).error).toEqual(jasmine.any(String));
+		expect(parseApiResponse([MOCK_RESPONSE, invalidJSON]).value.error).toEqual(jasmine.any(String));
 	});
 	it('returns an object with a string "error" value for API response with "problem"', () => {
 		const responeWithProblem = JSON.stringify(MOCK_API_PROBLEM);
-		expect(parseApiResponse(responeWithProblem).error).toEqual(jasmine.any(String));
+		expect(parseApiResponse([MOCK_RESPONSE, responeWithProblem]).value.error).toEqual(jasmine.any(String));
+	});
+	it('returns an object with a string "error" value for a not-ok response', () => {
+		const badStatus = {
+			ok: false,
+			status: 500,
+			statusText: 'Problems',
+		};
+		const nonOkReponse = { ...MOCK_RESPONSE, ...badStatus };
+		expect(parseApiResponse([nonOkReponse, '{}']).value.error).toEqual(badStatus.statusText);
 	});
 });
 

--- a/src/apiProxy/api-proxy.test.js
+++ b/src/apiProxy/api-proxy.test.js
@@ -70,7 +70,7 @@ describe('parseApiResponse', () => {
 	});
 	it('returns the flags set in the X-Meetup-Flags header', () => {
 		const headers = {
-			'X-Meetup-Flags': 'foo=true,bar=false',
+			'x-meetup-flags': 'foo=true,bar=false',
 		};
 		const flaggedResponse = { ...MOCK_RESPONSE, headers };
 		expect(parseApiResponse([flaggedResponse, '{}']).flags.foo).toBe(true);

--- a/src/apiProxy/api-proxy.test.js
+++ b/src/apiProxy/api-proxy.test.js
@@ -44,7 +44,7 @@ describe('parseApiResponse', () => {
 	const MOCK_RESPONSE = {
 		headers: {},
 		ok: true,
-		status: 200
+		statusCode: 200
 	};
 	it('converts valid JSON into an equivalent object', () => {
 		const validJSON = JSON.stringify(MOCK_GROUP);


### PR DESCRIPTION
The REST API provides a way of reading arbitrary feature flag values using headers in the API requests.

This PR adds a feature to the `query` parsing in the API proxy that will read an array of feature flag names and return a map of `{ [flagName]: [Boolean value] }` in the response so that the flags can be stored in Redux and consumed by the app's UI components