### PR TITLE
WP 75 encrypt auth cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.10]
+
+- **New env variable** - `COOKIE_ENCRYPT_SECRET` must be in your env vars. It
+must be a 32+ character random string.
+
 ## [0.9]
 
 - **Removed** - Many of the shared methods in `src/util/testUtils`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - **New env variable** - `COOKIE_ENCRYPT_SECRET` must be in your env vars. It
 must be a 32+ character random string.
+- **Refactored** - auth cookies are now encrypted, so existing cookies must be
+cleared in the browser.
 
 ## [0.9]
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CI_BUILD_NUMBER ?= $(USER)-snapshot
-VERSION ?= 0.9.$(CI_BUILD_NUMBER)
+VERSION ?= 0.10.$(CI_BUILD_NUMBER)
 
 version:
 	@echo $(VERSION)

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -1,6 +1,5 @@
 import CsrfPlugin from 'electrode-csrf-jwt';
 import Good from 'good';
-import Joi from 'joi';
 import requestAuthPlugin from './plugins/requestAuthPlugin';
 
 /**
@@ -9,9 +8,7 @@ import requestAuthPlugin from './plugins/requestAuthPlugin';
  * @module ServerPlugins
  */
 
-export function getCsrfPlugin() {
-	const secret = process.env.CSRF_SECRET;
-	Joi.validate(secret, Joi.string().min(32).required());
+export function getCsrfPlugin(secret) {
 	return {
 		register: CsrfPlugin.register,
 		options: {
@@ -68,7 +65,7 @@ export function getRequestAuthPlugin(options) {
 
 export default function getPlugins(config) {
 	return [
-		getCsrfPlugin(),
+		getCsrfPlugin(config.CSRF_SECRET),
 		getConsoleLogPlugin(),
 		getRequestAuthPlugin(config),
 	];

--- a/src/plugins/requestAuthPlugin.js
+++ b/src/plugins/requestAuthPlugin.js
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import Rx from 'rxjs';
 
 import { tryJSON } from '../util/fetchUtils';
-import { applyAuthState, removeAuthState } from '../util/authUtils';
+import { applyAuthState, applyServerState, removeAuthState } from '../util/authUtils';
 
 /**
  * @module requestAuthPlugin
@@ -220,6 +220,7 @@ export const oauthScheme = (server, options) => {
 	// create a single stream for modifying an arbitrary request with anonymous auth
 	const authorizeRequest$ = requestAuthorizer(auth$);
 
+	applyServerState(server, options);
 	server.ext('onPreAuth', (request, reply) => {
 		// Used for setting and unsetting state, not for replying to request
 		request.plugins.requestAuth = {

--- a/src/plugins/requestAuthPlugin.test.js
+++ b/src/plugins/requestAuthPlugin.test.js
@@ -19,6 +19,7 @@ const MOCK_SERVER = {
 		scheme: () => {},
 	},
 	ext: () => {},
+	state: () => {},
 };
 const MOCK_HEADERS = {};
 const MOCK_REPLY_FN = () => {};
@@ -205,6 +206,7 @@ describe('oauthScheme', () => {
 			key: '1234',
 			secret: 'abcd',
 		},
+		COOKIE_ENCRYPT_SECRET: 'asdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdf',
 	};
 	it('calls server.ext with an \'onPreAuth\' function', () => {
 		spyOn(MOCK_SERVER, 'ext');

--- a/src/util/authUtils.js
+++ b/src/util/authUtils.js
@@ -61,11 +61,8 @@ export const removeAuthState = (names, request, reply) => {
 	});
 };
 
-function validateOptions(options) {
-	const optionsSchema = Joi.object({
-		password: Joi.string().min(32),
-	});
-	const { value, error } = Joi.validate(options, optionsSchema);
+function validateSecret(secret) {
+	const { value, error } = Joi.validate(secret, Joi.string().min(32));
 	if (error) {
 		throw error;
 	}
@@ -73,10 +70,10 @@ function validateOptions(options) {
 }
 
 export const applyServerState = (server, options) => {
-	options = validateOptions(options);
+	const password = validateSecret(options.COOKIE_ENCRYPT_SECRET);
 	const authCookieOptions = {
 		encoding: 'iron',
-		password: options.COOKIE_ENCRYPT_SECRET,
+		password,
 		// isSecure: process.env.NODE_ENV === 'production',   // enable when SSL is active
 		path: '/',
 		isHttpOnly: true,

--- a/src/util/authUtils.js
+++ b/src/util/authUtils.js
@@ -61,8 +61,8 @@ export const removeAuthState = (names, request, reply) => {
 	});
 };
 
-function validateSecret(secret) {
-	const { value, error } = Joi.validate(secret, Joi.string().min(32));
+export function validateSecret(secret) {
+	const { value, error } = Joi.validate(secret, Joi.string().min(32).required());
 	if (error) {
 		throw error;
 	}

--- a/src/util/authUtils.test.js
+++ b/src/util/authUtils.test.js
@@ -1,0 +1,36 @@
+import {
+	// applyAuthState,
+	applyServerState,
+	// configureAuthState,
+	// removeAuthState,
+} from './authUtils';
+
+describe('applyServerState', () => {
+	const serverWithState = {
+		state: () => {},
+	};
+	it('calls server.state for each auth cookie name', () => {
+		const goodOptions = {
+			COOKIE_ENCRYPT_SECRET: 'asdklfjahsdflkjasdfhlkajsdfkljasdlkasdjhfalksdjfbalkjsdhfalsdfasdlkfasd',
+		};
+		spyOn(serverWithState, 'state');
+		applyServerState(serverWithState, goodOptions);
+		const callArgs = serverWithState.state.calls.allArgs();
+		expect(callArgs.length).toBeGreaterThan(0);
+		callArgs.forEach(args => {
+			expect(args[0]).toEqual(jasmine.any(String));
+			expect(args[1]).toEqual(jasmine.any(Object));
+		});
+	});
+	it('throws an error when secret is missing', () => {
+		const missingSecretOpts = {};
+		expect(() => applyServerState(serverWithState, missingSecretOpts)).toThrow();
+	});
+	it('throws an error when secret is too short', () => {
+		const shortSecretOpts = {
+			COOKIE_ENCRYPT_SECRET: 'less than 32 characters',
+		};
+		expect(() => applyServerState(serverWithState, shortSecretOpts)).toThrow();
+	});
+});
+

--- a/src/util/config.js
+++ b/src/util/config.js
@@ -18,9 +18,11 @@ export default function getConfig(overrideConfig) {
 		console.warn('The ANONYMOUS_AUTH_URL env variable is deprecated - please rename to OAUTH_AUTH_URL');
 	}
 	const config = {
-		DEV_SERVER_PORT: process.env.DEV_SERVER_PORT || 8000,
 		API_PROTOCOL: process.env.API_PROTOCOL || 'https',
 		API_HOST: process.env.API_HOST || 'api.dev.meetup.com',
+		COOKIE_ENCRYPT_SECRET: process.env.COOKIE_ENCRYPT_SECRET,
+		CSRF_SECRET: process.env.CSRF_SECRET,
+		DEV_SERVER_PORT: process.env.DEV_SERVER_PORT || 8000,
 		OAUTH_AUTH_URL: process.env.OAUTH_AUTH_URL ||
 			process.env.ANONYMOUS_AUTH_URL ||
 			'https://secure.dev.meetup.com/oauth2/authorize',
@@ -43,9 +45,16 @@ export default function getConfig(overrideConfig) {
 function validateConfig(config) {
 	const oauthError = new Error('get oauth secrets from web platform team');
 	const configSchema = Joi.object().keys({
-		DEV_SERVER_PORT: Joi.number().integer().max(65535),
 		API_PROTOCOL: Joi.any().only(['https', 'http']).required(),
 		API_HOST: Joi.string().hostname().required(),
+		API_SERVER_ROOT_URL: Joi.string().uri(),
+		COOKIE_ENCRYPT_SECRET: Joi.string().min(32).required().error(
+			new Error('set COOKIE_ENCRYPT_SECRET env variable to a random 32+ character string')
+		),
+		CSRF_SECRET: Joi.string().min(32).required().error(
+			new Error('set CSRF_SECRET env variable to a random 32+ character string')
+		),
+		DEV_SERVER_PORT: Joi.number().integer().max(65535),
 		OAUTH_AUTH_URL: Joi.string().uri().required(),
 		OAUTH_ACCESS_URL: Joi.string().uri().required(),
 		PHOTO_SCALER_SALT: Joi.string().min(1).required().error(
@@ -55,7 +64,6 @@ function validateConfig(config) {
 			secret: Joi.string().min(1).required().error(oauthError),
 			key: Joi.string().min(1).required().error(oauthError),
 		}).required(),
-		API_SERVER_ROOT_URL: Joi.string().uri()
 	}).required();
 
 	const result = Joi.validate(config, configSchema);


### PR DESCRIPTION
This was sort of an experimental security improvement, but it works well and provides a solid base for applying encryption to our current auth-related cookies and any secret-related cookies that we might want to pass around in the future.

The 'breaking' part of the update is that it requires a new random string environment variable: `COOKIE_ENCRYPT_SECRET`. When we update mup-web, we'll need to add this secret through kubernetes.