### PR TITLE
WP 83 login sync

### DIFF
--- a/src/actions/authActionCreators.js
+++ b/src/actions/authActionCreators.js
@@ -1,4 +1,3 @@
-import { locationSync } from './syncActionCreators';
 /**
  * @module authActionCreators
  */
@@ -27,7 +26,8 @@ export function loginPost(params) {
 				if (response.value.errors) {
 					return loginError(response.value.errors);
 				}
-				return locationSync();
+				// otherwise return the action
+				return loginSuccess();
 			},
 			onError: loginError
 		}

--- a/src/actions/authActionCreators.js
+++ b/src/actions/authActionCreators.js
@@ -1,3 +1,4 @@
+import { locationSync } from './syncActionCreators';
 /**
  * @module authActionCreators
  */
@@ -26,8 +27,7 @@ export function loginPost(params) {
 				if (response.value.errors) {
 					return loginError(response.value.errors);
 				}
-				// otherwise return the action
-				return loginSuccess(response);
+				return locationSync();
 			},
 			onError: loginError
 		}

--- a/src/actions/syncActionCreators.js
+++ b/src/actions/syncActionCreators.js
@@ -26,11 +26,8 @@ export function apiComplete() {
 	};
 }
 
-export function locationSync(location) {
-	return {
-		type: 'LOCATION_SYNC',
-		payload: location,
-	};
+export function locationSync() {
+	return { type: 'LOCATION_SYNC' };
 }
 
 

--- a/src/actions/syncActionCreators.js
+++ b/src/actions/syncActionCreators.js
@@ -26,8 +26,11 @@ export function apiComplete() {
 	};
 }
 
+/**
+ * A simple signal to indicate that the app should re-sync data with the
+ * current router location. Usually used for authorization changes
+ */
 export function locationSync() {
 	return { type: 'LOCATION_SYNC' };
 }
-
 

--- a/src/epics/sync.js
+++ b/src/epics/sync.js
@@ -34,7 +34,7 @@ export const getNavEpic = routes => {
  * state
  */
 export const locationSyncEpic = (action$, store) =>
-	action$.ofType('LOCATION_SYNC')
+	action$.ofType('LOCATION_SYNC', 'LOGIN_SUCCESS')
 		.map(() => ({
 			type: LOCATION_CHANGE,
 			payload: store.getState().routing.locationBeforeTransitions,

--- a/src/epics/sync.js
+++ b/src/epics/sync.js
@@ -6,7 +6,6 @@ import {
 	apiSuccess,
 	apiError,
 	apiComplete,
-	locationSync,
 } from '../actions/syncActionCreators';
 import { activeRouteQueries$ } from '../util/routeUtils';
 import { fetchQueries } from '../util/fetchUtils';
@@ -23,7 +22,7 @@ import { fetchQueries } from '../util/fetchUtils';
 export const getNavEpic = routes => {
 	const activeQueries$ = activeRouteQueries$(routes);
 	return (action$, store) =>
-		action$.ofType(LOCATION_CHANGE, '@@server/RENDER', 'LOCATION_SYNC')
+		action$.ofType(LOCATION_CHANGE, '@@server/RENDER')
 			.map(({ payload }) => payload)  // extract the `location` from the action payload
 			.flatMap(activeQueries$)        // find the queries for the location
 			.map(apiRequest);               // dispatch apiRequest with all queries
@@ -35,10 +34,11 @@ export const getNavEpic = routes => {
  * state
  */
 export const locationSyncEpic = (action$, store) =>
-	action$.ofType('LOGIN_SUCCESS')
-		.map(() => locationSync(
-			store.getState().routing.locationBeforeTransitions)
-		);
+	action$.ofType('LOCATION_SYNC')
+		.map(() => ({
+			type: LOCATION_CHANGE,
+			payload: store.getState().routing.locationBeforeTransitions,
+		}));
 
 /**
  * Listen for actions that provide queries to send to the api - mainly

--- a/src/epics/sync.test.js
+++ b/src/epics/sync.test.js
@@ -15,6 +15,7 @@ import {
 } from '../util/testUtils';
 import getSyncEpic from '../epics/sync';
 import * as syncActionCreators from '../actions/syncActionCreators';
+import * as authActionCreators from '../actions/authActionCreators';
 /**
  * @module SyncEpicTest
  */
@@ -46,6 +47,20 @@ describe('Sync epic', () => {
 		return epicIgnoreAction(SyncEpic, locationChange)()
 			.then(epicIgnoreAction(SyncEpic, serverRender))
 			.then(epicIgnoreAction(SyncEpic, locationSync));
+	});
+
+	it('emits LOCATION_SYNC on LOGIN_SUCCESS', function() {
+		const mockFetchQueries = () => () => Promise.resolve({});
+
+		const loginSuccess = authActionCreators.loginSuccess();
+		const action$ = ActionsObservable.of(loginSuccess);
+		const fakeStore = createFakeStore(MOCK_APP_STATE);
+		return getSyncEpic(routes, mockFetchQueries)(action$, fakeStore)
+			.toPromise()
+			.then(action => {
+				expect(action.type).toEqual('LOCATION_SYNC');
+				expect(action.payload).toEqual(MOCK_APP_STATE.routing.locationBeforeTransitions);
+			});
 	});
 
 	it('emits API_SUCCESS and API_COMPLETE on successful API_REQUEST', function() {

--- a/src/epics/sync.test.js
+++ b/src/epics/sync.test.js
@@ -15,7 +15,6 @@ import {
 } from '../util/testUtils';
 import getSyncEpic from '../epics/sync';
 import * as syncActionCreators from '../actions/syncActionCreators';
-import * as authActionCreators from '../actions/authActionCreators';
 /**
  * @module SyncEpicTest
  */
@@ -25,9 +24,8 @@ describe('Sync epic', () => {
 	it('emits API_REQUEST for nav-related actions with matched query', function(done) {
 		const locationChange = { type: LOCATION_CHANGE, payload: MOCK_RENDERPROPS.location };
 		const serverRender = { type: '@@server/RENDER', payload: MOCK_RENDERPROPS.location };
-		const locationSync = syncActionCreators.locationSync(MOCK_RENDERPROPS.location);
 
-		const action$ = ActionsObservable.of(locationChange, serverRender, locationSync);
+		const action$ = ActionsObservable.of(locationChange, serverRender);
 		const epic$ = getSyncEpic(MOCK_ROUTES)(action$);
 		epic$.subscribe(
 			action => expect(action.type).toEqual('API_REQUEST'),
@@ -42,23 +40,21 @@ describe('Sync epic', () => {
 		const noMatchLocation = { ...MOCK_RENDERPROPS.location, pathname };
 		const locationChange = { type: LOCATION_CHANGE, payload: noMatchLocation };
 		const serverRender = { type: '@@server/RENDER', payload: noMatchLocation };
-		const locationSync = syncActionCreators.locationSync(noMatchLocation);
 
 		return epicIgnoreAction(SyncEpic, locationChange)()
-			.then(epicIgnoreAction(SyncEpic, serverRender))
-			.then(epicIgnoreAction(SyncEpic, locationSync));
+			.then(epicIgnoreAction(SyncEpic, serverRender));
 	});
 
-	it('emits LOCATION_SYNC on LOGIN_SUCCESS', function() {
+	it('emits LOCATION_CHANGE on LOCATION_SYNC', function() {
 		const mockFetchQueries = () => () => Promise.resolve({});
 
-		const loginSuccess = authActionCreators.loginSuccess();
-		const action$ = ActionsObservable.of(loginSuccess);
+		const locationSync = syncActionCreators.locationSync();
+		const action$ = ActionsObservable.of(locationSync);
 		const fakeStore = createFakeStore(MOCK_APP_STATE);
 		return getSyncEpic(routes, mockFetchQueries)(action$, fakeStore)
 			.toPromise()
 			.then(action => {
-				expect(action.type).toEqual('LOCATION_SYNC');
+				expect(action.type).toEqual(LOCATION_CHANGE);
 				expect(action.payload).toEqual(MOCK_APP_STATE.routing.locationBeforeTransitions);
 			});
 	});

--- a/src/util/mocks/app.js
+++ b/src/util/mocks/app.js
@@ -30,7 +30,9 @@ export const MOCK_APP_STATE = {
 	},
 	config: {},
 	routing: {
-		locationBeforeTransitions: {}
+		locationBeforeTransitions: {
+			pathname: '/foo',
+		}
 	},
 };
 


### PR DESCRIPTION
Currently, the platform depends on the consumer applications to update the application state on `LOGIN_SUCCESS`. In general, however, a successful login (like a successful logout) should _always_ refresh the current application state _completely_ to show the user-targeted data. The most direct way of doing this is through a navigation event, but since logins are POSTs, we need to simulate a navigation event to the current route when the POST succeeds.

This update will allow mup-web to remove the special-case handling of `LOGIN_SUCCESS` and `LOGIN_ERROR` in its app reducer by letting the platform automatically push a `LOCATION_SYNC` action on `LOGIN_SUCCESS`