### PR TITLE
WP-144 read forwarded request protocol if available

### DIFF
--- a/src/renderers/server-render.jsx
+++ b/src/renderers/server-render.jsx
@@ -144,15 +144,17 @@ const makeRenderer = (
 	middleware = middleware || [];
 	request.log(['info'], chalk.green(`Rendering ${request.url.href}`));
 	const {
-		url,
+		connection,
+		headers,
 		info,
 		log,
+		url,
 	} = request;
 
 	const location = url.path;
 	// request protocol might be different from original request that hit proxy
 	// we want to use the proxy's protocol
-	const requestProtocol = request.headers['x-forwarded-proto'] || request.connection.info.protocol;
+	const requestProtocol = headers['x-forwarded-proto'] || connection.info.protocol;
 	const apiUrl = `${requestProtocol}://${info.host}/api`;
 
 	// create the store

--- a/src/renderers/server-render.jsx
+++ b/src/renderers/server-render.jsx
@@ -146,12 +146,14 @@ const makeRenderer = (
 	const {
 		url,
 		info,
-		server,
 		log,
 	} = request;
 
 	const location = url.path;
-	const apiUrl = `${server.info.protocol}://${info.host}/api`;
+	// request protocol might be different from original request that hit proxy
+	// we want to use the proxy's protocol
+	const requestProtocol = request.headers['x-forwarded-proto'] || request.connection.info.protocol;
+	const apiUrl = `${requestProtocol}://${info.host}/api`;
 
 	// create the store
 	const store = createServerStore(routes, reducer, {}, middleware, request);


### PR DESCRIPTION
in order to correctly set the `apiUrl` with the correct protocol, we need to get the forwarded protocol from the SSL proxy if it's available.