### PR TITLE
Platform reducer (WP part of MW 406)

### DIFF
--- a/src/reducers/platform.js
+++ b/src/reducers/platform.js
@@ -1,0 +1,92 @@
+/**
+ * The root level reducer for the app.
+ * @module reducer
+ **/
+
+import { combineReducers } from 'redux';
+import { routerReducer } from 'react-router-redux';
+
+export const DEFAULT_APP_STATE = {};
+export const DEFAULT_AUTH_STATE = {};
+
+/**
+ * The primary reducer for data provided by the API
+ * `state.app` sub-tree
+ *
+ * @param {Object} state
+ * @param {ReduxAction} action
+ * @return {Object}
+ */
+export function app(state=DEFAULT_APP_STATE, action={}) {
+	let newState;
+
+	switch (action.type) {
+	case 'CACHE_SUCCESS':  // fall through - same effect as API success
+	case 'API_SUCCESS':
+			// API_SUCCESS contains an array of responses, but we just need to build a single
+			// object to update state with
+		newState = Object.assign.apply(Object, [{}].concat(action.payload.responses));
+		return { ...state, ...newState };
+	case 'LOGOUT_REQUEST':
+		// need to clear ALL private data, i.e. all data
+		return DEFAULT_APP_STATE;
+	default:
+		return state;
+	}
+}
+
+export function config(state={}, action) {
+	let apiUrl,
+		trackId;
+
+	switch(action.type) {
+	case 'CONFIGURE_API_URL':
+		apiUrl = action.payload;
+		return { ...state, apiUrl };
+	case 'CONFIGURE_TRACKING_ID':
+		trackId = action.payload;
+		return { ...state, trackId };
+	default:
+		return state;
+	}
+}
+
+/**
+ * This reducer manages a list of boolean flags that indicate the 'ready to
+ * render' state of the application. It is used exclusively by the server,
+ * which triggers actions when initializing a response that should eventually
+ * make all flags 'true'
+ *
+ * The server can then read these flags from state and render when ready
+ */
+export function preRenderChecklist([apiDataLoaded] = [false], action) {
+	return [
+		apiDataLoaded || Boolean(['API_COMPLETE', 'API_ERROR'].find(type => type === action.type)),
+	];
+}
+
+const routing = routerReducer;
+
+const platformReducers = {
+	app,
+	config,
+	preRenderChecklist,
+	routing,
+};
+
+/**
+ * A function that builds a reducer combining platform-standard reducers and
+ * app-specific reducers
+ */
+export default function makeRootReducer(appReducers) {
+	Object.keys(platformReducers).forEach(reducer => {
+		if (reducer in platformReducers) {
+			throw new Error(`'${reducer}' is a reserved platform reducer name`);
+		}
+	});
+	return combineReducers({
+		...platformReducers,
+		...appReducers,
+	});
+}
+

--- a/src/reducers/platform.js
+++ b/src/reducers/platform.js
@@ -78,8 +78,8 @@ const platformReducers = {
  * A function that builds a reducer combining platform-standard reducers and
  * app-specific reducers
  */
-export default function makeRootReducer(appReducers) {
-	Object.keys(platformReducers).forEach(reducer => {
+export default function makeRootReducer(appReducers={}) {
+	Object.keys(appReducers).forEach(reducer => {
 		if (reducer in platformReducers) {
 			throw new Error(`'${reducer}' is a reserved platform reducer name`);
 		}

--- a/src/reducers/platform.test.js
+++ b/src/reducers/platform.test.js
@@ -1,0 +1,16 @@
+import {
+	DEFAULT_APP_STATE,
+	app,
+} from './platform';
+
+describe('reducer', () => {
+	beforeEach(function() {
+		this.MOCK_STATE = { foo: 'bar' };
+	});
+	it('returns default state for empty action', () => {
+		expect(app(undefined, {})).toEqual(DEFAULT_APP_STATE);
+	});
+	it('app data should be cleared by a LOGOUT_REQUEST event', function() {
+		expect(app(this.MOCK_STATE, { type: 'LOGOUT_REQUEST' })).toEqual(DEFAULT_APP_STATE);
+	});
+});


### PR DESCRIPTION
After #52, there is no longer any need for app-specific code in the current mup-web reducer, which means that it might as well live in the platform.

This update creates a new `src/reducers/platform.js` module that exports a `makeRootReducer` function that allows applications to inject app-specific reducers alongside the full suite of platform-standard reducers (`app`, `config`, `preRenderChecklist`, `routing`).
