### PR TITLE
WP-188 ensure JSON-stringified tracking POST request

### DIFF
--- a/src/plugins/good-meetup-tracking.js
+++ b/src/plugins/good-meetup-tracking.js
@@ -4,18 +4,15 @@
 
 const avro = require('avsc');
 const Hoek = require('hoek');
-const querystring = require('querystring');
 const request = require('request');
 const Stream = require('stream');
 
-const doPost = process.env.NODE_ENV === 'production' &&
-	process.env.CONTINUOUS_INTEGRATION !== 'true';
-
 const internals = {
 	defaults: {
+
 		endpoint: 'http://log.analytics.mup-prod.mup.zone/log',
 		// in prod, make a `request` call, otherwise no-op
-		postData: doPost ?
+		postData: process.env.NODE_ENV === 'production' ?
 			request.post.bind(request) :
 			() => {},
 		// currently the schema is manually copied from
@@ -109,10 +106,15 @@ class GoodMeetupTracking extends Stream.Transform {
 			date: eventDate.toISOString().substr(0, 10),  // YYYY-MM-DD
 		};
 
+		const body = JSON.stringify(data);
+		const headers = {
+			'Content-Type': 'application/json',
+		};
+
 		// format data for avro
 		this._settings.postData(
 			this._settings.endpoint,
-			{ body: querystring.stringify(data) },
+			{ headers, body },
 			GoodMeetupTracking.postDataCallback
 		);
 

--- a/src/plugins/good-meetup-tracking.test.js
+++ b/src/plugins/good-meetup-tracking.test.js
@@ -1,4 +1,3 @@
-import querystring from 'querystring';
 import avro from 'avsc';
 import GoodMeetupTracking from './good-meetup-tracking';
 import Stream from 'stream';
@@ -27,9 +26,9 @@ describe('GoodMeetupTracking', () => {
 		it('logs an error when response status is not 200', () => {
 			spyOn(global.console, 'error');
 			const response = {
-				statusCode: 400,
+				statusCode: 410,
 			};
-			const body = 'Bad Request';
+			const body = 'Bad Test Request';
 			GoodMeetupTracking.postDataCallback(null, response, body);
 			expect(global.console.error).toHaveBeenCalled();
 		});
@@ -40,7 +39,6 @@ describe('GoodMeetupTracking', () => {
 	});
 	it('transforms input into base64-encoded avro buffer', () => {
 		const config = {
-			postData() {},
 			schema: avro.parse({
 				type: 'record',
 				fields: [
@@ -79,9 +77,7 @@ describe('Integration with tracking logs', () => {
 	});
 
 	it('encodes standard output from logTrack', () => {
-		const tracker = new GoodMeetupTracking({
-			postData() {},
-		});
+		const tracker = new GoodMeetupTracking();
 
 		return testTransform(
 			tracker,
@@ -114,9 +110,12 @@ describe('Integration with tracking logs', () => {
 			tracker,
 			trackInfo,
 			data => {
-				const body = querystring.stringify(data);
+				const body = JSON.stringify(data);
+				const headers = {
+					'Content-Type': 'application/json',
+				};
 				expect(config.postData)
-					.toHaveBeenCalledWith(config.endpoint, { body }, jasmine.any(Function));
+					.toHaveBeenCalledWith(config.endpoint, { headers, body }, jasmine.any(Function));
 			}
 		);
 	});


### PR DESCRIPTION
The url-encoded data was not playing nicely with the tracking endpoint, but I have confirmed that JSON-encoded data works just fine. At least, it gives a `{ "message": "success" }` response from the endpoint.