### PR TITLE
WP-59 make sure oauth token is set before syncing location

### DIFF
--- a/src/actions/authActionCreators.js
+++ b/src/actions/authActionCreators.js
@@ -34,11 +34,11 @@ export function loginPost(params) {
 	};
 }
 
-export function configureAuth(auth, isServer) {
+export function configureAuth(auth, suppressSync) {
 	return {
 		type: 'CONFIGURE_AUTH',
 		payload: auth,
-		meta: isServer
+		meta: suppressSync
 	};
 }
 

--- a/src/epics/sync.js
+++ b/src/epics/sync.js
@@ -40,7 +40,8 @@ export const getNavEpic = routes => {
  */
 export const resetLocationEpic = (action$, store) =>
 	action$.ofType('CONFIGURE_AUTH')  // auth changes imply privacy changes - reload
-		.filter(({ meta }) => !meta)  // throw out any server-side actions
+		.filter(({ meta }) => !meta)  // throw out any cases where sync is specifically suppressed
+		.filter(() => !store.getState().auth.oauth_token)  // ignore cases where auth tokens are not set
 		.map(() => locationSync(store.getState().routing.locationBeforeTransitions));
 
 /**


### PR DESCRIPTION
Currently, we attempt to re-load the application state from the API as soon as someone logs out because the auth info has changed. However, we can't actually re-load from the API because the auth info has been _cleared_, so we don't have a valid oauth_token for the API call.

This PR updates the logic so that we never try to re-load the app state from the API without an oauth_token.

The downside is that it takes two http round trips to get the logged-out app state, because we have to make one request to the anonymous auth endpoint, and a separate request to the API once we receive a new anonymous oauth token. This can be a little slow, but for now I consider it acceptable behavior.

In the future, we might want to optimize by caching the most recently-used anonymous oauth token in some way so that it can immediately be used to get reload the logged-out app state when the initial `LOGOUT_REQUEST` is dispatched.
