### PR TITLE
remove conversation id from endpoint url in groupCommunication

### DIFF
--- a/src/apiProxy/apiConfigCreators.js
+++ b/src/apiProxy/apiConfigCreators.js
@@ -40,12 +40,11 @@ export function group(params) {
  * 	`apiMethod: 'unfollow' - POST unfollow
  */
 export function groupCommunication(params) {
-	const { urlname, conversationId, apiMethod } = params;
+	const { urlname, apiMethod } = params;
 
 	const endpoint = [
 		urlname,
 		'communications',
-		conversationId,
 		apiMethod
 	]
 		.filter(urlFragment => urlFragment) // only inlcude populated fragments


### PR DESCRIPTION
yet another small fix; this removes the conversation id from the endpoint url (the id is passed as a param)