### PR TITLE
WP-112 handle auth failures without crashing

### DIFF
--- a/src/plugins/requestAuthPlugin.js
+++ b/src/plugins/requestAuthPlugin.js
@@ -199,10 +199,13 @@ export const getAuthenticate = authorizeRequest$ => (request, reply) => {
 		.do(request => {
 			request.log(['info', 'auth'], 'Request authenticated');
 		})
-		.subscribe(({ state: { oauth_token } }) => {
-			const credentials = oauth_token;
-			reply.continue({ credentials, artifacts: credentials });
-		});
+		.subscribe(
+			({ state: { oauth_token } }) => {
+				const credentials = oauth_token;
+				reply.continue({ credentials, artifacts: credentials });
+			},
+			err => reply(err, null, { credentials: null })
+		);
 };
 
 /**

--- a/src/plugins/requestAuthPlugin.test.js
+++ b/src/plugins/requestAuthPlugin.test.js
@@ -216,22 +216,43 @@ describe('oauthScheme', () => {
 describe('getAuthenticate', () => {
 	it('calls request.authorize', () => {
 		const spyable = {
-			authenticateRequest$: x => Rx.Observable.of(x),
+			authorizeRequest$: x => Rx.Observable.of(x),
 		};
-		spyOn(spyable, 'authenticateRequest$').and.callThrough();
+		spyOn(spyable, 'authorizeRequest$').and.callThrough();
 		return new Promise((resolve, reject) =>
-			getAuthenticate(spyable.authenticateRequest$)(MOCK_REQUEST, MOCK_REPLY_FN).add(() => {
-				expect(spyable.authenticateRequest$).toHaveBeenCalled();
-				resolve();
-			})
+			getAuthenticate(spyable.authorizeRequest$)(MOCK_REQUEST, MOCK_REPLY_FN)
+				.add(() => {
+					expect(spyable.authorizeRequest$).toHaveBeenCalled();
+					resolve();
+				})
 		);
 	});
 	it('calls reply.continue with credentials and artifacts', () => {
 		spyOn(MOCK_REPLY_FN, 'continue');
 		return new Promise((resolve, reject) =>
-			getAuthenticate(x => Rx.Observable.of(x))({ ...MOCK_AUTHED_REQUEST }, MOCK_REPLY_FN).add(() => {
-				expect(MOCK_REPLY_FN.continue)
-					.toHaveBeenCalledWith({ credentials: jasmine.any(String), artifacts: jasmine.any(String) });
+			getAuthenticate(x => Rx.Observable.of(x))({ ...MOCK_AUTHED_REQUEST }, MOCK_REPLY_FN)
+				.add(() => {
+					expect(MOCK_REPLY_FN.continue)
+						.toHaveBeenCalledWith({
+							credentials: jasmine.any(String),
+							artifacts: jasmine.any(String)
+						});
+					resolve();
+				})
+		);
+	});
+	it('calls reply(err...) when auth throws an error', () => {
+		const theError = new Error('badness');
+		const authorizeRequest$ = x => Rx.Observable.throw(theError);
+		const spyable = { MOCK_REPLY_FN };
+		spyOn(spyable, 'MOCK_REPLY_FN');
+		return new Promise((resolve, reject) =>
+			getAuthenticate(authorizeRequest$)(
+				{ ...MOCK_AUTHED_REQUEST },
+				spyable.MOCK_REPLY_FN
+			).add(() => {
+				expect(spyable.MOCK_REPLY_FN)
+					.toHaveBeenCalledWith(theError, null, jasmine.any(Object));
 				resolve();
 			})
 		);


### PR DESCRIPTION
I hadn't added the correct `reply(err, ...)` call when authentication fails, so certain auth server responses (e.g. 400 Bad Request) would crash the whole app server.

This PR just adds the appropriate `error` handler to the authentication Observer, which passes the error back to Hapi for processing like any other response failure.