### PR TITLE
WP 95 allow queries to specify API endpoint - deprecate apiConfigCreators

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,12 +132,13 @@ endpoint. A query takes the following shape:
 
 ```js
 {
+	ref: <string>,
 	type: <string>,
 	params: {
 		<string>: <string>,
 		...
 	},
-	ref: <string>,
+	endpoint?: <string>,  // specify api endpoint string directly, e.g. '/members/self',
 	flags?: [<string>, ...],
 }
 ```

--- a/src/apiProxy/api-proxy.js
+++ b/src/apiProxy/api-proxy.js
@@ -91,15 +91,12 @@ export const parseApiResponse = ([response, body]) => {
  */
 export function queryToApiConfig({ endpoint, type, params, flags }) {
 	if (!endpoint) {
-		const configCreator = apiConfigCreators[type];
-		if (type in configCreator) {
+		if (!(type in apiConfigCreators)) {
 			throw new ReferenceError(`No API specified for query type ${type} and no endpoint provided`);
 		}
-
-		return {
-			...configCreator(params),  // endpoint, params
-			flags,
-		};
+		const baseConfig = apiConfigCreators[type](params);
+		endpoint = baseConfig.endpoint;
+		params = baseConfig.params;
 	}
 	return {
 		endpoint,

--- a/src/apiProxy/api-proxy.js
+++ b/src/apiProxy/api-proxy.js
@@ -91,6 +91,10 @@ export const parseApiResponse = ([response, body]) => {
  */
 export function queryToApiConfig({ endpoint, type, params, flags }) {
 	if (!endpoint) {
+		console.warn(
+			'Queries without an explicit `endpoint` key are deprecated.',
+			'Please specify the endpoint and params in the query function directly.'
+		);
 		if (!(type in apiConfigCreators)) {
 			throw new ReferenceError(`No API specified for query type ${type} and no endpoint provided`);
 		}

--- a/src/apiProxy/api-proxy.js
+++ b/src/apiProxy/api-proxy.js
@@ -89,13 +89,21 @@ export const parseApiResponse = ([response, body]) => {
  * @param {Object} query a query object from the application
  * @return {Object} the arguments for api request, including endpoint
  */
-export function queryToApiConfig({ type, params, flags }) {
-	const configCreator = apiConfigCreators[type];
-	if (!configCreator) {
-		throw new ReferenceError(`No API specified for query type ${type}`);
+export function queryToApiConfig({ endpoint, type, params, flags }) {
+	if (!endpoint) {
+		const configCreator = apiConfigCreators[type];
+		if (type in configCreator) {
+			throw new ReferenceError(`No API specified for query type ${type} and no endpoint provided`);
+		}
+
+		return {
+			...configCreator(params),  // endpoint, params
+			flags,
+		};
 	}
 	return {
-		...configCreator(params),  // endpoint, params
+		endpoint,
+		params,
 		flags,
 	};
 }

--- a/src/apiProxy/api-proxy.test.js
+++ b/src/apiProxy/api-proxy.test.js
@@ -91,6 +91,22 @@ describe('parseApiResponse', () => {
 });
 
 describe('queryToApiConfig', () => {
+	it('returns endpoint, params, flags unchanged when endpoint is present', () => {
+		const query = {
+			endpoint: 'foo',
+			type: 'bar',
+			params: {
+				foo: 'bar',
+			},
+			flags: ['asdf'],
+		};
+		const expectedApiConfig = {
+			endpoint: query.endpoint,
+			params: query.params,
+			flags: query.flags,
+		};
+		expect(queryToApiConfig(query)).toEqual(expectedApiConfig);
+	});
 	it('transforms a query of known type to an object for API consumption', () => {
 		const testQueryResults = mockQuery(MOCK_RENDERPROPS);
 		expect(queryToApiConfig(testQueryResults)).toEqual(jasmine.any(Object));

--- a/src/apiProxy/apiConfigCreators.js
+++ b/src/apiProxy/apiConfigCreators.js
@@ -4,6 +4,7 @@
  * API
  *
  * @module apiConfigCreators
+ * @deprecated
  */
 
 /**


### PR DESCRIPTION
The API-agnostic benefit of the `apiConfigCreators` module introduces more dev burden than it alleviates for many/most API calls. Instead, the PR allows queries to specify the `endpoint` value directly, and passes through the query's `params` to the API unmodified. This requires engineers to have a bit more familiarity with the spec of the Meetup API endpoints they are using and may introduce some redundancy for different queries accessing the same endpoint, but it does help encapsulation and allows product development to move faster within the consumer app, without having to worry about whether the platform supports a particular endpoint through `apiConfigCreators`