### PR TITLE
MW-494 don't use Secure cookies in dev

### DIFF
--- a/src/plugins.js
+++ b/src/plugins.js
@@ -9,8 +9,14 @@ import requestAuthPlugin from './plugins/requestAuthPlugin';
  */
 
 export function getCsrfPlugin(secret) {
+	const register = (server, options, next) => {
+		server.state('x-csrf-jwt', {
+			isSecure: process.env.NODE_ENV === 'production',
+		});
+		return CsrfPlugin.register(server, options, next);
+	};
 	return {
-		register: CsrfPlugin.register,
+		register,
 		options: {
 			secret,
 		}

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -15,6 +15,7 @@ export function getCsrfPlugin(secret) {
 		});
 		return CsrfPlugin.register(server, options, next);
 	};
+	register.attributes = CsrfPlugin.register.attributes;
 	return {
 		register,
 		options: {

--- a/src/util/authUtils.js
+++ b/src/util/authUtils.js
@@ -74,7 +74,7 @@ export const applyServerState = (server, options) => {
 	const authCookieOptions = {
 		encoding: 'iron',
 		password,
-		// isSecure: process.env.NODE_ENV === 'production',   // enable when SSL is active
+		isSecure: process.env.NODE_ENV === 'production',
 		path: '/',
 		isHttpOnly: true,
 		clearInvalid: true,

--- a/src/util/serverUtils.js
+++ b/src/util/serverUtils.js
@@ -74,4 +74,3 @@ export function server(routes, connection, plugins, platform_agent, config) {
 		.then(() => server);
 }
 
-

--- a/src/util/tracking.js
+++ b/src/util/tracking.js
@@ -5,6 +5,7 @@ const COOKIE_OPTS = {
 	encoding: 'none',
 	path: '/',
 	isHttpOnly: true,
+	isSecure: process.env.NODE_ENV === 'production',
 };
 
 


### PR DESCRIPTION
A recent Hapi upgrade made all cookies 'Secure' by default, which means they could only be sent over HTTPS.

Since our dev environment is currently not served over HTTPS, no cookies were active, and things broke.

Badly.

This PR sets `isSecure` to `false` in dev for every affected cookie