### PR TITLE
WP 97 track logout

### DIFF
--- a/src/apiProxy/api-proxy.js
+++ b/src/apiProxy/api-proxy.js
@@ -339,7 +339,7 @@ export const makeApiRequest$ = (request, API_TIMEOUT, duotoneUrls) => {
  * @param {Object} baseUrl API server base URL for all API requests
  * @return Array$ contains all API responses corresponding to the provided queries
  */
-const apiProxy$ = ({ API_TIMEOUT=5000, baseUrl='', duotoneUrls={} }) => {
+const apiProxy$ = ({ API_TIMEOUT=8000, baseUrl='', duotoneUrls={} }) => {
 
 	return request => {
 		request.log(['api', 'info'], 'Parsing api endpoint request');

--- a/src/util/tracking.js
+++ b/src/util/tracking.js
@@ -114,7 +114,10 @@ export const trackApi = log => (response, queryResponses, metadata={}) => {
 	const loginResponse = queryResponses.find(r => r.login);
 	if (loginResponse) {
 		const member_id = JSON.stringify(loginResponse.login.value.member.id);
-		return trackLogin(log)(response, member_id);
+		trackLogin(log)(response, member_id);
+	}
+	if ('logout' in response.request.query) {
+		trackLogout(log)(response);
 	}
 };
 


### PR DESCRIPTION
This adds a `trackLogout` call to `trackApi` when `logout` is in the request querystring.

There's also some related cleanup to the tracking code to remove the unnecessary return values that prevent making multiple tracking calls from `trackApi`, and refactoring the tests to account for the lack of return values.

Also some consolidation of the redundant `request` definitions in the tracking tests to make it more explicit what request conditions are being tested.