### PR TITLE
WP-85 fix oauth cookie refresh

### DIFF
--- a/src/epics/post.js
+++ b/src/epics/post.js
@@ -1,5 +1,3 @@
-import { fetchQueries } from '../util/fetchUtils';
-
 /**
  * PostEpic provides a generic interface for triggering POST requests and
  * dispatching particular actions with the API response. The POST action must
@@ -36,7 +34,7 @@ import { fetchQueries } from '../util/fetchUtils';
  * @param {Object} postAction, providing query, onSuccess, and onError
  * @return {Promise} results of the fetch, either onSuccess or onError
  */
-const getPostActionFetch = ({ getState }) =>
+const getPostActionFetch = ({ getState }, fetchQueries) =>
 	({ type, payload: { query, onSuccess, onError }}) => {
 		const {
 			config,
@@ -48,8 +46,8 @@ const getPostActionFetch = ({ getState }) =>
 			.catch(onError);
 	};
 
-const PostEpic = (action$, store) =>
+const getPostEpic = fetchQueries => (action$, store) =>
 	action$.filter(({ type })=> type.endsWith('_POST') || type.startsWith('POST_'))
-		.flatMap(getPostActionFetch(store));
+		.flatMap(getPostActionFetch(store, fetchQueries));
 
-export default PostEpic;
+export default getPostEpic;

--- a/src/epics/post.test.js
+++ b/src/epics/post.test.js
@@ -9,19 +9,19 @@ import {
 	createFakeStore,
 } from '../util/testUtils';
 import * as fetchUtils from '../util/fetchUtils';  // used for mocking
-import PostEpic from './post';
+import getPostEpic from './post';
 
 /**
  * @module PostEpicTest
  */
 const store = createFakeStore(MOCK_APP_STATE);
-describe('PostEpic', () => {
-	it('does not pass through arbitrary actions', epicIgnoreAction(PostEpic));
+describe('getPostEpic', () => {
+	it('does not pass through arbitrary actions', epicIgnoreAction(getPostEpic(fetchUtils.fetchQueries)));
 	it('calls fetchQueries with `method: "POST"`', function() {
 		const response = 'success';
 		spyOn(fetchUtils, 'fetchQueries').and.callFake(() => () => Promise.resolve(response));
 		const action$ = ActionsObservable.of(MOCK_POST_ACTION);
-		return PostEpic(action$, store)
+		return getPostEpic(fetchUtils.fetchQueries)(action$, store)
 			.do(() => {
 				expect(fetchUtils.fetchQueries.calls.count()).toBe(1);
 				const methodArg = fetchUtils.fetchQueries.calls.argsFor(0)[1].method;
@@ -34,7 +34,7 @@ describe('PostEpic', () => {
 		fetchUtils.fetchQueries = jest.fn(() => () => Promise.resolve(response));
 		spyOn(MOCK_POST_ACTION.payload, 'onSuccess');
 		const action$ = ActionsObservable.of(MOCK_POST_ACTION);
-		return PostEpic(action$, store)
+		return getPostEpic(fetchUtils.fetchQueries)(action$, store)
 			.do(() => expect(MOCK_POST_ACTION.payload.onSuccess).toHaveBeenCalledWith(response))
 			.toPromise();
 	});
@@ -45,7 +45,7 @@ describe('PostEpic', () => {
 		// The promises resolve async, but resolution is not accessible to test, so
 		// we use a setTimeout to make sure execution has completed
 		const action$ = ActionsObservable.of(MOCK_POST_ACTION);
-		return PostEpic(action$, store)
+		return getPostEpic(fetchUtils.fetchQueries)(action$, store)
 			.do(() => expect(MOCK_POST_ACTION.payload.onError).toHaveBeenCalledWith(err))
 			.toPromise();
 	});

--- a/src/epics/sync.js
+++ b/src/epics/sync.js
@@ -8,7 +8,6 @@ import {
 	apiComplete,
 } from '../actions/syncActionCreators';
 import { activeRouteQueries$ } from '../util/routeUtils';
-import { fetchQueries } from '../util/fetchUtils';
 
 /**
  * Navigation actions will provide the `location` as the payload, which this
@@ -47,10 +46,10 @@ export const getFetchQueriesEpic = fetchQueriesFn => (action$, store) =>
 				.catch(err => Observable.of(apiError(err)));  // ... or apiError
 		});
 
-export default function getSyncEpic(routes, fetchQueriesFn=fetchQueries) {
+export default function getSyncEpic(routes, fetchQueries) {
 	return combineEpics(
 		getNavEpic(routes),
-		getFetchQueriesEpic(fetchQueriesFn)
+		getFetchQueriesEpic(fetchQueries)
 	);
 }
 

--- a/src/middleware/epic.js
+++ b/src/middleware/epic.js
@@ -9,6 +9,10 @@ import getPostEpic from '../epics/post';
  * The middleware is exported as a getter because it needs the application's
  * routes in order to set up the nav-related epic(s) that are part of the
  * final middleware
+ *
+ * **Note** it's unlikely that the server needs any epics other than `sync` in
+ * order to render the application. We may want to write a server-specific
+ * middleware that doesn't include the other epics if performance is an issue
  */
 const getPlatformMiddleware = (routes, fetchQueries) => createEpicMiddleware(
 	combineEpics(

--- a/src/middleware/epic.js
+++ b/src/middleware/epic.js
@@ -10,9 +10,9 @@ import postEpic from '../epics/post';
  * routes in order to set up the nav-related epic(s) that are part of the
  * final middleware
  */
-const getPlatformMiddleware = routes => createEpicMiddleware(
+const getPlatformMiddleware = (routes, fetchQueries) => createEpicMiddleware(
 	combineEpics(
-		getSyncEpic(routes),
+		getSyncEpic(routes, fetchQueries),
 		getCacheEpic(),
 		postEpic
 	)

--- a/src/middleware/epic.js
+++ b/src/middleware/epic.js
@@ -3,7 +3,7 @@ import { combineEpics, createEpicMiddleware } from 'redux-observable';
 
 import getSyncEpic from '../epics/sync';
 import getCacheEpic from '../epics/cache';
-import postEpic from '../epics/post';
+import getPostEpic from '../epics/post';
 
 /**
  * The middleware is exported as a getter because it needs the application's
@@ -14,7 +14,7 @@ const getPlatformMiddleware = (routes, fetchQueries) => createEpicMiddleware(
 	combineEpics(
 		getSyncEpic(routes, fetchQueries),
 		getCacheEpic(),
-		postEpic
+		getPostEpic(fetchQueries)
 	)
 );
 

--- a/src/plugins/requestAuthPlugin.js
+++ b/src/plugins/requestAuthPlugin.js
@@ -191,7 +191,6 @@ export const requestAuth$ = config => {
 
 export const authenticate = (request, reply) => {
 	request.log(['info', 'auth'], 'Authenticating request');
-	console.log(`\nreceived headers:\n${JSON.stringify(request.headers, null, 2)}\n`);
 	return request.authorize()
 		.do(request => {
 			request.log(['info', 'auth'], 'Request authenticated');

--- a/src/plugins/requestAuthPlugin.js
+++ b/src/plugins/requestAuthPlugin.js
@@ -1,5 +1,4 @@
 import chalk from 'chalk';
-import nodeFetch from 'node-fetch';
 import Rx from 'rxjs';
 
 import { tryJSON } from '../util/fetchUtils';
@@ -67,7 +66,7 @@ const applyAuthState = request => auth => {
 	const authCookies = Object.keys(authState);
 
 	request.log(['auth', 'info'], `Setting auth cookies: ${JSON.stringify(authCookies)}`);
-	Object.keys(authState).forEach(name => {
+	authCookies.forEach(name => {
 		const cookieVal = authState[name];
 		// apply to request
 		request.state[name] = cookieVal.value;
@@ -249,6 +248,7 @@ export const authenticate = (request, reply) => {
 	}
 
 	request.log(['info', 'auth'], 'Authenticating request');
+	console.log(`\nreceived headers:\n${JSON.stringify(request.headers, null, 2)}\n`);
 	return request.authorize()
 		.do(request => {
 			request.log(['info', 'auth'], 'Request authenticated');
@@ -259,13 +259,6 @@ export const authenticate = (request, reply) => {
 		});
 };
 
-/**
- * create a `fetch` function that contains the cookie header passed in
- */
-const cookieFetch = cookie => (url, options={}) => {
-	const headers = { ...(options.headers || {}), cookie };
-	return nodeFetch(url, { ...options, headers });
-};
 /**
  * Request authorizing scheme
  *
@@ -289,9 +282,6 @@ export const oauthScheme = (server, options) => {
 	);
 
 	server.ext('onPreAuth', (request, reply) => {
-		// overwrite fetch to inject _this_ request's cookies
-		global.fetch = cookieFetch(request.headers.cookie);
-
 		// Used for setting and unsetting state, not for replying to request
 		request.authorize.reply = reply;
 

--- a/src/renderers/server-render.jsx
+++ b/src/renderers/server-render.jsx
@@ -7,7 +7,7 @@ import RouterContext from 'react-router/lib/RouterContext';
 import match from 'react-router/lib/match';
 import { Provider } from 'react-redux';
 
-import createStore from '../util/createStore';
+import { createServerStore } from '../util/createStore';
 import Dom from '../components/dom';
 import { polyfillNodeIntl } from '../util/localizationUtils';
 
@@ -154,7 +154,7 @@ const makeRenderer = (
 	const apiUrl = `${server.info.protocol}://${info.host}/api`;
 
 	// create the store
-	const store = createStore(routes, reducer, {}, middleware);
+	const store = createServerStore(routes, reducer, {}, middleware, request);
 	// load initial config
 	dispatchConfig(store, { apiUrl, log: log.bind(request) });
 

--- a/src/util/fetchUtils.js
+++ b/src/util/fetchUtils.js
@@ -18,6 +18,7 @@ export const fetchQueries = (apiUrl, options) => queries => {
 	options.method = options.method || 'GET';
 	const {
 		method,
+		headers,
 	} = options;
 
 	const isPost = method.toLowerCase() === 'post';
@@ -29,6 +30,7 @@ export const fetchQueries = (apiUrl, options) => queries => {
 	const fetchConfig = {
 		method,
 		headers: {
+			...(headers || {}),
 			'content-type': isPost ? 'application/x-www-form-urlencoded' : 'text/plain',
 		},
 		credentials: 'same-origin'  // allow response to set-cookies
@@ -51,4 +53,9 @@ export const tryJSON = reqUrl => response => {
 	}
 	return response.text().then(text => JSON.parse(text));
 };
+
+export const makeCookieHeader = cookieObj =>
+	Object.keys(cookieObj)
+		.map(name => `${name}=${cookieObj[name]}`)
+		.join('; ');
 

--- a/src/util/fetchUtils.test.js
+++ b/src/util/fetchUtils.test.js
@@ -53,3 +53,11 @@ describe('fetchQueries', () => {
 		});
 	});
 });
+
+describe('makeCookieHeader', () => {
+	it('makes a cookie header string from a { key<string> : value<string> } object', () => {
+		expect(fetchUtils.makeCookieHeader({ foo: 'foo', bar: 'bar' }))
+			.toEqual('foo=foo; bar=bar');
+	});
+});
+


### PR DESCRIPTION
The current code overrides `global.fetch` with a function that applies the current request's cookies to any `fetch` call. Looking back at it, that is a _really bad idea_, since `global` is shared by all requests, whereas we only want to affect a single request's `fetch`.

This PR updates `createStore.js` with a `createServerStore` function that takes the current Hapi `request` and sets up the sync middleware to apply the `request`'s cookies to the API `fetch` used in initially rendering the application.

Overview:

1. Receive request with cookies from the browser
2. Validate/authenticates/refresh those cookies
3. Start assembling the app
4. Make a Redux store with middleware that passes the request's cookies along to API calls
5. Make API calls
6. Render and respond with app