### PR TITLE
WP-84 Apply oauth from login API call, clear auth on logout

### DIFF
--- a/src/apiProxy/api-proxy.js
+++ b/src/apiProxy/api-proxy.js
@@ -5,7 +5,7 @@ const externalRequest$ = Rx.Observable.bindNodeCallback(externalRequest);
 
 import * as apiConfigCreators from './apiConfigCreators';
 import { duotoneRef } from '../util/duotone';
-import { applyAuth } from '../util/authUtils';
+import { applyAuthState } from '../util/authUtils';
 
 const parseResponseFlags = ({ headers }) =>
 	(headers['x-meetup-flags'] || '')
@@ -259,13 +259,15 @@ const parseLoginAuth = (request, query) => response => {
 			expires_in,
 			member,
 		} = response.value;
-		applyAuth(request, request.authorize.reply)({
+		applyAuthState(request, request.authorize.reply)({
 			oauth_token,
 			refresh_token,
 			expires_in
 		});
 		return {
-			member
+			value: {
+				member,
+			},
 		};
 	}
 	return response;

--- a/src/apiProxy/api-proxy.js
+++ b/src/apiProxy/api-proxy.js
@@ -251,6 +251,12 @@ export const apiResponseDuotoneSetter = duotoneUrls => {
 	};
 };
 
+/**
+ * Login responses contain oauth info that should be applied to the response.
+ * If `request.authorize.reply` exists (supplied by the requestAuthPlugin),
+ * the application is able to set cookies on the response. Otherwise, return
+ * the login response unchanged
+ */
 const parseLoginAuth = (request, query) => response => {
 	if (query.type === 'login' && request.authorize) {
 		const {
@@ -264,11 +270,7 @@ const parseLoginAuth = (request, query) => response => {
 			refresh_token,
 			expires_in
 		});
-		return {
-			value: {
-				member,
-			},
-		};
+		return { value: { member } };
 	}
 	return response;
 };

--- a/src/apiProxy/api-proxy.js
+++ b/src/apiProxy/api-proxy.js
@@ -257,7 +257,7 @@ export const apiResponseDuotoneSetter = duotoneUrls => {
  * the application is able to set cookies on the response. Otherwise, return
  * the login response unchanged
  */
-const parseLoginAuth = (request, query) => response => {
+export const parseLoginAuth = (request, query) => response => {
 	if (query.type === 'login' && request.authorize) {
 		const {
 			oauth_token,

--- a/src/plugins/requestAuthPlugin.js
+++ b/src/plugins/requestAuthPlugin.js
@@ -3,12 +3,11 @@ import nodeFetch from 'node-fetch';
 import Rx from 'rxjs';
 
 import { tryJSON } from '../util/fetchUtils';
+import { applyAuthState, removeAuthState } from '../util/authUtils';
 
 /**
  * @module requestAuthPlugin
  */
-
-const YEAR_IN_MS = 1000 * 60 * 60 * 24 * 365;
 
 function verifyAuth(auth) {
 	const keys = Object.keys(auth);
@@ -23,66 +22,6 @@ function verifyAuth(auth) {
 	}
 	return auth;
 }
-
-/**
- * Transform auth info from the API into a configuration for the corresponding
- * cookies to write into the Hapi request/response
- *
- * @param {Object} auth { oauth_token || access_token, refresh_token, expires_in }
- * object from API/Auth endpoint
- */
-const configureAuthState = auth => {
-	const path = '/';
-	return {
-		oauth_token: {
-			value: auth.oauth_token || auth.access_token,
-			opts: {
-				path,
-				ttl: auth.expires_in * 1000,
-				isHttpOnly: true,
-			},
-		},
-		refresh_token: {
-			value: auth.refresh_token,
-			opts: {
-				path,
-				ttl: YEAR_IN_MS * 2,
-				isHttpOnly: true,
-			},
-		}
-	};
-};
-
-/**
- * Both the incoming request and the outgoing response need to have an
- * 'authorized' state in order for the app to render correctly with data from
- * the API, so this function modifies the request and the reply
- *
- * @param request Hapi request
- * @param auth { oauth_token || access_token, expires_in (seconds), refresh_token }
- */
-const applyAuthState = request => auth => {
-	// there are secret tokens in `auth`, be careful with logging
-	const authState = configureAuthState(auth);
-	const authCookies = Object.keys(authState);
-
-	request.log(['auth', 'info'], `Setting auth cookies: ${JSON.stringify(authCookies)}`);
-	Object.keys(authState).forEach(name => {
-		const cookieVal = authState[name];
-		// apply to request
-		request.state[name] = cookieVal.value;
-		// apply to response - note this special `request.authorize.reply` prop assigned onPreAuth
-		request.authorize.reply.state(name, cookieVal.value, cookieVal.opts);
-	});
-	return request;
-};
-
-const removeAuthState = (names, request) => {
-	names.forEach(name => {
-		request.state[name] = null;
-		request.authorize.reply.unstate(name);
-	});
-};
 
 /**
  * Ensure that the passed-in Request contains a valid Oauth token
@@ -109,7 +48,7 @@ export const requestAuthorizer = auth$ => request => {
 			.do(() => request.log(['info', 'auth'], `Request contains auth token (${authType})`)),
 		request$
 			.do(() => request.log(['info', 'auth'], 'Request does not contain auth token'))
-			.flatMap(request => auth$(request).do(applyAuthState(request)).map(() => request))
+			.flatMap(request => auth$(request).do(applyAuthState(request, request.authorize.reply)).map(() => request))
 	);
 };
 
@@ -245,7 +184,7 @@ export const authenticate = (request, reply) => {
 	// logout is accomplished exclusively through a `logout` querystring value
 	if ('logout' in request.query) {
 		request.log(['info', 'auth'], 'Logout received, clearing cookies to re-authenticate');
-		return removeAuthState(['oauth_token', 'refresh_token'], request);
+		return removeAuthState(['oauth_token', 'refresh_token'], request, reply);
 	}
 
 	request.log(['info', 'auth'], 'Authenticating request');

--- a/src/routes.js
+++ b/src/routes.js
@@ -43,6 +43,10 @@ export default function getRoutes(
 						const response = reply(JSON.stringify(queryResponses))
 							.type('application/json');
 						reply.track(response, 'api', queryResponses);
+						// if login, gotta re-authorize with response
+						// if (request.query.queries ... contains login)
+						// remove oauth info from response, apply to reply.state
+						// should this happen in API proxy? probably
 					},
 					(err) => { reply(Boom.badImplementation(err.message)); }
 				)

--- a/src/routes.js
+++ b/src/routes.js
@@ -43,10 +43,6 @@ export default function getRoutes(
 						const response = reply(JSON.stringify(queryResponses))
 							.type('application/json');
 						reply.track(response, 'api', queryResponses);
-						// if login, gotta re-authorize with response
-						// if (request.query.queries ... contains login)
-						// remove oauth info from response, apply to reply.state
-						// should this happen in API proxy? probably
 					},
 					(err) => { reply(Boom.badImplementation(err.message)); }
 				)

--- a/src/util/authUtils.js
+++ b/src/util/authUtils.js
@@ -1,0 +1,67 @@
+/**
+ * @module authUtils
+ */
+
+const YEAR_IN_MS = 1000 * 60 * 60 * 24 * 365;
+
+/**
+ * Transform auth info from the API into a configuration for the corresponding
+ * cookies to write into the Hapi request/response
+ *
+ * @param {Object} auth { oauth_token || access_token, refresh_token, expires_in }
+ * object from API/Auth endpoint
+ */
+export const configureAuthState = auth => {
+	const path = '/';
+	return {
+		oauth_token: {
+			value: auth.oauth_token || auth.access_token,
+			opts: {
+				path,
+				ttl: auth.expires_in * 1000,
+				isHttpOnly: true,
+			},
+		},
+		refresh_token: {
+			value: auth.refresh_token,
+			opts: {
+				path,
+				ttl: YEAR_IN_MS * 2,
+				isHttpOnly: true,
+			},
+		}
+	};
+};
+
+/**
+ * Both the incoming request and the outgoing response need to have an
+ * 'authorized' state in order for the app to render correctly with data from
+ * the API, so this function modifies the request and the reply
+ *
+ * @param request Hapi request
+ * @param auth { oauth_token || access_token, expires_in (seconds), refresh_token }
+ */
+export const applyAuthState = (request, reply) => auth => {
+	// there are secret tokens in `auth`, be careful with logging
+	const authState = configureAuthState(auth);
+	const authCookies = Object.keys(authState);
+
+	request.log(['auth', 'info'], `Setting auth cookies: ${JSON.stringify(authCookies)}`);
+	Object.keys(authState).forEach(name => {
+		const cookieVal = authState[name];
+		// apply to request
+		request.state[name] = cookieVal.value;
+		// apply to response - note this special `request.authorize.reply` prop assigned onPreAuth
+		reply.state(name, cookieVal.value, cookieVal.opts);
+	});
+	return request;
+};
+
+export const removeAuthState = (names, request, reply) => {
+	names.forEach(name => {
+		request.state[name] = null;
+		reply.unstate(name);
+	});
+};
+
+

--- a/src/util/routeUtils.js
+++ b/src/util/routeUtils.js
@@ -24,6 +24,7 @@ function getActiveRouteQueries([ , { routes, location, params }]) {
 		}, [])
 		.map(query => query({ location, params }));  // call the query function
 
+	// any location with logout will send a 'logout' query automatically
 	if ('logout' in location.query) {
 		queries.unshift({ type: 'logout' });
 	}

--- a/src/util/routeUtils.js
+++ b/src/util/routeUtils.js
@@ -16,13 +16,19 @@ const match$ = Rx.Observable.bindNodeCallback(match);
  * @return {Array} The return values of each active route's query function
  */
 function getActiveRouteQueries([ , { routes, location, params }]) {
-	return routes
+	const queries = routes
 		.filter(({ query }) => query)  // only get routes with queries
 		.reduce((queries, { query }) => {  // assemble into one array of queries
 			const routeQueries = query instanceof Array ? query : [query];
 			return queries.concat(routeQueries);
 		}, [])
 		.map(query => query({ location, params }));  // call the query function
+
+	if ('logout' in location.query) {
+		queries.unshift({ type: 'logout' });
+	}
+
+	return queries;
 }
 
 export const activeRouteQueries$ = routes => location =>


### PR DESCRIPTION
In order to set oauth cookies with values received from a login API call, we need to hijack the api-proxy response to set response cookies.

In order to reduce the auth info leaked to the browser, this PR also removes the oauth info from the login response before it is returned.

:hooray: security