### PR TITLE
WP-72 Fix UTF-8 encoded characters when passing URLs through to the api.

### DIFF
--- a/src/apiProxy/api-proxy.js
+++ b/src/apiProxy/api-proxy.js
@@ -99,7 +99,7 @@ function urlFormatParams(params, doEncode) {
  */
 export const buildRequestArgs = externalRequestOpts => ({ endpoint, params }) => {
 	const externalRequestOptsQuery = { ...externalRequestOpts };
-	externalRequestOptsQuery.url = `/${endpoint}`;
+	externalRequestOptsQuery.url = encodeURI(`/${endpoint}`);
 
 	const dataParams = urlFormatParams(params, externalRequestOptsQuery.method === 'get');
 

--- a/src/apiProxy/api-proxy.test.js
+++ b/src/apiProxy/api-proxy.test.js
@@ -100,12 +100,12 @@ describe('buildRequestArgs', () => {
 
 	const testQueryResults_utf8 = mockQuery(MOCK_RENDERPROPS_UTF8);
 	const apiConfig_utf8 = queryToApiConfig(testQueryResults_utf8);
-	const encoded_url = '/%E3%83%90-%E4%BA%AC';
 
 	it('Properly encodes the URL', () => {
 		const method = 'get';
 		const getArgs = buildRequestArgs({ ...options, method })(apiConfig_utf8);
-		expect(getArgs.url.split('?')[0]).toEqual(encoded_url);
+		const { pathname } = require('url').parse(getArgs.url);
+		expect(/^[\x00-\xFF]*$/.test(pathname)).toBe(true);
 	});
 
 });

--- a/src/apiProxy/api-proxy.test.js
+++ b/src/apiProxy/api-proxy.test.js
@@ -94,7 +94,24 @@ describe('buildRequestArgs', () => {
 		expect(postArgs.body).toEqual(jasmine.any(String));  // post requests will add body string
 		// post requests will add body string
 		expect(postArgs.headers['content-type']).toEqual('application/x-www-form-urlencoded');
+
 	});
+
+	const encoded_uri = 'http://example.com/%E3%82%BA%E3%83%B3%E3%83%90-%E6%9D%B1%E4%BA%AC/'
+	const options_utf8 = {
+		url: 'http://example.com/ズンバ-東京/',
+		headers: {
+			authorization: 'Bearer testtoken'
+		},
+		mode: 'no-cors'
+
+	};
+
+	it('Properly encodes the URL'), () => {
+		const method = 'get';
+		const getArgs = buildRequestArgs({ ...options_utf8, method })(apiConfig);
+		expect(getArgs.url).toBe(encoded_uri);
+	}
 
 });
 

--- a/src/apiProxy/api-proxy.test.js
+++ b/src/apiProxy/api-proxy.test.js
@@ -4,6 +4,7 @@ import {
 	MOCK_API_PROBLEM,
 	MOCK_AUTH_HEADER,
 	MOCK_RENDERPROPS,
+	MOCK_RENDERPROPS_UTF8,
 } from '../util/mocks/app';
 import {
 	MOCK_DUOTONE_URLS,
@@ -97,21 +98,15 @@ describe('buildRequestArgs', () => {
 
 	});
 
-	const encoded_uri = 'http://example.com/%E3%82%BA%E3%83%B3%E3%83%90-%E6%9D%B1%E4%BA%AC/'
-	const options_utf8 = {
-		url: 'http://example.com/ズンバ-東京/',
-		headers: {
-			authorization: 'Bearer testtoken'
-		},
-		mode: 'no-cors'
+	const testQueryResults_utf8 = mockQuery(MOCK_RENDERPROPS_UTF8);
+	const apiConfig_utf8 = queryToApiConfig(testQueryResults_utf8);
+	const encoded_url = '/%E3%83%90-%E4%BA%AC';
 
-	};
-
-	it('Properly encodes the URL'), () => {
+	it('Properly encodes the URL', () => {
 		const method = 'get';
-		const getArgs = buildRequestArgs({ ...options_utf8, method })(apiConfig);
-		expect(getArgs.url).toBe(encoded_uri);
-	}
+		const getArgs = buildRequestArgs({ ...options, method })(apiConfig_utf8);
+		expect(getArgs.url.split('?')[0]).toEqual(encoded_url);
+	});
 
 });
 

--- a/src/util/mocks/app.js
+++ b/src/util/mocks/app.js
@@ -79,6 +79,19 @@ export const MOCK_RENDERPROPS = {
 	}
 };
 
+export const MOCK_RENDERPROPS_UTF8 = {
+	location: {  // https://github.com/reactjs/history/blob/master/docs/Location.md
+		pathname: '/バ-京',
+		search: '',
+		state: {},
+		action: 'PUSH',
+		key: '1234'
+	},
+	params: {
+		urlname: 'バ-京'
+	}
+};
+
 export const MOCK_MEANINGLESS_ACTION = {
 	type: 'ARBITRARY',
 	payload: '/'


### PR DESCRIPTION
This fixes the problem with the API not recognizing group URLs when calling through the api. We were encode the params, but not the URL itself.