### PR TITLE
Server app runtime - isDevConfig

### DIFF
--- a/src/util/serverUtils.js
+++ b/src/util/serverUtils.js
@@ -40,6 +40,11 @@ export function configureEnv(config) {
 export function server(routes, connection, plugins, platform_agent, config) {
 	const server = new Hapi.Server();
 
+	// store runtime state
+	// https://hapijs.com/api#serverapp
+	server.app = {
+		isDevConfig: checkForDevUrl(config),
+	};
 	server.decorate('reply', 'track', track(platform_agent));
 
 	return server.connection(connection)

--- a/src/util/serverUtils.js
+++ b/src/util/serverUtils.js
@@ -43,7 +43,7 @@ export function server(routes, connection, plugins, platform_agent, config) {
 	// store runtime state
 	// https://hapijs.com/api#serverapp
 	server.app = {
-		isDevConfig: checkForDevUrl(config),
+		isDevConfig: checkForDevUrl(config),  // indicates dev API or prod API
 	};
 	server.decorate('reply', 'track', track(platform_agent));
 


### PR DESCRIPTION
I am starting to run into more cases where it would be helpful to know if the `.dev.meetup` API urls are being used, which is determined independently of whether the app server is running in 'development' or 'production' mode. Hapi provides a convenient place to store that 'runtime' state, in `server.app`, which is also accessible from every Hapi request as `request.server.app`.

This adds a single value to the `server.app` namespace - `isDevConfig`.