### PR TITLE
WP 132 log failed api response

### DIFF
--- a/src/util/apiUtils.js
+++ b/src/util/apiUtils.js
@@ -377,6 +377,10 @@ export const makeApiRequest$ = (request, API_TIMEOUT, duotoneUrls) => {
 				.do(logApiResponse(request))             // this will leak private info in API response
 				.map(parseApiResponse(requestOpts.url))  // parse into plain object
 				.map(parseLoginAuth(request, query))     // login has oauth secrets - special case
+				.catch(err => Rx.Observable.of({
+					value: formatApiError(err),
+					meta: {},
+				}))
 				.map(apiResponseToQueryResponse(query))  // convert apiResponse to app-ready queryResponse
 				.map(setApiResponseDuotones);            // special duotone prop
 		});

--- a/src/util/apiUtils.test.js
+++ b/src/util/apiUtils.test.js
@@ -19,11 +19,13 @@ import {
 	apiResponseToQueryResponse,
 	apiResponseDuotoneSetter,
 	buildRequestArgs,
+	errorResponse$,
 	logApiResponse,
 	makeApiRequest$,
 	makeExternalApiRequest,
 	parseRequest,
 	parseApiResponse,
+	parseApiValue,
 	parseLoginAuth,
 	queryToApiConfig,
 	groupDuotoneSetter,
@@ -73,23 +75,37 @@ describe('makeExternalApiRequest', () => {
 	});
 });
 
-describe('parseApiResponse', () => {
+describe('errorResponse$', () => {
+	it('returns the request url pathname as response.meta.endpoint', () => {
+		const endpoint = '/pathname';
+		return errorResponse$(`http://example.com${endpoint}`)(new Error())
+			.toPromise()
+			.then(response => expect(response.meta.endpoint).toEqual(endpoint));
+	});
+	it('returns the error message as the response.value.error', () => {
+		const message = 'foo';
+		return errorResponse$('http://example.com')(new Error(message))
+			.toPromise()
+			.then(response => expect(response.value.error).toEqual(message));
+	});
+});
+describe('parseApiValue', () => {
 	const MOCK_RESPONSE = {
 		headers: {},
 		statusCode: 200
 	};
 	it('converts valid JSON into an equivalent object', () => {
 		const validJSON = JSON.stringify(MOCK_GROUP);
-		expect(parseApiResponse('http://example.com')([MOCK_RESPONSE, validJSON]).value).toEqual(jasmine.any(Object));
-		expect(parseApiResponse('http://example.com')([MOCK_RESPONSE, validJSON]).value).toEqual(MOCK_GROUP);
+		expect(parseApiValue([MOCK_RESPONSE, validJSON])).toEqual(jasmine.any(Object));
+		expect(parseApiValue([MOCK_RESPONSE, validJSON])).toEqual(MOCK_GROUP);
 	});
 	it('returns an object with a string "error" value for invalid JSON', () => {
 		const invalidJSON = 'not valid';
-		expect(parseApiResponse('http://example.com')([MOCK_RESPONSE, invalidJSON]).value.error).toEqual(jasmine.any(String));
+		expect(parseApiValue([MOCK_RESPONSE, invalidJSON]).error).toEqual(jasmine.any(String));
 	});
 	it('returns an object with a string "error" value for API response with "problem"', () => {
 		const responeWithProblem = JSON.stringify(MOCK_API_PROBLEM);
-		expect(parseApiResponse('http://example.com')([MOCK_RESPONSE, responeWithProblem]).value.error).toEqual(jasmine.any(String));
+		expect(parseApiValue([MOCK_RESPONSE, responeWithProblem]).error).toEqual(jasmine.any(String));
 	});
 	it('returns an object with a string "error" value for a not-ok response', () => {
 		const badStatus = {
@@ -98,8 +114,14 @@ describe('parseApiResponse', () => {
 			statusMessage: 'Problems',
 		};
 		const nonOkReponse = { ...MOCK_RESPONSE, ...badStatus };
-		expect(parseApiResponse('http://example.com')([nonOkReponse, '{}']).value.error).toEqual(badStatus.statusMessage);
+		expect(parseApiValue([nonOkReponse, '{}']).error).toEqual(badStatus.statusMessage);
 	});
+});
+describe('parseApiResponse', () => {
+	const MOCK_RESPONSE = {
+		headers: {},
+		statusCode: 200
+	};
 	it('returns the flags set in the X-Meetup-Flags header', () => {
 		const headers = {
 			'x-meetup-flags': 'foo=true,bar=false',


### PR DESCRIPTION
We needed a higher-level `catch` on our API response parser so that it would still send something to the client even when the API failed.

This will make it easier to see/debug bad API responses.

_Note_: the only new code is the `errorResponse$` function that is added in with a `.catch` on the api request observable - everything else is in this PR is organization improvements and tests