### PR TITLE
WP-124 use MEETUP_LANGUAGE cookie to help determine language

### DIFF
--- a/src/util/languageUtils.test.js
+++ b/src/util/languageUtils.test.js
@@ -1,5 +1,9 @@
+import querystring from 'querystring';
 import url from 'url';
 import {
+	getCookieLang,
+	getUrlLang,
+	getBrowserLang,
 	getLanguage,
 	checkLanguageRedirect,
 } from './languageUtils';
@@ -8,39 +12,68 @@ const rootUrl = 'http://example.com/';
 const MOCK_HAPI_REQUEST = {
 	log() {},
 	url: url.parse(rootUrl),
-	headers: {}
+	headers: {},
+	state: {},
 };
 const MOCK_HAPI_REPLY = {
 	redirect() {},
 };
-
-describe('getLanguage', () => {
-	const defaultLang = 'en-US';
-	const altLang = 'fr-FR';
-	const supportedLangs = [defaultLang, altLang];
+const defaultLang = 'en-US';
+const altLang = 'fr-FR';
+const altLang2 = 'de-DE';
+const altLang3 = 'es-ES';
+const supportedLangs = [defaultLang, altLang, altLang2, altLang3];
+describe('getCookieLang', () => {
+	it('returns undefined when no cookie in state', () => {
+		const request = { ...MOCK_HAPI_REQUEST };
+		const lang = getCookieLang(request, supportedLangs);
+		expect(lang).toBeUndefined();
+	});
+	it('returns supported MEETUP_LANGUAGE cookie when present', () => {
+		const MEETUP_LANGUAGE = querystring.stringify({
+			country: 'FR',
+			language: 'fr',
+		});
+		const request = { ...MOCK_HAPI_REQUEST, state: { MEETUP_LANGUAGE } };
+		const lang = getCookieLang(request, supportedLangs);
+		expect(lang).toEqual(altLang);
+	});
+});
+describe('getUrlLang', () => {
+	it('returns false for unsupported lang in url', () => {
+		const requestLang = 'this-isnt-even-a-language';
+		const request = { ...MOCK_HAPI_REQUEST, url: url.parse(`${rootUrl}${requestLang}/`) };
+		const lang = getUrlLang(request, supportedLangs);
+		expect(lang).toBe(false);
+	});
 	it('returns supported language from URL pathname, if present', () => {
 		const requestLang = altLang;
 		const request = { ...MOCK_HAPI_REQUEST, url: url.parse(`${rootUrl}${requestLang}/`) };
-		const lang = getLanguage(request, supportedLangs);
+		const lang = getUrlLang(request, supportedLangs);
 		expect(lang).toEqual(requestLang);
+	});
+});
+describe('getBrowserLang', () => {
+	it('returns false for unsupported browser language', () => {
+		const acceptLang = 'this-isnt-even-a-language';
+		const request = { ...MOCK_HAPI_REQUEST, headers: { 'accept-language': acceptLang } };
+		const lang = getBrowserLang(request, supportedLangs);
+		expect(lang).toBe(false);
 	});
 	it('returns supported language from brower "Accept-Language" header, if present', () => {
 		const acceptLang = altLang;
 		const request = { ...MOCK_HAPI_REQUEST, headers: { 'accept-language': acceptLang } };
-		const lang = getLanguage(request, supportedLangs);
+		const lang = getBrowserLang(request, supportedLangs);
 		expect(lang).toEqual(acceptLang);
 	});
+});
+describe('getLanguage', () => {
 	it('returns default language if no supported lang or URL pathname prefix', () => {
 		const lang = getLanguage(MOCK_HAPI_REQUEST, supportedLangs, defaultLang);
 		expect(lang).toEqual(defaultLang);
 	});
 });
 describe('checkLanguageRedirect', () => {
-	const defaultLang = 'en-US';
-	const altLang = 'fr-FR';
-	const altLang2 = 'de-DE';
-	const altLang3 = 'es-ES';
-	const supportedLangs = [defaultLang, altLang, altLang2, altLang3];
 	function getRedirect({ requestLang, requestUrl }) {
 		const request = { ...MOCK_HAPI_REQUEST, url: url.parse(requestUrl) };
 		return checkLanguageRedirect(request, MOCK_HAPI_REPLY, requestLang, supportedLangs, defaultLang);


### PR DESCRIPTION
This PR includes a functional refactor of `getLanguage` that eliminates redundant request parsing and makes things more testable