### PR TITLE
WP-143 include all x-meetup headers in api response

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "js-cookie": "^2.1.2",
     "meetup-web-mocks": "0.1.23",
     "node-fetch": "1.6.3",
+    "qs": "6.3.0",
     "react": "15.4.1",
     "react-addons-test-utils": "15.4.1",
     "react-dom": "15.4.1",

--- a/src/routes.test.js
+++ b/src/routes.test.js
@@ -1,4 +1,4 @@
-import querystring from 'querystring';
+import querystring from 'qs';
 import {
 	MOCK_API_RESULT,
 	MOCK_renderRequestMap,

--- a/src/util/apiUtils.js
+++ b/src/util/apiUtils.js
@@ -50,8 +50,12 @@ export const createCookieJar = requestUrl => {
 	return null;
 };
 
+const X_HEADERS = [
+	'x-total-count'
+];
+
 export const parseMetaHeaders = headers => {
-	const meta = Object.keys(headers)
+	const meetupHeaders = Object.keys(headers)
 		.filter(h => h.startsWith('x-meetup-'))
 		.reduce((meta, h) => {
 			const key = toCamelCase(h.replace('x-meetup-', ''));
@@ -60,11 +64,25 @@ export const parseMetaHeaders = headers => {
 		}, {});
 
 	// special case handling for flags
-	meta.flags = querystring.parse(meta.flags, {
-		delimiter: ',',
-		decoder: coerceBool,
-	});
-	return meta;
+	if (meetupHeaders.flags) {
+		meetupHeaders.flags = querystring.parse(meetupHeaders.flags, {
+			delimiter: ',',
+			decoder: coerceBool,
+		});
+	}
+
+	const xHeaders = X_HEADERS.reduce((meta, h) => {
+		const key = toCamelCase(h.replace('x-', ''));
+		if (h in headers) {
+			meta[key] = headers[h];
+		}
+		return meta;
+	}, {});
+
+	return {
+		...meetupHeaders,
+		...xHeaders,
+	};
 };
 
 /**

--- a/src/util/apiUtils.mockRequest.test.js
+++ b/src/util/apiUtils.mockRequest.test.js
@@ -102,7 +102,6 @@ describe('makeApiRequest$', () => {
 		const expectedResponse = {
 			[query.ref]: {
 				meta: {
-					flags: {},
 					requestId: 'mock request',
 					endpoint
 				},

--- a/src/util/apiUtils.test.js
+++ b/src/util/apiUtils.test.js
@@ -163,8 +163,10 @@ describe('parseApiResponse', () => {
 			'x-meetup-flags': 'foo=true,bar=false',
 		};
 		const flaggedResponse = { ...MOCK_RESPONSE, headers };
-		expect(parseApiResponse('http://example.com')([flaggedResponse, '{}']).meta.flags.foo).toBe(true);
-		expect(parseApiResponse('http://example.com')([flaggedResponse, '{}']).meta.flags.bar).toBe(false);
+		expect(parseApiResponse('http://example.com')([flaggedResponse, '{}']).meta.flags).toEqual({
+			foo: true,
+			bar: false,
+		});
 	});
 	it('returns the requestId set in the X-Meetup-Request-Id header', () => {
 		const requestId = '1234';

--- a/src/util/apiUtils.test.js
+++ b/src/util/apiUtils.test.js
@@ -218,7 +218,7 @@ describe('parseLoginAuth', () => {
 });
 
 describe('parseMetaHeaders', () => {
-	it('parses x-meetup headers intreturns x-meetup-flags as flags object with real booleanso camelcased obj', () => {
+	it('parses x-meetup headers intreturns x-meetup-flags as flags object with real booleans camelcased obj', () => {
 		expect(parseMetaHeaders({ 'x-meetup-foo-bar': 'whatwhat' }))
 			.toEqual({ fooBar: 'whatwhat' });
 	});

--- a/src/util/apiUtils.test.js
+++ b/src/util/apiUtils.test.js
@@ -29,6 +29,7 @@ import {
 	parseApiResponse,
 	parseApiValue,
 	parseLoginAuth,
+	parseMetaHeaders,
 	queryToApiConfig,
 	groupDuotoneSetter,
 } from './apiUtils';
@@ -213,6 +214,21 @@ describe('parseLoginAuth', () => {
 		const returnVal = parseLoginAuth(request, query)(loginResponse);
 		expect(authUtils.removeAuthState).not.toHaveBeenCalled();
 		expect(returnVal).toBe(loginResponse);
+	});
+});
+
+describe('parseMetaHeaders', () => {
+	it('parses x-meetup headers intreturns x-meetup-flags as flags object with real booleanso camelcased obj', () => {
+		expect(parseMetaHeaders({ 'x-meetup-foo-bar': 'whatwhat' }))
+			.toEqual({ fooBar: 'whatwhat' });
+	});
+	it('returns x-meetup-flags as flags object with real booleans', () => {
+		expect(parseMetaHeaders({ 'x-meetup-flags': 'foo=true,bar=false' }))
+			.toEqual({ flags: { foo: true, bar: false } });
+	});
+	it('parses specified x- headers', () => {
+		expect(parseMetaHeaders({ 'x-total-count': 'whatwhat' }))
+			.toEqual({ totalCount: 'whatwhat' });
 	});
 });
 

--- a/src/util/apiUtils.test.js
+++ b/src/util/apiUtils.test.js
@@ -218,7 +218,7 @@ describe('parseLoginAuth', () => {
 });
 
 describe('parseMetaHeaders', () => {
-	it('parses x-meetup headers intreturns x-meetup-flags as flags object with real booleans camelcased obj', () => {
+	it('returns x-meetup-flags as flags object with real booleans camelcased', () => {
 		expect(parseMetaHeaders({ 'x-meetup-foo-bar': 'whatwhat' }))
 			.toEqual({ fooBar: 'whatwhat' });
 	});

--- a/src/util/languageUtils.js
+++ b/src/util/languageUtils.js
@@ -1,4 +1,4 @@
-import querystring from 'querystring';
+import querystring from 'qs';
 import url from 'url';
 import Accepts from 'accepts';
 

--- a/src/util/languageUtils.test.js
+++ b/src/util/languageUtils.test.js
@@ -1,4 +1,4 @@
-import querystring from 'querystring';
+import querystring from 'qs';
 import url from 'url';
 import {
 	getCookieLang,

--- a/src/util/stringUtils.js
+++ b/src/util/stringUtils.js
@@ -1,0 +1,19 @@
+export const coerceBool = s => {
+	switch(s) {
+	case 'true':
+		return true;
+	case 'false':
+		return false;
+	default:
+		return s;
+	}
+};
+
+/**
+ * simple camel case function - not really interested in edge cases, just
+ * straightforward 'this-is-hyphen' to 'thisIsHyphen'
+ */
+export function toCamelCase(s) {
+	return s.replace(/-(\w)/g, g => g[1].toUpperCase());
+}
+

--- a/src/util/stringUtils.test.js
+++ b/src/util/stringUtils.test.js
@@ -1,0 +1,29 @@
+import {
+	coerceBool,
+	toCamelCase,
+} from './stringUtils';
+
+describe('coerceBool', () => {
+	it('turns boolean strings into real Booleans', () => {
+		expect(coerceBool('true')).toBe(true);
+		expect(coerceBool('false')).toBe(false);
+	});
+	it('leaves non-bool strings unchanged', () => {
+		const identityCamel = s => expect(coerceBool(s)).toBe(s);
+
+		identityCamel('notbool');
+		identityCamel('1234.345');
+		identityCamel('0');
+		identityCamel('TRUE');
+	});
+});
+
+describe('toCamelCase', () => {
+	it('turns hyphenated words into camelCase', () => {
+		expect(toCamelCase('a-good-one')).toEqual('aGoodOne');
+		expect(toCamelCase('a')).toEqual('a');
+		expect(toCamelCase('request-id')).toEqual('requestId');
+		expect(toCamelCase('')).toEqual('');
+		expect(toCamelCase('this-is-compLICAT-ED')).toEqual('thisIsCompLICATED');
+	});
+});

--- a/tests/integration/api.int.js
+++ b/tests/integration/api.int.js
@@ -58,7 +58,6 @@ describe('API proxy endpoint integration tests', () => {
 					type: 'foo',
 					value: {},  // from the mocked `request` module
 					meta: {
-						flags: {},
 						endpoint: '/foo',
 					},
 				}

--- a/tests/integration/api.post.int.js
+++ b/tests/integration/api.post.int.js
@@ -97,7 +97,6 @@ describe('API proxy POST endpoint integration tests', () => {
 					type: mockQuery.type,
 					value: {},  // from the mocked `request` module
 					meta: {
-						flags: {},
 						endpoint: '/foo',
 					},
 				}


### PR DESCRIPTION
Also adds `x-total-count` value, and everything is assigned to a key that is the camelCased version of the header name.

Check out the tests for examples.