### PR TITLE
WP-175 default lang should redirect to no-prefix path

### DIFF
--- a/src/util/languageUtils.js
+++ b/src/util/languageUtils.js
@@ -57,8 +57,9 @@ export const checkLanguageRedirect = (
 	const firstPathComponent = originalPath.split('/')[1];
 	const redirect = makeRedirect(reply, request.url);
 	if (requestLanguage === defaultLang) {
-		if (requestLanguage === firstPathComponent) {
-			request.log(['info'], `Redundant ${defaultLang} path prefix, redirecting`);
+		// ensure that we are serving from un-prefixed URL
+		if (supportedLangs.includes(firstPathComponent)) {
+			request.log(['info'], `Incorrect lang path prefix (${firstPathComponent}), redirecting`);
 			return redirect(originalPath.replace(`/${firstPathComponent}`, ''));
 		}
 	} else if (requestLanguage !== firstPathComponent) {

--- a/src/util/languageUtils.test.js
+++ b/src/util/languageUtils.test.js
@@ -113,6 +113,13 @@ describe('checkLanguageRedirect', () => {
 			expectedRedirect: rootUrl,
 		})
 	);
+	it('calls redirect to root path when default lang requested on incorrect language path', () =>
+		testRedirect({
+			requestLang: defaultLang,
+			requestUrl: `${rootUrl}${altLang}/`,
+			expectedRedirect: rootUrl,
+		})
+	);
 	it('calls redirect to requestLanguage path from incorrect language path', () => {
 		const requestLang = altLang;
 		supportedLangs.filter(l => l !== altLang).forEach(lang =>


### PR DESCRIPTION
The redirect function only strips `/en-US` URL prefixes when the requested language is en-US, but it should actually strip _any_ language prefix when the requested language is en-US