### PR TITLE
WP 135 always call API_SUCCESS for successful POSTs

### DIFF
--- a/src/epics/post.js
+++ b/src/epics/post.js
@@ -38,8 +38,11 @@ import {
  * @param {Object} postAction, providing query, onSuccess, and onError
  * @return {Promise} results of the fetch, either onSuccess or onError
  */
-const getPostQueryFetch = (fetchQueries, { apiUrl, csrf }) =>
-	query => fetchQueries(apiUrl, { method: 'POST', csrf })([query]);
+const getPostQueryFetch = (fetchQueries, store) =>
+	query => {
+		const { config: { apiUrl, csrf } } = store.getState();
+		return fetchQueries(apiUrl, { method: 'POST', csrf })([query]);
+	};
 
 /**
  * Make the POST call to the API and send the responses to the appropriate
@@ -66,7 +69,7 @@ const getPostEpic = fetchQueries => (action$, store) =>
 		.map(({ payload }) => payload)
 		.flatMap(
 			doPost$(
-				getPostQueryFetch(fetchQueries, store.getState().config)
+				getPostQueryFetch(fetchQueries, store)
 			)
 		);
 

--- a/src/epics/post.js
+++ b/src/epics/post.js
@@ -1,3 +1,7 @@
+import Rx from 'rxjs';
+import {
+	apiSuccess
+} from '../actions/syncActionCreators';
 /**
  * PostEpic provides a generic interface for triggering POST requests and
  * dispatching particular actions with the API response. The POST action must
@@ -27,27 +31,43 @@
  * get a function that receives a post action and returns the corresponding
  * fetch Promise
  *
- * The wrapping function needs a store so that the returned function can
- * read from state
+ * The wrapping function needs current app state in order to apply correct
+ * config
  *
- * @param {Redux Store} store
+ * @param {Object} { apiUrl, csrf } from state.config
  * @param {Object} postAction, providing query, onSuccess, and onError
  * @return {Promise} results of the fetch, either onSuccess or onError
  */
-const getPostActionFetch = ({ getState }, fetchQueries) =>
-	({ type, payload: { query, onSuccess, onError }}) => {
-		const {
-			config,
-		} = getState();
-		const fetchOpts = { method: 'POST', csrf: config.csrf };
+const getPostQueryFetch = (fetchQueries, { apiUrl, csrf }) =>
+	query => fetchQueries(apiUrl, { method: 'POST', csrf })([query]);
 
-		return fetchQueries(config.apiUrl, fetchOpts)([query])
-			.then(onSuccess)
-			.catch(onError);
-	};
+/**
+ * Make the POST call to the API and send the responses to the appropriate
+ * places
+ *
+ * 1. Always send successful post responses to API_SUCCESS action
+ * 2. If POST action has an 'onSuccess' action creators, send successful
+ *    responses there as well
+ * 3. Failed POST responses will be sent to the POST action's `onError`
+ */
+const doPost$ = fetchPostQuery => ({ query, onSuccess, onError }) =>
+	Rx.Observable.fromPromise(fetchPostQuery(query))  // make the fetch call
+		.flatMap(responses =>
+			// success! return API_SUCCESS and whatever the POST action wants to do onSuccess
+			Rx.Observable.of(
+				apiSuccess(responses),
+				onSuccess && onSuccess(responses)
+			)
+		)
+		.catch(err => Rx.Observable.of(onError(err)));
 
 const getPostEpic = fetchQueries => (action$, store) =>
-	action$.filter(({ type })=> type.endsWith('_POST') || type.startsWith('POST_'))
-		.flatMap(getPostActionFetch(store, fetchQueries));
+	action$.filter(({ type }) => type.endsWith('_POST') || type.startsWith('POST_'))
+		.map(({ payload }) => payload)
+		.flatMap(
+			doPost$(
+				getPostQueryFetch(fetchQueries, store.getState().config)
+			)
+		);
 
 export default getPostEpic;

--- a/src/epics/post.test.js
+++ b/src/epics/post.test.js
@@ -16,10 +16,15 @@ import {
 
 import getPostEpic from './post';
 import * as fetchUtils from '../util/fetchUtils';  // used for mocking
+import * as syncActionCreators from '../actions/syncActionCreators';
 
 /**
  * @module PostEpicTest
  */
+MOCK_APP_STATE.config = {
+	apiUrl: 'http://fake.api.meetup.com',
+	csrf: '1234_fake_csrf',
+};
 const store = createFakeStore(MOCK_APP_STATE);
 describe('getPostEpic', () => {
 	it('does not pass through arbitrary actions', epicIgnoreAction(getPostEpic(fetchUtils.fetchQueries)));
@@ -30,19 +35,39 @@ describe('getPostEpic', () => {
 		return getPostEpic(fetchUtils.fetchQueries)(action$, store)
 			.do(() => {
 				expect(fetchUtils.fetchQueries.calls.count()).toBe(1);
-				const methodArg = fetchUtils.fetchQueries.calls.argsFor(0)[1].method;
-				expect(methodArg).toEqual('POST');
+				const fetchArgs = fetchUtils.fetchQueries.calls.argsFor(0);
+				expect(fetchArgs[1].method).toEqual('POST');
+				expect(fetchArgs[1].csrf).toEqual(MOCK_APP_STATE.config.csrf);
+				expect(fetchArgs[0]).toEqual(MOCK_APP_STATE.config.apiUrl);
 			})
 			.toPromise();
 	});
-	it('Returns response from fetchqueries as argument to action\'s onSuccess', function() {
+	it('Returns response from fetchqueries as argument to API_SUCCESS', function() {
+		const response = 'success';
+		fetchUtils.fetchQueries = jest.fn(() => () => Promise.resolve(response));
+		const noSuccessPayload = { ...MOCK_POST_ACTION.payload };
+		delete noSuccessPayload.onSuccess;
+		const postWithoutOnSuccess = { ...MOCK_POST_ACTION, payload: noSuccessPayload };
+		spyOn(syncActionCreators, 'apiSuccess');
+		const action$ = ActionsObservable.of(postWithoutOnSuccess);
+		return getPostEpic(fetchUtils.fetchQueries)(action$, store)
+			.toPromise()
+			.then(() => {
+				expect(syncActionCreators.apiSuccess).toHaveBeenCalledWith(response);
+			});
+	});
+	it('Returns response from fetchqueries as argument to API_SUCCESS and action\'s onSuccess', function() {
 		const response = 'success';
 		fetchUtils.fetchQueries = jest.fn(() => () => Promise.resolve(response));
 		spyOn(MOCK_POST_ACTION.payload, 'onSuccess');
+		spyOn(syncActionCreators, 'apiSuccess');
 		const action$ = ActionsObservable.of(MOCK_POST_ACTION);
 		return getPostEpic(fetchUtils.fetchQueries)(action$, store)
-			.do(() => expect(MOCK_POST_ACTION.payload.onSuccess).toHaveBeenCalledWith(response))
-			.toPromise();
+			.toPromise()
+			.then(() => {
+				expect(syncActionCreators.apiSuccess).toHaveBeenCalledWith(response);
+				expect(MOCK_POST_ACTION.payload.onSuccess).toHaveBeenCalledWith(response);
+			});
 	});
 	it('Returns error from fetchQueries as argument to action\'s onError', function() {
 		const err = new Error('boo');


### PR DESCRIPTION
`onSuccess` for POST queries is now optional, because `apiSuccess` will always be called - if all you want to do is update `state.app` with the response to a POST, no need to do anything.

MAJOR BENEFIT: the CSRF token only gets refreshed correctly with `apiSuccess`, so consumer apps don't have to think about that any more.