### PR TITLE
fetchUtils: test meta handling, add tryJSON tests

### DIFF
--- a/src/util/fetchUtils.js
+++ b/src/util/fetchUtils.js
@@ -64,7 +64,9 @@ export const fetchQueries = (apiUrl, options) => (queries, meta) => {
 export const tryJSON = reqUrl => response => {
 	const { status, statusText } = response;
 	if (status >= 400) {  // status always 200: bugzilla #52128
-		throw new Error(`Request to ${reqUrl} responded with error code ${status}: ${statusText}`);
+		return Promise.reject(
+			new Error(`Request to ${reqUrl} responded with error code ${status}: ${statusText}`)
+		);
 	}
 	return response.text().then(text => JSON.parse(text));
 };


### PR DESCRIPTION
This fleshes out some tests that would have prevented an error that appeared in a previous merge.

The one code change is returning a `Promise.reject` rather than just throwing an error when there is an error response