### PR TITLE
Testing redux-observable imports

### DIFF
--- a/src/middleware/epic.js
+++ b/src/middleware/epic.js
@@ -1,13 +1,8 @@
-require('rxjs');  // required to enable all Observable operators in subsequent imports
+import { combineEpics, createEpicMiddleware } from '../util/reduxObservableFull';
 
-const getSyncEpic = require('../epics/sync').default;
-const getCacheEpic = require('../epics/cache').default;
-const getPostEpic = require('../epics/post').default;
-
-const {
-	combineEpics,
-	createEpicMiddleware,
-} = require('redux-observable');
+import getSyncEpic from '../epics/sync';
+import getCacheEpic from '../epics/cache';
+import getPostEpic from '../epics/post';
 
 /**
  * The middleware is exported as a getter because it needs the application's

--- a/src/util/reduxObservableFull.js
+++ b/src/util/reduxObservableFull.js
@@ -1,0 +1,5 @@
+require('rxjs');
+const rxObs = require('redux-observable');
+
+module.exports = rxObs;
+


### PR DESCRIPTION
'rxjs' needs to be imported before any redux-observable code so that all the Observable operators are available. It appears that webpack might be arranging some imports in unexpected ways, so that RxJS has not been imported before redux-observable.

This PR will allow me to generate beta versions that I can try out in mup-web - `npm link` doesn't produce the 'missing operator' error that a regular `npm install` does. Go figure