### PR TITLE
WP 81 validate /api requests

### DIFF
--- a/src/apiProxy/api-proxy.js
+++ b/src/apiProxy/api-proxy.js
@@ -9,6 +9,9 @@ import { duotoneRef } from '../util/duotone';
 import {
 	applyAuthState,
 } from '../util/authUtils';
+import {
+	querySchema
+} from '../util/validation';
 
 const parseResponseFlags = ({ headers }) =>
 	(headers['x-meetup-flags'] || '')
@@ -195,7 +198,10 @@ export function parseRequest(request, baseUrl) {
 
 
 	const queriesJSON = request.method === 'get' ? query.queries : payload.queries;
-	const validatedQueries = Joi.validate(JSON.parse(queriesJSON), Joi.array(Joi.object({ type: Joi.string(), ref: Joi.string(), params: Joi.object(), })));
+	const validatedQueries = Joi.validate(
+		JSON.parse(queriesJSON),
+		Joi.array(querySchema)
+	);
 	if (validatedQueries.error) {
 		throw validatedQueries.error;
 	}

--- a/src/apiProxy/api-proxy.js
+++ b/src/apiProxy/api-proxy.js
@@ -1,5 +1,6 @@
 import querystring from 'querystring';
 import externalRequest from 'request';
+import Joi from 'joi';
 import Rx from 'rxjs';
 const externalRequest$ = Rx.Observable.bindNodeCallback(externalRequest);
 
@@ -194,7 +195,11 @@ export function parseRequest(request, baseUrl) {
 
 
 	const queriesJSON = request.method === 'get' ? query.queries : payload.queries;
-	const queries = JSON.parse(queriesJSON);
+	const validatedQueries = Joi.validate(JSON.parse(queriesJSON), Joi.array(Joi.object({ type: Joi.string(), ref: Joi.string(), params: Joi.object(), })));
+	if (validatedQueries.error) {
+		throw validatedQueries.error;
+	}
+	const queries = validatedQueries.value;
 	return { queries, externalRequestOpts };
 }
 

--- a/src/routes.js
+++ b/src/routes.js
@@ -3,6 +3,7 @@ import url from 'url';
 import Accepts from 'accepts';
 import Boom from 'boom';
 import chalk from 'chalk';
+import Joi from 'joi';
 
 import apiProxy$ from './apiProxy/api-proxy';
 
@@ -27,6 +28,22 @@ export default function getRoutes(
 		duotoneUrls: getDuotoneUrls(duotones, PHOTO_SCALER_SALT),
 	});
 
+	const handleQueryResponses = reply => queryResponses => {
+		const response = reply(JSON.stringify(queryResponses))
+			.type('application/json');
+
+		const metadata = JSON.parse(response.request.query.metadata || '{}');
+		const originUrl = response.request.info.referrer;
+		metadata.url = url.parse(originUrl).pathname;
+
+		reply.track(
+			response,
+			'api',
+			queryResponses,
+			metadata
+		);
+	};
+
 	/**
 	 * This handler converts the application-supplied queries into external API
 	 * calls, and converts the API call responses into a standard format that
@@ -36,29 +53,33 @@ export default function getRoutes(
 	 *   by `apiAdapter.apiResponseToQueryResponse`
 	 */
 	const apiProxyRoute = {
-		method: ['GET', 'POST', 'DELETE', 'PATCH'],
 		path: '/api',
-		handler: (request, reply) =>
+		handler: (request, reply) => {
 			proxyApiRequest$(request)
 				.subscribe(
-					queryResponses => {
-						const response = reply(JSON.stringify(queryResponses))
-							.type('application/json');
-
-						const metadata = JSON.parse(response.request.query.metadata || '{}');
-						const originUrl = response.request.info.referrer;
-						metadata.url = url.parse(originUrl).pathname;
-
-						reply.track(
-							response,
-							'api',
-							queryResponses,
-							metadata
-						);
-					},
+					handleQueryResponses(reply),
 					(err) => { reply(Boom.badImplementation(err.message)); }
-				)
+				);
+		}
 	};
+	const apiGetRoute = {
+		...apiProxyRoute,
+		method: ['GET', 'DELETE', 'PATCH'],
+		config: {
+			validate: {
+				query: Joi.object({
+					queries: Joi.string().required(),
+					metadata: Joi.string(),
+					logout: Joi.any(),
+				})
+			},
+		},
+	};
+	const apiPostRoute = {
+		...apiProxyRoute,
+		method: 'POST',
+	};
+
 
 	/**
 	 * Only one wildcard route for all application GET requests - exceptions are
@@ -80,11 +101,12 @@ export default function getRoutes(
 
 					reply.track(response, 'session');
 				});
-		}
+		},
 	};
 
 	return [
-		apiProxyRoute,
+		apiGetRoute,
+		apiPostRoute,
 		applicationRoute,
 	];
 }

--- a/src/routes.test.js
+++ b/src/routes.test.js
@@ -1,3 +1,4 @@
+import querystring from 'querystring';
 import {
 	MOCK_API_RESULT,
 	MOCK_renderRequestMap,
@@ -26,9 +27,11 @@ describe('routes', () => {
 		getResponse({ url: '/' })
 			.then(response => expect(response.payload).toEqual(MOCK_RENDER_RESULT))
 	);
-	it('serves the api route', () =>
-		getResponse({ url: '/api' })
-			.then(response => expect(JSON.parse(response.payload)).toEqual(MOCK_API_RESULT))
-	);
+	it('serves the api route', () => {
+		const validQuery = { type: 'a', ref: 'b', params: {} };
+		const qs = querystring.stringify({ queries: JSON.stringify([validQuery]) });
+		return getResponse({ url: `/api?${qs}` })
+			.then(response => expect(JSON.parse(response.payload)).toEqual(MOCK_API_RESULT));
+	});
 });
 

--- a/src/util/validation.js
+++ b/src/util/validation.js
@@ -1,0 +1,9 @@
+import Joi from 'joi';
+
+export const querySchema = Joi.object({
+	type: Joi.string().required(),
+	ref: Joi.string().required(),
+	params: Joi.object().required(),
+	flags: Joi.array(),
+});
+


### PR DESCRIPTION
In order to make the `/api` endpoint a bit more secure, this PR adds payload validation, which requires separating the `POST` route handler from the `GET/DELETE/PATCH` route handler.

Validation happens at two levels:

1. Only known querystring/post-body keys are allowed (`queries`, `metadata`, `logout`) - only `queries` is required.
2. The JSON-parsed `queries` value must be an array of query objects.

There's also a new `validation` module where we can start building up a set of validation schemas for use throughout the server code.