### PR TITLE
MW-492 'NotFound' component to allow 404 status on server render

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ the page is refreshed/reloaded without the param in the querystring.
 http://localhost:8000/ny-tech/?__nocache
 ```
 
-### POST
+#### POST
 
 `POST` API requests are handled by `PostMiddleware`, which provides a generalized
 interface for sending data to the API and handling return values. The middleware
@@ -232,6 +232,34 @@ their return values will be `dispatch`ed by the middleware in the API success/er
 case.
 
 Use reducers to parse the response and update application state.
+
+## Client
+
+### Rendering 'empty' state with `<NotFound>`
+
+To correctly render a 'not found' state for a feature, you should render a
+`<NotFound>` component, which the server will use to set the response status to
+404.
+
+#### Example:
+
+```jsx
+import NotFound from 'meetup-web-platform/lib/components/NotFound';
+
+class GroupContainer extends React.Component {
+	render() {
+		if (!this.props.group) {
+			return (
+				<NotFound>
+					<h1>Sorry, no matching group was found</h1>
+				</NotFound>
+			);
+		}
+
+		return <GroupDetail group={this.props.group} />;
+	}
+}
+```
 
 ## Tracking
 

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "react-redux": "5.0.1",
     "react-router": "2.8.1",
     "react-router-redux": "4.0.7",
+    "react-side-effect": "1.0.2",
     "redbox-react": "1.3.3",
     "redux": "^3.5.2",
     "redux-observable": "0.12.2",

--- a/src/components/NotFound.jsx
+++ b/src/components/NotFound.jsx
@@ -4,10 +4,16 @@ import withSideEffect from 'react-side-effect';
 /**
  * Use this component as a wrapper for your 'not found' UI when the API returns
  * no data
+ *
+ * Note that only one child is allowed for this component since it does not
+ * provide any rendered output itself
  */
 class NotFound extends React.Component {
 	render() {
-		return React.Children.only(this.props.children);
+		if (this.props.children) {
+			return React.Children.only(this.props.children);
+		}
+		return null;
 	}
 }
 

--- a/src/components/NotFound.jsx
+++ b/src/components/NotFound.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import withSideEffect from 'react-side-effect';
+
+/**
+ * Use this component as a wrapper for your 'not found' UI when the API returns
+ * no data
+ */
+class NotFound extends React.Component {
+	render() {
+		return React.Children.only(this.props.children);
+	}
+}
+
+function reducePropsToState(propsList) {
+	if (!propsList.length) {
+		return;
+	}
+	return 404;
+}
+
+function handleStateChangeOnClient(code) {
+}
+
+export default withSideEffect(
+	reducePropsToState,
+	handleStateChangeOnClient
+)(NotFound);
+

--- a/src/renderers/server-render.jsx
+++ b/src/renderers/server-render.jsx
@@ -10,6 +10,7 @@ import { Provider } from 'react-redux';
 
 import { createServerStore } from '../util/createStore';
 import Dom from '../components/dom';
+import NotFound from '../components/NotFound';
 import { polyfillNodeIntl } from '../util/localizationUtils';
 
 import {
@@ -89,7 +90,9 @@ const getRouterRenderer = (store, baseUrl, clientFilename, assetPublicPath) =>
 				initialState,
 				appMarkup
 			);
-			statusCode = renderProps.routes.pop().statusCode || 200;
+			statusCode = NotFound.rewind() ||  // if NotFound is mounted, return 404
+				renderProps.routes.pop().statusCode ||
+				200;
 		} catch(e) {
 			// log the error stack here because Observable logs not great
 			console.error(e.stack);


### PR DESCRIPTION
This new component uses a similar pattern to `Helmet` because it provides side effect information to the server once the main application has been rendered. If the API has not returned valid results, consumer applications should render a `NotFound` component, which will provide a signal to the server to return a 404 status code with the HTML response.