### PR TITLE
WP 186 server render integration test

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,14 @@
     "iron": "4.0.4",
     "jest-cli": "18.1.0",
     "meetup-web-mocks": "0.1.51",
+    "react": "^15.4.2",
+    "react-helmet": "^3.3.2",
+    "react-intl": "^2.2.3",
+    "react-redux": "^5.0.2",
+    "react-router": "^3.0.2",
     "react-addons-test-utils": "15.4.2",
+    "redux": "^3.5.2",
+    "rxjs": "^5.0.3"
     "tough-cookie": "2.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "react-router": "^3.0.2",
     "react-addons-test-utils": "15.4.2",
     "redux": "^3.5.2",
-    "rxjs": "^5.0.3"
+    "rxjs": "^5.0.3",
     "tough-cookie": "2.3.2"
   }
 }

--- a/tests/integration/render.int.js
+++ b/tests/integration/render.int.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import makeRenderer from '../../src/renderers/server-render';
 import makeRootReducer from '../../src/reducers/platform';
 
@@ -34,9 +35,13 @@ const getMockFetch = (mockResponseValue=[{}], headers={}) =>
 const clientFilename = 'client.whatever.js';
 const assetPublicPath = '//whatever';
 
+const expectedOutputMessage = 'Looking good';
+const TestRender = props => <div>{expectedOutputMessage}</div>;
+
+
 const routes = {
 	path: '/ny-tech',
-	component: 'div',
+	component: TestRender,
 	query: () => ({}),
 };
 const reducer = makeRootReducer();
@@ -77,7 +82,7 @@ describe('Full dummy app render', () => {
 					credentials: 'whatever',
 				};
 				return server.inject(request).then(
-					response => expect(true).toBe(false)
+					response => expect(response.payload).toContain(expectedOutputMessage)
 				)
 				.then(() => server.stop())
 				.catch(err => {

--- a/tests/integration/render.int.js
+++ b/tests/integration/render.int.js
@@ -32,33 +32,35 @@ const getMockFetch = (mockResponseValue=[{}], headers={}) =>
 		},
 	});
 
-const clientFilename = 'client.whatever.js';
-const assetPublicPath = '//whatever';
-
 const expectedOutputMessage = 'Looking good';
-const TestRender = props => <div>{expectedOutputMessage}</div>;
 
+const getMockRenderRequestMap = () => {
+	const clientFilename = 'client.whatever.js';
+	const assetPublicPath = '//whatever';
 
-const routes = {
-	path: '/ny-tech',
-	component: TestRender,
-	query: () => ({}),
-};
-const reducer = makeRootReducer();
+	const TestRenderComponent = props => <div>{expectedOutputMessage}</div>;
 
-const basename = '/';
+	const routes = {
+		path: '/ny-tech',
+		component: TestRenderComponent,
+		query: () => ({}),
+	};
+	const reducer = makeRootReducer();
 
-const renderRequest$ = makeRenderer(
-	routes,
-	reducer,
-	clientFilename,
-	assetPublicPath,
-	[],
-	basename
-);
+	const basename = '/';
 
-const renderRequestMap = {
-	'en-US': renderRequest$,
+	const renderRequest$ = makeRenderer(
+		routes,
+		reducer,
+		clientFilename,
+		assetPublicPath,
+		[],
+		basename
+	);
+
+	return {
+		'en-US': renderRequest$,
+	};
 };
 
 describe('Full dummy app render', () => {
@@ -74,7 +76,7 @@ describe('Full dummy app render', () => {
 	});
 	it('calls the handler for /{*wild}', () => {
 		spyOn(global, 'fetch').and.returnValue(getMockFetch());
-		return start(renderRequestMap, {}, mockConfig)
+		return start(getMockRenderRequestMap(), {}, mockConfig)
 			.then(server => {
 				const request = {
 					method: 'get',

--- a/tests/integration/render.int.js
+++ b/tests/integration/render.int.js
@@ -1,0 +1,91 @@
+import makeRenderer from '../../src/renderers/server-render';
+import makeRootReducer from '../../src/reducers/platform';
+
+import start from '../../src/server';
+
+jest.mock('request', () =>
+	jest.fn(
+		(requestOpts, cb) =>
+			setTimeout(() =>
+				cb(null, {
+					headers: {},
+					statusCode: 200,
+					elapsedTime: 234,
+					request: {
+						uri: {
+							query: 'foo=bar',
+							pathname: '/foo',
+						},
+						method: 'get',
+					},
+				}, '{}'), 234)
+	)
+);
+
+const getMockFetch = (mockResponseValue=[{}], headers={}) =>
+	Promise.resolve({
+		text: () => Promise.resolve(JSON.stringify(mockResponseValue)),
+		json: () => Promise.resolve(mockResponseValue),
+		headers: {
+			get: key => headers[key],
+		},
+	});
+
+const clientFilename = 'client.whatever.js';
+const assetPublicPath = '//whatever';
+
+const routes = {
+	path: '/ny-tech',
+	component: 'div',
+	query: () => ({}),
+};
+const reducer = makeRootReducer();
+
+const basename = '/';
+
+const renderRequest$ = makeRenderer(
+	routes,
+	reducer,
+	clientFilename,
+	assetPublicPath,
+	[],
+	basename
+);
+
+const renderRequestMap = {
+	'en-US': renderRequest$,
+};
+
+describe('Full dummy app render', () => {
+	const random32 = 'asdfasdfasdfasdfasdfasdfasdfasdf';
+	const mockConfig = () => Promise.resolve({
+		API_HOST: 'www.api.meetup.com',
+		CSRF_SECRET: random32,
+		COOKIE_ENCRYPT_SECRET: random32,
+		oauth: {
+			key: random32,
+			secret: random32,
+		}
+	});
+	it('calls the handler for /{*wild}', () => {
+		spyOn(global, 'fetch').and.returnValue(getMockFetch());
+		return start(renderRequestMap, {}, mockConfig)
+			.then(server => {
+				const request = {
+					method: 'get',
+					url: '/ny-tech',
+					credentials: 'whatever',
+				};
+				return server.inject(request).then(
+					response => expect(true).toBe(false)
+				)
+				.then(() => server.stop())
+				.catch(err => {
+					server.stop();
+					throw err;
+				});
+			});
+	});
+});
+
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -1226,6 +1226,10 @@ decamelize@^1.0.0, decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
+deep-equal@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
+
 deep-extend@~0.4.0:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.1.tgz#efe4113d08085f4e6f9687759810f807469e2253"
@@ -1545,6 +1549,10 @@ exec-sh@^0.2.0:
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.2.0.tgz#14f75de3f20d286ef933099b2ce50a90359cef10"
   dependencies:
     merge "^1.1.3"
+
+exenv@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.1.tgz#75de1c8dee02e952b102aa17f8875973e0df14f9"
 
 exit-hook@^1.0.0:
   version "1.1.1"
@@ -2520,14 +2528,14 @@ js-tokens@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.0.tgz#a2f2a969caae142fb3cd56228358c89366957bd1"
 
-js-yaml@3.6.1:
+js-yaml@3.6.1, js-yaml@^3.5.1:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.6.1.tgz#6e5fe67d8b205ce4d22fad05b7781e8dadcc4b30"
   dependencies:
     argparse "^1.0.7"
     esprima "^2.6.0"
 
-js-yaml@^3.5.1, js-yaml@^3.7.0:
+js-yaml@^3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80"
   dependencies:
@@ -2741,7 +2749,7 @@ lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
 
-lodash.keys@^3.0.0:
+lodash.keys@^3.0.0, lodash.keys@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-3.1.2.tgz#4dbc0472b156be50a0b286855d1bd0b0c656098a"
   dependencies:
@@ -3245,7 +3253,15 @@ react-dom@15.4.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
 
-react-intl@2.2.3:
+react-helmet@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-3.3.2.tgz#0d5a985aca6fba0331331fb567ca3d96681a381c"
+  dependencies:
+    deep-equal "1.0.1"
+    object-assign "^4.0.1"
+    react-side-effect "^1.1.0"
+
+react-intl@2.2.3, react-intl@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/react-intl/-/react-intl-2.2.3.tgz#8eebb03cddc38b337ed22fab78037ab53a594270"
   dependencies:
@@ -3254,7 +3270,7 @@ react-intl@2.2.3:
     intl-relativeformat "^1.3.0"
     invariant "^2.1.1"
 
-react-redux@5.0.2:
+react-redux@5.0.2, react-redux@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-5.0.2.tgz#3d9878f5f71c6fafcd45de1fbb162ea31f389814"
   dependencies:
@@ -3268,7 +3284,7 @@ react-router-redux@4.0.7:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/react-router-redux/-/react-router-redux-4.0.7.tgz#9b1fde4e70106c50f47214e12bdd888cfb96e2a6"
 
-react-router@3.0.2:
+react-router@3.0.2, react-router@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-3.0.2.tgz#5a19156678810e01d81901f9c0fef63284b8a514"
   dependencies:
@@ -3283,6 +3299,13 @@ react-side-effect@1.0.2:
   resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-1.0.2.tgz#98e354decdbf0281e4223d87852d33e345eda561"
   dependencies:
     fbjs "0.1.0-alpha.10"
+
+react-side-effect@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-1.1.0.tgz#57209f7ebc940d55e0fda82fe51422654175d609"
+  dependencies:
+    exenv "^1.2.1"
+    shallowequal "^0.2.2"
 
 react@^15.4.2:
   version "15.4.2"
@@ -3307,7 +3330,19 @@ read-pkg@^1.0.0:
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
 
-readable-stream@^2.0.0, readable-stream@^2.0.2, readable-stream@~2.0.5:
+readable-stream@^2.0.0, "readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.0.2, readable-stream@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.2.tgz#a9e6fec3c7dda85f8bb1b3ba7028604556fc825e"
+  dependencies:
+    buffer-shims "^1.0.0"
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "~1.0.0"
+    process-nextick-args "~1.0.6"
+    string_decoder "~0.10.x"
+    util-deprecate "~1.0.1"
+
+readable-stream@~2.0.5:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.0.6.tgz#8f90341e68a53ccc928788dacfcd11b36eb9b78e"
   dependencies:
@@ -3318,21 +3353,9 @@ readable-stream@^2.0.0, readable-stream@^2.0.2, readable-stream@~2.0.5:
     string_decoder "~0.10.x"
     util-deprecate "~1.0.1"
 
-"readable-stream@^2.0.0 || ^1.1.13", readable-stream@~2.1.4:
+readable-stream@~2.1.4:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.1.5.tgz#66fa8b720e1438b364681f2ad1a63c618448c9d0"
-  dependencies:
-    buffer-shims "^1.0.0"
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "~1.0.0"
-    process-nextick-args "~1.0.6"
-    string_decoder "~0.10.x"
-    util-deprecate "~1.0.1"
-
-readable-stream@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.2.tgz#a9e6fec3c7dda85f8bb1b3ba7028604556fc825e"
   dependencies:
     buffer-shims "^1.0.0"
     core-util-is "~1.0.0"
@@ -3382,7 +3405,7 @@ redux-observable@0.12.2:
   version "0.12.2"
   resolved "https://registry.yarnpkg.com/redux-observable/-/redux-observable-0.12.2.tgz#4bc1657c7eedace577e114b74ffe6f6fb2b36ccf"
 
-redux@3.6.0:
+redux@3.6.0, redux@^3.5.2:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/redux/-/redux-3.6.0.tgz#887c2b3d0b9bd86eca2be70571c27654c19e188d"
   dependencies:
@@ -3553,7 +3576,7 @@ rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
 
-rxjs@5.0.3:
+rxjs@5.0.3, rxjs@^5.0.3:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.0.3.tgz#fc8bdf464ebf938812748e4196788f392fef9754"
   dependencies:
@@ -3593,6 +3616,12 @@ set-immediate-shim@^1.0.1:
 setimmediate@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
+
+shallowequal@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-0.2.2.tgz#1e32fd5bcab6ad688a4812cb0cc04efc75c7014e"
+  dependencies:
+    lodash.keys "^3.1.2"
 
 shelljs@^0.7.5:
   version "0.7.6"


### PR DESCRIPTION
The platform repo doesn't have a full integration test that actually calls the route handler for the application - the current server integration test just makes sure a dummy handler gets called.

This PR adds an integration test with a more sophisticated app rendering handler that invokes the full server-render module (setting up a Redux store with middleware, React Router, and mocked `fetch` call), which is a more complete integration test covering the breadth of the rendering pipeline constructed by the platform