### PR TITLE
WP 157: Clear cache and app state on logout API_REQUEST

### DIFF
--- a/src/epics/sync.js
+++ b/src/epics/sync.js
@@ -32,9 +32,16 @@ export const getNavEpic = routes => {
 					referrer: currentLocation.pathname,
 					logout: 'logout' in payload.query,
 				};
-				return activeQueries$(payload)  // find the queries for the location
+
+				const apiRequestActions$ = activeQueries$(payload)  // find the queries for the location
 					.map(queries => apiRequest(queries, requestMetadata))
 					.do(() => currentLocation = payload);  // update to new location
+
+				// emit cache clear _only_ when logout requested
+				const cacheClearAction$ = requestMetadata.logout ?
+					Observable.of({ type: 'CACHE_CLEAR' }) : Observable.empty();
+
+				return Observable.merge(cacheClearAction$, apiRequestActions$);
 			});
 };
 

--- a/src/epics/sync.test.js
+++ b/src/epics/sync.test.js
@@ -41,6 +41,25 @@ describe('Sync epic', () => {
 			done
 		);
 	});
+	it('emits CACHE_CLEAR and API_REQUEST for nav-related actions with logout query', function() {
+		const logoutLocation = {
+			...MOCK_RENDERPROPS.location,
+			query: {
+				...MOCK_RENDERPROPS.query,
+				logout: true,
+			}
+		};
+		const locationChange = { type: LOCATION_CHANGE, payload: logoutLocation };
+
+		const action$ = ActionsObservable.of(locationChange);
+		return getSyncEpic(MOCK_ROUTES)(action$)
+			.toArray()
+			.toPromise()
+			.then(actions => {
+				expect(actions[0].type).toEqual('CACHE_CLEAR');
+				expect(actions[1].type).toEqual('API_REQUEST');
+			});
+	});
 	it('does not emit for nav-related actions without matched query', () => {
 		const SyncEpic = getSyncEpic(MOCK_ROUTES);
 

--- a/src/reducers/platform.js
+++ b/src/reducers/platform.js
@@ -21,6 +21,11 @@ export function app(state=DEFAULT_APP_STATE, action={}) {
 	let newState;
 
 	switch (action.type) {
+	case 'API_REQUEST':
+		if (action.meta.logout) {
+			return DEFAULT_APP_STATE;  // clear app state during logout
+		}
+		return state;
 	case 'CACHE_SUCCESS':  // fall through - same effect as API success
 	case 'API_SUCCESS':
 		// API_SUCCESS contains an array of responses, but we just need to build a single
@@ -28,9 +33,6 @@ export function app(state=DEFAULT_APP_STATE, action={}) {
 		newState = action.payload.responses.reduce((s, r) => ({ ...s, ...r }), {});
 		delete state.error;
 		return { ...state, ...newState };
-	case 'LOGOUT_REQUEST':
-		// need to clear ALL private data, i.e. all data
-		return DEFAULT_APP_STATE;
 	case 'API_ERROR':
 		return {
 			...state,

--- a/src/reducers/platform.test.js
+++ b/src/reducers/platform.test.js
@@ -11,7 +11,7 @@ describe('reducer', () => {
 	it('returns default state for empty action', () => {
 		expect(app(undefined, {})).toEqual(DEFAULT_APP_STATE);
 	});
-	it('re-sets app state on logout API_REQUEST', () => {
+	it('re-sets app state on logout API_REQUEST', function() {
 		const logoutRequest = syncActionCreators.apiRequest([], { logout: true });
 		expect(app(this.MOCK_STATE, logoutRequest)).toEqual(DEFAULT_APP_STATE);
 	});
@@ -35,8 +35,5 @@ describe('reducer', () => {
 		};
 		const errorState = app(undefined, API_ERROR);
 		expect(errorState.error).toBe(API_ERROR.payload);
-	});
-	it('app data should be cleared by a LOGOUT_REQUEST event', function() {
-		expect(app(this.MOCK_STATE, { type: 'LOGOUT_REQUEST' })).toEqual(DEFAULT_APP_STATE);
 	});
 });

--- a/src/reducers/platform.test.js
+++ b/src/reducers/platform.test.js
@@ -1,3 +1,4 @@
+import * as syncActionCreators from '../actions/syncActionCreators';
 import {
 	DEFAULT_APP_STATE,
 	app,
@@ -9,6 +10,10 @@ describe('reducer', () => {
 	});
 	it('returns default state for empty action', () => {
 		expect(app(undefined, {})).toEqual(DEFAULT_APP_STATE);
+	});
+	it('re-sets app state on logout API_REQUEST', () => {
+		const logoutRequest = syncActionCreators.apiRequest([], { logout: true });
+		expect(app(this.MOCK_STATE, logoutRequest)).toEqual(DEFAULT_APP_STATE);
 	});
 	it('assembles success responses into single state tree', () => {
 		const API_SUCCESS = {


### PR DESCRIPTION
we no longer have a dedicated 'LOGOUT_REQUEST', so this PR re-applies the state-clearing rules from LOGOUT_REQUEST to API_REQUEST when `action.meta.logout` is truthy.