### PR TITLE
WP 67 navigation logs

### DIFF
--- a/src/actions/syncActionCreators.js
+++ b/src/actions/syncActionCreators.js
@@ -1,8 +1,8 @@
-export function apiRequest(queries, referrer) {
+export function apiRequest(queries, meta) {
 	return {
 		type: 'API_REQUEST',
 		payload: queries,
-		meta: referrer,
+		meta,
 	};
 }
 

--- a/src/actions/syncActionCreators.js
+++ b/src/actions/syncActionCreators.js
@@ -1,7 +1,8 @@
-export function apiRequest(queries) {
+export function apiRequest(queries, referrer) {
 	return {
 		type: 'API_REQUEST',
 		payload: queries,
+		meta: referrer,
 	};
 }
 

--- a/src/apiProxy/api-proxy.js
+++ b/src/apiProxy/api-proxy.js
@@ -239,7 +239,7 @@ export const apiResponseDuotoneSetter = duotoneUrls => {
 					groups.forEach(setGroupDuotone);
 					break;
 				case 'home':
-					(value.rows || []).map(({ items }) => items)
+					(value && value.rows || []).map(({ items }) => items)
 						.forEach(items => items.filter(({ type }) => type === 'group')
 							.forEach(({ group }) => setGroupDuotone(group))
 						);

--- a/src/apiProxy/api-proxy.js
+++ b/src/apiProxy/api-proxy.js
@@ -248,6 +248,9 @@ export const apiResponseDuotoneSetter = duotoneUrls => {
 		Object.keys(queryResponse)
 			.forEach(key => {
 				const { type, value } = queryResponse[key];
+				if (!value || value.error) {
+					return;
+				}
 				let groups;
 				switch (type) {
 				case 'group':
@@ -255,7 +258,7 @@ export const apiResponseDuotoneSetter = duotoneUrls => {
 					groups.forEach(setGroupDuotone);
 					break;
 				case 'home':
-					(value && value.rows || []).map(({ items }) => items)
+					(value.rows || []).map(({ items }) => items)
 						.forEach(items => items.filter(({ type }) => type === 'group')
 							.forEach(({ group }) => setGroupDuotone(group))
 						);

--- a/src/epics/sync.js
+++ b/src/epics/sync.js
@@ -24,7 +24,7 @@ export const getNavEpic = routes => (action$, store) =>
 		.map(({ payload }) => payload)  // extract the `location` from the action payload
 		.flatMap(location =>
 			activeRouteQueries$(routes)  // find the queries for the location
-				.map(queries => apiRequest(queries, browserHistory && browserHistory.previous))
+				.map(queries => apiRequest(queries, browserHistory && browserHistory.previous || null))
 		);
 /**
  * Any action that should reload the API data should be handled here, e.g.

--- a/src/epics/sync.js
+++ b/src/epics/sync.js
@@ -21,16 +21,17 @@ import { fetchQueries } from '../util/fetchUtils';
  */
 export const getNavEpic = routes => {
 	const activeQueries$ = activeRouteQueries$(routes);
-	let currentRoute = {};  // keep track of current route so that apiRequest can get 'referrer'
+	let currentLocation = {};  // keep track of current route so that apiRequest can get 'referrer'
 	return (action$, store) =>
 		action$.ofType(LOCATION_CHANGE, '@@server/RENDER')
-			.flatMap(({ payload }) =>
-				activeQueries$(payload)  // find the queries for the location
-					.map(queries =>
-						apiRequest(queries, currentRoute.pathname)
-					)
-					.do(() => currentRoute = payload)
-			);
+			.flatMap(({ payload }) => {
+				const requestMetadata = {
+					referrer: currentLocation.pathname,
+				};
+				return activeQueries$(payload)  // find the queries for the location
+					.map(queries => apiRequest(queries, requestMetadata))
+					.do(() => currentLocation = payload);  // update to new location
+			});
 };
 
 /**

--- a/src/epics/sync.js
+++ b/src/epics/sync.js
@@ -14,7 +14,10 @@ import { activeRouteQueries$ } from '../util/routeUtils';
  * epic will use to collect the current Reactive Queries associated with the
  * active routes.
  *
- * These queries will then be dispatched in the payload of `apiRequest`
+ * These queries will then be dispatched in the payload of `apiRequest`. Any
+ * metadata about the navigation action can also be sent to the `apiRequest`
+ * here.
+ *
  * @param {Object} routes The application's React Router routes
  * @returns {Function} an Epic function that emits an API_REQUEST action
  */
@@ -24,6 +27,7 @@ export const getNavEpic = routes => {
 	return (action$, store) =>
 		action$.ofType(LOCATION_CHANGE, '@@server/RENDER')
 			.flatMap(({ payload }) => {
+				// inject request metadata from context, including `store.getState()`
 				const requestMetadata = {
 					referrer: currentLocation.pathname,
 				};

--- a/src/routes.js
+++ b/src/routes.js
@@ -49,8 +49,10 @@ export default function getRoutes(
 							response,
 							'api',
 							queryResponses,
-							url.parse(response.request.info.referrer).pathname,
-							response.request.query.referrer
+							{
+								referrer: url.parse(response.request.info.referrer).pathname,
+								url: response.request.query.referrer,
+							}
 						);
 					},
 					(err) => { reply(Boom.badImplementation(err.message)); }

--- a/src/routes.js
+++ b/src/routes.js
@@ -42,7 +42,13 @@ export default function getRoutes(
 					queryResponses => {
 						const response = reply(JSON.stringify(queryResponses))
 							.type('application/json');
-						reply.track(response, 'api', queryResponses);
+						reply.track(
+							response,
+							'api',
+							queryResponses,
+							response.request.info.referrer,
+							response.request.query.referrer
+						);
 					},
 					(err) => { reply(Boom.badImplementation(err.message)); }
 				)

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,3 +1,5 @@
+import url from 'url';
+
 import Accepts from 'accepts';
 import Boom from 'boom';
 import chalk from 'chalk';
@@ -42,11 +44,12 @@ export default function getRoutes(
 					queryResponses => {
 						const response = reply(JSON.stringify(queryResponses))
 							.type('application/json');
+
 						reply.track(
 							response,
 							'api',
 							queryResponses,
-							response.request.info.referrer,
+							url.parse(response.request.info.referrer).pathname,
 							response.request.query.referrer
 						);
 					},

--- a/src/routes.js
+++ b/src/routes.js
@@ -46,7 +46,8 @@ export default function getRoutes(
 							.type('application/json');
 
 						const metadata = JSON.parse(response.request.query.metadata || '{}');
-						metadata.url = url.parse(response.request.info.referrer).pathname;
+						const originUrl = response.request.info.referrer;
+						metadata.url = url.parse(originUrl).pathname;
 
 						reply.track(
 							response,

--- a/src/routes.js
+++ b/src/routes.js
@@ -45,7 +45,7 @@ export default function getRoutes(
 						const response = reply(JSON.stringify(queryResponses))
 							.type('application/json');
 
-						const metadata = JSON.parse(response.request.query.metadata);
+						const metadata = JSON.parse(response.request.query.metadata || '{}');
 						metadata.url = url.parse(response.request.info.referrer).pathname;
 
 						reply.track(

--- a/src/routes.js
+++ b/src/routes.js
@@ -45,14 +45,14 @@ export default function getRoutes(
 						const response = reply(JSON.stringify(queryResponses))
 							.type('application/json');
 
+						const metadata = JSON.parse(response.request.query.metadata);
+						metadata.url = url.parse(response.request.info.referrer).pathname;
+
 						reply.track(
 							response,
 							'api',
 							queryResponses,
-							{
-								referrer: url.parse(response.request.info.referrer).pathname,
-								url: response.request.query.referrer,
-							}
+							metadata
 						);
 					},
 					(err) => { reply(Boom.badImplementation(err.message)); }

--- a/src/util/createStore.js
+++ b/src/util/createStore.js
@@ -44,12 +44,13 @@ function finalCreateStore(routes, reducer, initialState=null, middleware=[], fet
  * @param {Object} cookieState { name: value } object of cookies to inject
  * @return {Function} a fetchQueries function
  */
-const serverFetchQueries = cookieState => (api, options) => {
-	const cookie = makeCookieHeader(cookieState);
+const serverFetchQueries = request => (api, options) => {
+	const cookie = makeCookieHeader(request.state);
 	options.headers = options.headers || {};
 	options.headers.cookie = options.headers.cookie ?
 		`${options.headers.cookie}; ${cookie}` :
 		cookie;
+	options.headers.referer = options.headers.referer || request.url.pathname;
 	return fetchQueries(api, options);
 };
 
@@ -73,7 +74,7 @@ export function createServerStore(
 		reducer,
 		initialState,
 		middleware,
-		serverFetchQueries(request.state)
+		serverFetchQueries(request)
 	);
 }
 

--- a/src/util/fetchUtils.js
+++ b/src/util/fetchUtils.js
@@ -25,7 +25,7 @@ export const fetchQueries = (apiUrl, options) => (queries, referrer) => {
 	const params = new URLSearchParams();
 	params.append('queries', JSON.stringify(queries));
 	if (referrer) {
-		params.append('referrer', JSON.stringify(referrer));
+		params.append('referrer', referrer);
 	}
 	const searchString = `?${params}`;
 	const fetchUrl = `${apiUrl}${isPost ? '' : searchString}`;

--- a/src/util/fetchUtils.js
+++ b/src/util/fetchUtils.js
@@ -14,7 +14,7 @@
  *   }
  * @return {Promise} resolves with a `{queries, responses}` object
  */
-export const fetchQueries = (apiUrl, options) => (queries, referrer) => {
+export const fetchQueries = (apiUrl, options) => (queries, meta) => {
 	options.method = options.method || 'GET';
 	const {
 		method,
@@ -24,8 +24,8 @@ export const fetchQueries = (apiUrl, options) => (queries, referrer) => {
 
 	const params = new URLSearchParams();
 	params.append('queries', JSON.stringify(queries));
-	if (referrer) {
-		params.append('referrer', referrer);
+	for (const key in meta) {
+		params.append(key, meta[key]);
 	}
 	const searchString = `?${params}`;
 	const fetchUrl = `${apiUrl}${isPost ? '' : searchString}`;

--- a/src/util/fetchUtils.js
+++ b/src/util/fetchUtils.js
@@ -24,7 +24,7 @@ export const fetchQueries = (apiUrl, options) => (queries, meta) => {
 
 	const params = new URLSearchParams();
 	params.append('queries', JSON.stringify(queries));
-	paranms.append('metadata', JSON.stringify(meta));
+	params.append('metadata', JSON.stringify(meta));
 	const searchString = `?${params}`;
 	const fetchUrl = `${apiUrl}${isPost ? '' : searchString}`;
 	const fetchConfig = {

--- a/src/util/fetchUtils.js
+++ b/src/util/fetchUtils.js
@@ -24,9 +24,7 @@ export const fetchQueries = (apiUrl, options) => (queries, meta) => {
 
 	const params = new URLSearchParams();
 	params.append('queries', JSON.stringify(queries));
-	for (const key in meta) {
-		params.append(key, meta[key]);
-	}
+	paranms.append('metadata', JSON.stringify(meta));
 	const searchString = `?${params}`;
 	const fetchUrl = `${apiUrl}${isPost ? '' : searchString}`;
 	const fetchConfig = {

--- a/src/util/fetchUtils.js
+++ b/src/util/fetchUtils.js
@@ -14,7 +14,7 @@
  *   }
  * @return {Promise} resolves with a `{queries, responses}` object
  */
-export const fetchQueries = (apiUrl, options) => queries => {
+export const fetchQueries = (apiUrl, options) => (queries, referrer) => {
 	options.method = options.method || 'GET';
 	const {
 		method,
@@ -24,6 +24,9 @@ export const fetchQueries = (apiUrl, options) => queries => {
 
 	const params = new URLSearchParams();
 	params.append('queries', JSON.stringify(queries));
+	if (referrer) {
+		params.append('referrer', JSON.stringify(referrer));
+	}
 	const searchString = `?${params}`;
 	const fetchUrl = `${apiUrl}${isPost ? '' : searchString}`;
 	const fetchConfig = {

--- a/src/util/tracking.js
+++ b/src/util/tracking.js
@@ -93,8 +93,8 @@ export const trackLogout = log => response =>
 	);
 
 export const trackNav = log => (response, queryResponses, url, referrer) => {
-	const queries = queryResponses.map(qr => [Object.keys(qr)[0]]);
-	log(
+	const queries = queryResponses.map(qr => Object.keys(qr)[0]);
+	return log(
 		response,
 		{
 			description: 'nav',
@@ -109,6 +109,7 @@ export const trackNav = log => (response, queryResponses, url, referrer) => {
 };
 
 export const trackApi = log => (response, queryResponses, url, referrer) => {
+
 	trackNav(log)(response, queryResponses, url, referrer);
 	// special case - login requests need to be tracked
 	const loginResponse = queryResponses.find(r => r.login);
@@ -147,7 +148,6 @@ export const logTrack = platform_agent => (response, trackInfo) => {
 	const requestHeaders = response.request.headers;
 	const trackLog = {
 		request_id: uuid.v4(),
-		referrer: 'this will be handled in a special way for navigation actions',
 		ip: requestHeaders['remote-addr'],
 		agent: requestHeaders['user-agent'],
 		platform: 'meetup-web-platform',

--- a/src/util/tracking.js
+++ b/src/util/tracking.js
@@ -108,7 +108,11 @@ export const trackNav = log => (response, queryResponses, url, referrer) => {
 	);
 };
 
-export const trackApi = log => (response, queryResponses, url, referrer) => {
+export const trackApi = log => (response, queryResponses, metadata={}) => {
+	const {
+		url,
+		referrer,
+	} = metadata;
 	trackNav(log)(response, queryResponses, url, referrer);
 	// special case - login requests need to be tracked
 	const loginResponse = queryResponses.find(r => r.login);

--- a/src/util/tracking.js
+++ b/src/util/tracking.js
@@ -92,12 +92,29 @@ export const trackLogout = log => response =>
 		}
 	);
 
-export const trackApi = log => (response, queryResponses) => {
+export const trackNav = log => (response, queryResponses, url, referrer) => {
+	const queries = queryResponses.map(qr => [Object.keys(qr)[0]]);
+	log(
+		response,
+		{
+			description: 'nav',
+			member_id: response.request.state.member_id,
+			track_id: response.request.state.track_id,
+			session_id: response.request.state.session_id,
+			url,
+			referrer,
+			queries,
+		}
+	);
+};
+
+export const trackApi = log => (response, queryResponses, url, referrer) => {
+	trackNav(log)(response, queryResponses, url, referrer);
 	// special case - login requests need to be tracked
 	const loginResponse = queryResponses.find(r => r.login);
 	if (loginResponse) {
 		const member_id = JSON.stringify(loginResponse.login.value.member.id);
-		return trackLogin(log)(response, member_id);
+		trackLogin(log)(response, member_id);
 	}
 };
 

--- a/src/util/tracking.js
+++ b/src/util/tracking.js
@@ -109,13 +109,12 @@ export const trackNav = log => (response, queryResponses, url, referrer) => {
 };
 
 export const trackApi = log => (response, queryResponses, url, referrer) => {
-
 	trackNav(log)(response, queryResponses, url, referrer);
 	// special case - login requests need to be tracked
 	const loginResponse = queryResponses.find(r => r.login);
 	if (loginResponse) {
 		const member_id = JSON.stringify(loginResponse.login.value.member.id);
-		trackLogin(log)(response, member_id);
+		return trackLogin(log)(response, member_id);
 	}
 };
 


### PR DESCRIPTION
This PR adds tracking/logging data for every navigation action. The tracking data includes the following props in addition to the standard ids/metadata:

```js
{
  url,  // the _from_ pathname (not including `protocol://host:port` info)
  referrer,  // the _to_ pathname
}
```
 
More importantly, it sets up a `meta` property on the `API_REQUEST` action that is an object containing arbitrary request-related data. This data is then sent to the app server in a querystring parameter so that the server can read it and use it for tracking purposes. Currently, it just contains the 'referrer' url, but it can be expanded over time to include more info, e.g. the names of rendered React components, and possible click tracking info