### PR TITLE
WP 148 login from logout

### DIFF
--- a/src/actions/syncActionCreators.js
+++ b/src/actions/syncActionCreators.js
@@ -30,11 +30,3 @@ export function apiComplete() {
 	};
 }
 
-/**
- * A simple signal to indicate that the app should re-sync data with the
- * current router location. Usually used for authorization changes
- */
-export function locationSync() {
-	return { type: 'LOCATION_SYNC' };
-}
-


### PR DESCRIPTION
This PR fixes an issue where if you logged out from the login page, and then tried to log in again, you couldn't. On successful login, the `?logout=true` query string will now be cleared.