### PR TITLE
WP 138 confine CSRF handling to /api endpoint

### DIFF
--- a/src/reducers/platform.js
+++ b/src/reducers/platform.js
@@ -40,10 +40,13 @@ export function config(state={}, action) {
 		apiUrl,
 		trackId;
 
-	switch(action.type) {
-	case 'API_SUCCESS':
+	if ((action.meta || {}).csrf) {
+		// any CSRF-bearing action should update state
 		csrf = action.meta.csrf;
-		return { ...state, csrf };
+		// create a copy of state with updated csrf
+		state = { ...state, csrf };
+	}
+	switch(action.type) {
 	case 'CONFIGURE_API_URL':
 		apiUrl = action.payload;
 		return { ...state, apiUrl };

--- a/src/routes.js
+++ b/src/routes.js
@@ -73,10 +73,16 @@ export default function getRoutes(
 				);
 		}
 	};
+	const plugins = {
+		'electrode-csrf-jwt': {
+			enabled: true,
+		}
+	};
 	const apiGetRoute = {
 		...apiProxyRoute,
 		method: ['GET', 'DELETE', 'PATCH'],
 		config: {
+			plugins,
 			validate: {
 				query: validApiPayloadSchema
 			},
@@ -86,6 +92,7 @@ export default function getRoutes(
 		...apiProxyRoute,
 		method: 'POST',
 		config: {
+			plugins,
 			validate: {
 				payload: validApiPayloadSchema
 			},

--- a/src/server.js
+++ b/src/server.js
@@ -45,6 +45,13 @@ export default function start(
 			const connection = {
 				host: '0.0.0.0',
 				port: config.DEV_SERVER_PORT,
+				routes: {
+					plugins: {
+						'electrode-csrf-jwt': {
+							enabled: false,
+						}
+					}
+				}
 			};
 
 			const finalPlugins = [ ...plugins, ...getPlugins(config) ];


### PR DESCRIPTION
This PR disables the CSRF plugin on all routes by default, and updates the API routes to opt-in to CSRF handling so that only API responses will set new CSRFs. It also updates the `config` reducer to read new CSRFs whenever they are supplied in the `meta` property of an action - this provides a little more assurance that a new CSRF will be correctly stored in app state whether or not it was supplied by a specific `API_SUCCESS` action or not.

Over time, I suspect we'll need to lock down the ways in which `/api` is called even more to avoid bugs, but this is a good non-breaking step