### PR TITLE
Gracefully handle /api errors

### DIFF
--- a/src/apiProxy/apiProxyHandler.js
+++ b/src/apiProxy/apiProxyHandler.js
@@ -2,8 +2,9 @@ import url from 'url';
 import Boom from 'boom';
 
 const handleQueryResponses = (request, reply) => queryResponses => {
-	const response = reply(JSON.stringify(queryResponses))
-		.type('application/json');
+	const response = reply(JSON.stringify({
+		responses: queryResponses,
+	})).type('application/json');
 
 	const payload = request.method === 'post' ?
 		request.payload :

--- a/src/apiProxy/apiProxyRoutes.js
+++ b/src/apiProxy/apiProxyRoutes.js
@@ -32,13 +32,16 @@ const getApiProxyRoutes = (path, env, apiProxyFn$) => {
 			enabled: true,
 		}
 	};
-
+	const app = {
+		jsonError: true,
+	};
 
 	const apiGetRoute = {
 		path,
 		handler,
 		method: ['GET', 'DELETE', 'PATCH'],
 		config: {
+			app,
 			plugins,
 			validate: {
 				query: validApiPayloadSchema
@@ -50,6 +53,7 @@ const getApiProxyRoutes = (path, env, apiProxyFn$) => {
 		handler,
 		method: 'POST',
 		config: {
+			app,
 			plugins,
 			validate: {
 				payload: validApiPayloadSchema

--- a/src/apiProxy/apiProxyRoutes.js
+++ b/src/apiProxy/apiProxyRoutes.js
@@ -26,35 +26,32 @@ const getApiProxyRoutes = (path, env, apiProxyFn$) => {
 	 * @returns Array query responses, which are in the format defined
 	 *   by `apiAdapter.apiResponseToQueryResponse`
 	 */
-	const handler = getApiProxyRouteHandler(proxyApiRequest$);
-	const plugins = {
-		'electrode-csrf-jwt': {
-			enabled: true,
-		}
-	};
-	const app = {
-		jsonError: true,
-	};
-
-	const apiGetRoute = {
+	const routeBase = {
 		path,
-		handler,
+		handler: getApiProxyRouteHandler(proxyApiRequest$),
+		config: {
+			plugins: {
+				'electrode-csrf-jwt': {
+					enabled: true,
+				}
+			},
+		},
+	};
+	const apiGetRoute = {
+		...routeBase,
 		method: ['GET', 'DELETE', 'PATCH'],
 		config: {
-			app,
-			plugins,
+			...routeBase.config,
 			validate: {
 				query: validApiPayloadSchema
 			},
 		},
 	};
 	const apiPostRoute = {
-		path,
-		handler,
+		...routeBase,
 		method: 'POST',
 		config: {
-			app,
-			plugins,
+			...routeBase.config,
 			validate: {
 				payload: validApiPayloadSchema
 			},
@@ -65,3 +62,4 @@ const getApiProxyRoutes = (path, env, apiProxyFn$) => {
 };
 
 export default getApiProxyRoutes;
+

--- a/src/apiProxy/apiProxyRoutes.js
+++ b/src/apiProxy/apiProxyRoutes.js
@@ -27,12 +27,19 @@ const getApiProxyRoutes = (path, env, apiProxyFn$) => {
 	 *   by `apiAdapter.apiResponseToQueryResponse`
 	 */
 	const handler = getApiProxyRouteHandler(proxyApiRequest$);
+	const plugins = {
+		'electrode-csrf-jwt': {
+			enabled: true,
+		}
+	};
+
 
 	const apiGetRoute = {
 		path,
 		handler,
 		method: ['GET', 'DELETE', 'PATCH'],
 		config: {
+			plugins,
 			validate: {
 				query: validApiPayloadSchema
 			},
@@ -43,13 +50,9 @@ const getApiProxyRoutes = (path, env, apiProxyFn$) => {
 		handler,
 		method: 'POST',
 		config: {
+			plugins,
 			validate: {
 				payload: validApiPayloadSchema
-			},
-			plugins: {
-				'electrode-csrf-jwt': {
-					enabled: true,
-				}
 			},
 		},
 	};

--- a/src/apiProxy/apiProxyRoutes.js
+++ b/src/apiProxy/apiProxyRoutes.js
@@ -46,6 +46,11 @@ const getApiProxyRoutes = (path, env, apiProxyFn$) => {
 			validate: {
 				payload: validApiPayloadSchema
 			},
+			plugins: {
+				'electrode-csrf-jwt': {
+					enabled: true,
+				}
+			},
 		},
 	};
 

--- a/src/reducers/platform.js
+++ b/src/reducers/platform.js
@@ -23,8 +23,8 @@ export function app(state=DEFAULT_APP_STATE, action={}) {
 	switch (action.type) {
 	case 'CACHE_SUCCESS':  // fall through - same effect as API success
 	case 'API_SUCCESS':
-			// API_SUCCESS contains an array of responses, but we just need to build a single
-			// object to update state with
+		// API_SUCCESS contains an array of responses, but we just need to build a single
+		// object to update state with
 		newState = action.payload.responses.reduce((s, r) => ({ ...s, ...r }), {});
 		delete state.error;
 		return { ...state, ...newState };

--- a/src/reducers/platform.js
+++ b/src/reducers/platform.js
@@ -25,11 +25,17 @@ export function app(state=DEFAULT_APP_STATE, action={}) {
 	case 'API_SUCCESS':
 			// API_SUCCESS contains an array of responses, but we just need to build a single
 			// object to update state with
-		newState = Object.assign.apply(Object, [{}].concat(action.payload.responses));
+		newState = action.payload.responses.reduce((s, r) => ({ ...s, ...r }), {});
+		delete state.error;
 		return { ...state, ...newState };
 	case 'LOGOUT_REQUEST':
 		// need to clear ALL private data, i.e. all data
 		return DEFAULT_APP_STATE;
+	case 'API_ERROR':
+		return {
+			...state,
+			error: action.payload
+		};
 	default:
 		return state;
 	}

--- a/src/reducers/platform.test.js
+++ b/src/reducers/platform.test.js
@@ -10,6 +10,27 @@ describe('reducer', () => {
 	it('returns default state for empty action', () => {
 		expect(app(undefined, {})).toEqual(DEFAULT_APP_STATE);
 	});
+	it('assembles success responses into single state tree', () => {
+		const API_SUCCESS = {
+			type: 'API_SUCCESS',
+			payload: {
+				responses: [{ foo: 'bar'}, { bar: 'baz' }, { baz: 'foo' }],
+			},
+		};
+		expect(app(undefined, API_SUCCESS)).toEqual({
+			foo: 'bar',
+			bar: 'baz',
+			baz: 'foo',
+		});
+	});
+	it('populates an `error` key on API_ERROR', () => {
+		const API_ERROR = {
+			type: 'API_ERROR',
+			payload: new Error('this is the worst'),
+		};
+		const errorState = app(undefined, API_ERROR);
+		expect(errorState.error).toBe(API_ERROR.payload);
+	});
 	it('app data should be cleared by a LOGOUT_REQUEST event', function() {
 		expect(app(this.MOCK_STATE, { type: 'LOGOUT_REQUEST' })).toEqual(DEFAULT_APP_STATE);
 	});

--- a/src/routes.test.js
+++ b/src/routes.test.js
@@ -31,7 +31,9 @@ describe('routes', () => {
 		const validQuery = { type: 'a', ref: 'b', params: {} };
 		const qs = querystring.stringify({ queries: JSON.stringify([validQuery]) });
 		return getResponse({ url: `/api?${qs}` })
-			.then(response => expect(JSON.parse(response.payload)).toEqual(MOCK_API_RESULT));
+			.then(response => expect(JSON.parse(response.payload)).toEqual({
+				responses: MOCK_API_RESULT
+			}));
 	});
 });
 

--- a/src/routes/appRoute.js
+++ b/src/routes/appRoute.js
@@ -1,4 +1,26 @@
+import React from 'react';
+import ReactDOMServer from 'react-dom/server';
 import { getAppRouteHandler } from './appRouteHandler';
+
+/**
+ * This function provides global error handling when there is a 500 error
+ */
+export const onPreResponse = {
+	method: (request, reply) => {
+		const response = request.response;
+		if (!response.isBoom) {
+			return reply.continue();
+		}
+		const error = response;
+		const { RedBoxError } = require('redbox-react');
+		const errorMarkup = ReactDOMServer.renderToString(
+			React.createElement(RedBoxError, { error })
+		);
+		const errorResponse = reply(`<!DOCTYPE html><html><body>${errorMarkup}</body></html>`);
+		errorResponse.code(error.output.statusCode);
+		return errorResponse;
+	},
+};
 
 /**
  * Only one wildcard route for all application GET requests - exceptions are
@@ -7,6 +29,11 @@ import { getAppRouteHandler } from './appRouteHandler';
 const getApplicationRoute = renderRequestMap => ({
 	method: 'GET',
 	path: '/{wild*}',
+	config: {
+		ext: {
+			onPreResponse,
+		},
+	},
 	handler: getAppRouteHandler(renderRequestMap),
 });
 

--- a/src/routes/appRoute.test.js
+++ b/src/routes/appRoute.test.js
@@ -1,0 +1,27 @@
+import Boom from 'boom';
+import { onPreResponse } from './appRoute';
+
+describe('onPreResponse.method', () => {
+	it('returns html containing error message', () => {
+		const errorMessage = 'foobar';
+		const errorCode = 432;
+		const request = {
+			response: Boom.create(errorCode, errorMessage),
+			route: {},
+		};
+		const replyObj = {
+			code() {}
+		};
+		const spyable = {
+			reply: () => replyObj,
+		};
+		spyOn(replyObj, 'code');
+		spyOn(spyable, 'reply').and.callThrough();
+		const errorResponse = onPreResponse.method(request, spyable.reply);
+		expect(errorResponse).toBe(replyObj);
+		const errorMarkup = spyable.reply.calls.mostRecent().args[0];
+		expect(errorMarkup.indexOf(errorMessage)).toBeGreaterThan(-1);
+		expect(replyObj.code).toHaveBeenCalledWith(errorCode);
+	});
+});
+

--- a/src/util/apiUtils.js
+++ b/src/util/apiUtils.js
@@ -347,6 +347,7 @@ export const logApiResponse = appRequest => ([response, body]) => {
 		},
 		response: {
 			elapsedTime: response.elapsedTime,
+			status: response.statusCode,
 			body: body.length > 256 ? `${body.substr(0, 256)}...`: body,
 		},
 	};

--- a/src/util/fetchUtils.js
+++ b/src/util/fetchUtils.js
@@ -52,10 +52,10 @@ export const fetchQueries = (apiUrl, options) => (queries, meta) => {
 		fetchConfig
 	)
 	.then(queryResponse =>
-		queryResponse.json().then(responses =>
+		queryResponse.json().then(({ responses }) =>
 			({
 				queries,
-				responses,
+				responses: responses || [],
 				csrf: queryResponse.headers.get('x-csrf-jwt'),
 			})
 		)

--- a/src/util/fetchUtils.js
+++ b/src/util/fetchUtils.js
@@ -52,13 +52,18 @@ export const fetchQueries = (apiUrl, options) => (queries, meta) => {
 		fetchConfig
 	)
 	.then(queryResponse =>
-		queryResponse.json().then(({ responses }) =>
-			({
+		queryResponse.json().then(({ responses, error, message }) => {
+			if (error) {
+				throw new Error(message);  // treat like an API error
+			}
+			return {
 				queries,
+				error,
+				message,
 				responses: responses || [],
 				csrf: queryResponse.headers.get('x-csrf-jwt'),
-			})
-		)
+			};
+		})
 	);
 };
 

--- a/src/util/fetchUtils.js
+++ b/src/util/fetchUtils.js
@@ -58,8 +58,6 @@ export const fetchQueries = (apiUrl, options) => (queries, meta) => {
 			}
 			return {
 				queries,
-				error,
-				message,
 				responses: responses || [],
 				csrf: queryResponse.headers.get('x-csrf-jwt'),
 			};

--- a/src/util/serverUtils.js
+++ b/src/util/serverUtils.js
@@ -41,7 +41,7 @@ export function configureEnv(config) {
  */
 export function onPreResponse(request, reply) {
 	const response = request.response;
-	if (!response.isBoom) {
+	if (!response.isBoom || request.route.path === '/api') {
 		return reply.continue();
 	}
 	const error = response;

--- a/src/util/serverUtils.js
+++ b/src/util/serverUtils.js
@@ -41,7 +41,7 @@ export function configureEnv(config) {
  */
 export function onPreResponse(request, reply) {
 	const response = request.response;
-	if (!response.isBoom || request.route.path === '/api') {
+	if (!response.isBoom || request.route.settings.app.jsonError) {
 		return reply.continue();
 	}
 	const error = response;

--- a/src/util/serverUtils.js
+++ b/src/util/serverUtils.js
@@ -1,6 +1,4 @@
 import https from 'https';
-import React from 'react';
-import ReactDOMServer from 'react-dom/server';
 import Hapi from 'hapi';
 
 import track from './tracking';
@@ -37,24 +35,6 @@ export function configureEnv(config) {
 }
 
 /**
- * This function provides global error handling when there is a 500 error
- */
-export function onPreResponse(request, reply) {
-	const response = request.response;
-	if (!response.isBoom || ((request.route.settings || {}).app || {}).jsonError) {
-		return reply.continue();
-	}
-	const error = response;
-	const { RedBoxError } = require('redbox-react');
-	const errorMarkup = ReactDOMServer.renderToString(
-		React.createElement(RedBoxError, { error })
-	);
-	const errorResponse = reply(`<!DOCTYPE html><html><body>${errorMarkup}</body></html>`);
-	errorResponse.code(error.output.statusCode);
-	return errorResponse;
-}
-
-/**
  * server-starting function
  */
 export function server(routes, connection, plugins, platform_agent, config) {
@@ -64,7 +44,6 @@ export function server(routes, connection, plugins, platform_agent, config) {
 
 	return server.connection(connection)
 		.register(plugins)
-		.then(() => server.ext('onPreResponse', onPreResponse))
 		.then(() => server.auth.strategy('default', 'oauth', true, config))
 		.then(() => server.log(['start'], `${plugins.length} plugins registered, assigning routes...`))
 		.then(() => server.route(routes))

--- a/src/util/serverUtils.js
+++ b/src/util/serverUtils.js
@@ -41,7 +41,7 @@ export function configureEnv(config) {
  */
 export function onPreResponse(request, reply) {
 	const response = request.response;
-	if (!response.isBoom || request.route.settings.app.jsonError) {
+	if (!response.isBoom || ((request.route.settings || {}).app || {}).jsonError) {
 		return reply.continue();
 	}
 	const error = response;

--- a/src/util/serverUtils.test.js
+++ b/src/util/serverUtils.test.js
@@ -40,27 +40,4 @@ describe('configureEnv', function() {
 	});
 });
 
-describe('onPreResponse', () => {
-	it('returns html containing error message', () => {
-		const errorMessage = 'foobar';
-		const errorCode = 432;
-		const request = {
-			response: Boom.create(errorCode, errorMessage),
-			route: {},
-		};
-		const replyObj = {
-			code() {}
-		};
-		const spyable = {
-			reply: () => replyObj,
-		};
-		spyOn(replyObj, 'code');
-		spyOn(spyable, 'reply').and.callThrough();
-		const errorResponse = serverUtils.onPreResponse(request, spyable.reply);
-		expect(errorResponse).toBe(replyObj);
-		const errorMarkup = spyable.reply.calls.mostRecent().args[0];
-		expect(errorMarkup.indexOf(errorMessage)).toBeGreaterThan(-1);
-		expect(replyObj.code).toHaveBeenCalledWith(errorCode);
-	});
-});
 

--- a/src/util/serverUtils.test.js
+++ b/src/util/serverUtils.test.js
@@ -45,7 +45,8 @@ describe('onPreResponse', () => {
 		const errorMessage = 'foobar';
 		const errorCode = 432;
 		const request = {
-			response: Boom.create(errorCode, errorMessage)
+			response: Boom.create(errorCode, errorMessage),
+			route: {},
 		};
 		const replyObj = {
 			code() {}

--- a/src/util/tracking.js
+++ b/src/util/tracking.js
@@ -123,7 +123,7 @@ export const trackApi = log => (response, queryResponses, metadata={}) => {
 	}
 	// special case - login requests need to be tracked
 	const loginResponse = queryResponses.find(r => r.login);
-	if (loginResponse && loginResponse.value.member) {
+	if ((((loginResponse || {}).login || {}).value || {}).member) {
 		const member_id = JSON.stringify(loginResponse.login.value.member.id);
 		trackLogin(log)(response, member_id);
 	}

--- a/src/util/tracking.js
+++ b/src/util/tracking.js
@@ -123,7 +123,7 @@ export const trackApi = log => (response, queryResponses, metadata={}) => {
 	}
 	// special case - login requests need to be tracked
 	const loginResponse = queryResponses.find(r => r.login);
-	if (((loginResponse.login || {}).value || {}).member) {
+	if ((loginResponse && loginResponse.login.value || {}).member) {
 		const member_id = JSON.stringify(loginResponse.login.value.member.id);
 		trackLogin(log)(response, member_id);
 	}

--- a/src/util/tracking.js
+++ b/src/util/tracking.js
@@ -123,7 +123,7 @@ export const trackApi = log => (response, queryResponses, metadata={}) => {
 	}
 	// special case - login requests need to be tracked
 	const loginResponse = queryResponses.find(r => r.login);
-	if (loginResponse) {
+	if (loginResponse && loginResponse.value.member) {
 		const member_id = JSON.stringify(loginResponse.login.value.member.id);
 		trackLogin(log)(response, member_id);
 	}

--- a/src/util/tracking.js
+++ b/src/util/tracking.js
@@ -123,7 +123,7 @@ export const trackApi = log => (response, queryResponses, metadata={}) => {
 	}
 	// special case - login requests need to be tracked
 	const loginResponse = queryResponses.find(r => r.login);
-	if ((((loginResponse || {}).login || {}).value || {}).member) {
+	if (((loginResponse.login || {}).value || {}).member) {
 		const member_id = JSON.stringify(loginResponse.login.value.member.id);
 		trackLogin(log)(response, member_id);
 	}

--- a/tests/integration/api.int.js
+++ b/tests/integration/api.int.js
@@ -1,0 +1,54 @@
+import start from '../../src/server';
+
+jest.mock('request', () =>
+	jest.fn(
+		(requestOpts, cb) =>
+			setTimeout(() =>
+				cb(null, {
+					headers: {},
+					statusCode: 200,
+					elapsedTime: 1234,
+					request: {
+						uri: {
+							query: 'foo=bar',
+							pathname: '/foo',
+						},
+						method: 'get',
+					},
+				}, '{}'), 200)
+	)
+);
+
+describe('API proxy endpoint integration tests', () => {
+	const random32 = 'asdfasdfasdfasdfasdfasdfasdfasdf';
+	const mockConfig = () => Promise.resolve({
+		CSRF_SECRET: random32,
+		COOKIE_ENCRYPT_SECRET: random32,
+		oauth: {
+			key: random32,
+			secret: random32,
+		}
+	});
+	it('calls the handler for /api', () => {
+		const expectedResponse = JSON.stringify({
+			responses: [{}],
+		});
+		return start({}, {}, mockConfig)
+			.then(server => {
+				const request = {
+					method: 'get',
+					url: '/api?queries=[{}]',
+					credentials: 'whatever',
+				};
+				return server.inject(request).then(
+					response => expect(response.payload).toEqual(expectedResponse)
+				)
+				.then(() => server.stop())
+				.catch(err => {
+					server.stop();
+					throw err;
+				});
+			});
+	});
+});
+

--- a/tests/integration/api.post.int.js
+++ b/tests/integration/api.post.int.js
@@ -1,0 +1,120 @@
+import Boom from 'boom';
+import csrf from 'electrode-csrf-jwt/lib/csrf';
+import uuid from 'uuid';
+import start from '../../src/server';
+import * as apiProxyHandler from '../../src/apiProxy/apiProxyHandler';
+
+jest.mock('request', () =>
+	jest.fn(
+		(requestOpts, cb) =>
+			setTimeout(() =>
+				cb(null, {
+					headers: {},
+					statusCode: 200,
+					elapsedTime: 234,
+					request: {
+						uri: {
+							pathname: '/foo',
+						},
+						method: 'post',
+					},
+				}, '{}'), 234)
+	)
+);
+
+
+const mockQuery = { type: 'foo', params: {}, ref: 'foo', endpoint: 'foo' };
+const mockPostPayload = {
+	queries: JSON.stringify([mockQuery])
+};
+
+const random32 = 'asdfasdfasdfasdfasdfasdfasdfasdf';
+function getCsrfHeaders() {
+	const options = {
+		secret: random32,
+	};
+	const id = uuid.v4();
+	const headerPayload = {type: 'header', uuid: id};
+	const cookiePayload = {type: 'cookie', uuid: id};
+
+	return csrf.create(headerPayload, options)
+		.then(headerToken => {
+			return csrf.create(cookiePayload, options)
+				.then(cookieToken => ([headerToken, cookieToken]));
+		});
+}
+const runTest = (test, payload=mockPostPayload, csrfHeaders=getCsrfHeaders) => server =>
+	csrfHeaders()
+		.then(([headerToken, cookieToken]) => {
+			const headers = {
+				'x-csrf-jwt': headerToken,
+				cookie: `x-csrf-jwt=${cookieToken}`,
+			};
+			const request = {
+				method: 'post',
+				url: '/api',
+				payload,
+				credentials: 'whatever',
+				headers,
+			};
+			return server.inject(request);
+		})
+		.then(test)
+		.then(() => server.stop())
+		.catch(err => {
+			server.stop();
+			throw err;
+		});
+
+
+describe('API proxy POST endpoint integration tests', () => {
+	const mockConfig = () => Promise.resolve({
+		CSRF_SECRET: random32,
+		COOKIE_ENCRYPT_SECRET: random32,
+		oauth: {
+			key: random32,
+			secret: random32,
+		}
+	});
+	it('calls the POST handler for /api', () => {
+		const spyable = {
+			handler: (request, reply) => reply('okay'),
+		};
+		spyOn(spyable, 'handler').and.callThrough();
+		spyOn(apiProxyHandler, 'getApiProxyRouteHandler')
+			.and.callFake(() => spyable.handler);
+
+		const test = response => expect(spyable.handler).toHaveBeenCalled();
+
+		return start({}, {}, mockConfig)
+			.then(runTest(test));
+	});
+	it('returns a formatted array of responses from POST /api', () => {
+		const expectedResponse = JSON.stringify({
+			responses: [{
+				[mockQuery.ref]: {
+					type: mockQuery.type,
+					value: {},  // from the mocked `request` module
+					meta: {
+						flags: {},
+						endpoint: '/foo',
+					},
+				}
+			}],
+		});
+		const test = response => expect(response.payload).toEqual(expectedResponse);
+
+		return start({}, {}, mockConfig)
+			.then(runTest(test));
+	});
+	it('return a an object with an error key when CSRF is invalid', () => {
+		const expectedPayload = JSON.stringify(Boom.create(400, 'INVALID_JWT').output.payload);
+		console.log(expectedPayload);
+		const test = response => expect(response.payload).toEqual(expectedPayload);
+		const csrfHeaders = () => getCsrfHeaders().then(([cookieToken, headerToken]) => ([cookieToken, '']));
+
+		return start({}, {}, mockConfig)
+			.then(runTest(test, mockConfig, csrfHeaders));
+	});
+});
+

--- a/tests/integration/api.post.int.js
+++ b/tests/integration/api.post.int.js
@@ -109,7 +109,6 @@ describe('API proxy POST endpoint integration tests', () => {
 	});
 	it('return a an object with an error key when CSRF is invalid', () => {
 		const expectedPayload = JSON.stringify(Boom.create(400, 'INVALID_JWT').output.payload);
-		console.log(expectedPayload);
 		const test = response => expect(response.payload).toEqual(expectedPayload);
 		const csrfHeaders = () => getCsrfHeaders().then(([cookieToken, headerToken]) => ([cookieToken, '']));
 

--- a/tests/integration/server.int.js
+++ b/tests/integration/server.int.js
@@ -1,8 +1,7 @@
 import start from '../../src/server';
-import * as apiProxyHandler from '../../src/apiProxy/apiProxyHandler';
 import * as appRouteHandler from '../../src/routes/appRouteHandler';
 
-describe('Integration tests', () => {
+describe('General server startup tests', () => {
 	const random32 = 'asdfasdfasdfasdfasdfasdfasdfasdf';
 	const mockConfig = () => Promise.resolve({
 		CSRF_SECRET: random32,
@@ -44,7 +43,11 @@ describe('Integration tests', () => {
 				return server.inject(requestFooRoute).then(
 					response => expect(response.payload).toEqual(expectedResponse)
 				)
-				.then(() => server.stop());
+				.then(() => server.stop())
+				.catch(err => {
+					server.stop();
+					throw err;
+				});
 			});
 	});
 	it('calls the handler for an authenticated route', () => {
@@ -66,27 +69,11 @@ describe('Integration tests', () => {
 				return server.inject(authedRequestFooRoute).then(
 					response => expect(response.payload).toEqual(expectedResponse)
 				)
-				.then(() => server.stop());
-			});
-	});
-	it('calls the handler for /api', () => {
-		const spyable = {
-			handler: (request, reply) => reply('okay'),
-		};
-		spyOn(spyable, 'handler').and.callThrough();
-		spyOn(apiProxyHandler, 'getApiProxyRouteHandler')
-			.and.callFake(() => spyable.handler);
-		return start({}, {}, mockConfig)
-			.then(server => {
-				const request = {
-					method: 'get',
-					url: '/api?queries=[]',
-					credentials: 'whatever',
-				};
-				return server.inject(request).then(
-					response => expect(spyable.handler).toHaveBeenCalled()
-				)
-				.then(() => server.stop());
+				.then(() => server.stop())
+				.catch(err => {
+					server.stop();
+					throw err;
+				});
 			});
 	});
 	it('calls the handler for /{*wild}', () => {
@@ -106,7 +93,11 @@ describe('Integration tests', () => {
 				return server.inject(request).then(
 					response => expect(spyable.handler).toHaveBeenCalled()
 				)
-				.then(() => server.stop());
+				.then(() => server.stop())
+				.catch(err => {
+					server.stop();
+					throw err;
+				});
 			});
 	});
 });


### PR DESCRIPTION
CSRF errors, oauth errors, etc

The main culprit is the `onPreResponse` handler that will generate an HTML response when there's an error in the request/response to `/api`, which the app will choke on because it's not JSON.

