### PR TITLE
Filtering out cf-ray header aaand logging all other headers for review

### DIFF
--- a/src/util/apiUtils.js
+++ b/src/util/apiUtils.js
@@ -165,8 +165,6 @@ export const buildRequestArgs = externalRequestOpts =>
 		const externalRequestOptsQuery = JSON.parse(JSON.stringify(externalRequestOpts));
 		externalRequestOptsQuery.url = encodeURI(`/${endpoint}`);
 
-		delete externalRequestOptsQuery.headers['cf-ray'];
-
 		if (flags) {
 			externalRequestOptsQuery.headers['X-Meetup-Request-Flags'] = flags.join(',');
 		}
@@ -184,8 +182,6 @@ export const buildRequestArgs = externalRequestOpts =>
 			externalRequestOptsQuery.headers['content-type'] = 'application/x-www-form-urlencoded';
 			break;
 		}
-
-		console.log(`External request query: ${JSON.stringify(externalRequestOptsQuery.headers)}`);
 
 		return externalRequestOptsQuery;
 	};
@@ -227,6 +223,9 @@ export function parseRequest(request, baseUrl) {
 	delete externalRequestHeaders['host'];
 	delete externalRequestHeaders['accept-encoding'];
 	delete externalRequestHeaders['content-length'];  // original request content-length is irrelevant
+	delete externalRequestHeaders['cf-ray']; // unique cloudflare id which will trip up api requests if present
+	
+	console.log(`External request headers: ${JSON.stringify(externalRequestHeaders)}`);
 
 	const externalRequestOpts = {
 		baseUrl,

--- a/src/util/apiUtils.js
+++ b/src/util/apiUtils.js
@@ -165,6 +165,8 @@ export const buildRequestArgs = externalRequestOpts =>
 		const externalRequestOptsQuery = JSON.parse(JSON.stringify(externalRequestOpts));
 		externalRequestOptsQuery.url = encodeURI(`/${endpoint}`);
 
+		delete externalRequestOptsQuery.headers['cf-ray'];
+
 		if (flags) {
 			externalRequestOptsQuery.headers['X-Meetup-Request-Flags'] = flags.join(',');
 		}
@@ -182,6 +184,8 @@ export const buildRequestArgs = externalRequestOpts =>
 			externalRequestOptsQuery.headers['content-type'] = 'application/x-www-form-urlencoded';
 			break;
 		}
+
+		console.log(`External request query: ${JSON.stringify(externalRequestOptsQuery.headers)}`);
 
 		return externalRequestOptsQuery;
 	};


### PR DESCRIPTION
We're seeing forbidden errors from Cloudflare when making requests to api.meetup.com from within the node app. We suspect the uniquely generated "cf-ray" header is being sent through, which Cloudflare is flagging and therefore rejecting the request.
