### PR TITLE
sort supportedLangs to ensure default is first

### DIFF
--- a/src/util/languageUtils.js
+++ b/src/util/languageUtils.js
@@ -28,6 +28,7 @@ export const getBrowserLang = (request, supportedLangs) => {
 
 export const getLanguage = (request, supportedLangs, defaultLang=LANG_DEFAULT) => {
 	// return the first language hit in the order of preference
+	supportedLangs = supportedLangs.sort(l => l !== defaultLang);
 	return getCookieLang(request, supportedLangs)
 		|| getUrlLang(request, supportedLangs)
 		|| getBrowserLang(request, supportedLangs)
@@ -44,6 +45,8 @@ export const checkLanguageRedirect = (
 	supportedLangs,
 	defaultLang=LANG_DEFAULT
 ) => {
+	// ensure defaultLang is first in supportedLangs
+	supportedLangs = supportedLangs.sort(l => l !== defaultLang);
 	const originalPath = request.url.pathname;
 	const firstPathComponent = originalPath.split('/')[1];
 	const redirect = makeRedirect(reply, request.url);

--- a/src/util/languageUtils.test.js
+++ b/src/util/languageUtils.test.js
@@ -19,10 +19,11 @@ const MOCK_HAPI_REPLY = {
 	redirect() {},
 };
 const defaultLang = 'en-US';
+const similarToDefault = 'en-AU';
 const altLang = 'fr-FR';
 const altLang2 = 'de-DE';
 const altLang3 = 'es-ES';
-const supportedLangs = [defaultLang, altLang, altLang2, altLang3];
+const supportedLangs = [similarToDefault, defaultLang, altLang, altLang2, altLang3];
 describe('getCookieLang', () => {
 	it('returns undefined when no cookie in state', () => {
 		const request = { ...MOCK_HAPI_REQUEST };
@@ -59,6 +60,13 @@ describe('getBrowserLang', () => {
 		const request = { ...MOCK_HAPI_REQUEST, headers: { 'accept-language': acceptLang } };
 		const lang = getBrowserLang(request, supportedLangs);
 		expect(lang).toBe(false);
+	});
+	it('returns en-US instead of en-AU for "en" if en-US is preferred', () => {
+		const acceptLang = 'en';
+		const supportedLangs = ['en-US', 'en-AU'];  // sorted by preference
+		const request = { ...MOCK_HAPI_REQUEST, headers: { 'accept-language': acceptLang } };
+		const lang = getBrowserLang(request, supportedLangs);
+		expect(lang).toEqual('en-US');
 	});
 	it('returns supported language from brower "Accept-Language" header, if present', () => {
 		const acceptLang = altLang;


### PR DESCRIPTION
the `accepts` package will use the first match from the supported language array for ambiguous language codes like `en`. We need to make sure that `supportedLangs` has the default `en-US` language code listed first so that it is chosen ahead of `en-AU` in that case.