### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "js-cookie": "^2.1.2",
     "meetup-web-mocks": "0.0.1",
     "node-fetch": "1.6.3",
-    "node-uuid": "^1.4.7",
     "react": "15.3.2",
     "react-addons-test-utils": "15.3.2",
     "react-dom": "15.3.2",
@@ -61,6 +60,7 @@
     "rxjs": "^5.0.0-beta.11",
     "source-map-support": "0.4.3",
     "tough-cookie": "2.3.1",
-    "url-search-params": "0.6.1"
+    "url-search-params": "0.6.1",
+    "uuid": "^3.0.0"
   }
 }

--- a/src/util/tracking.js
+++ b/src/util/tracking.js
@@ -1,4 +1,4 @@
-import uuid from 'node-uuid';
+import uuid from 'uuid';
 
 const YEAR_IN_MS = 1000 * 60 * 60 * 24 * 365;
 const COOKIE_OPTS = {


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.