### PR TITLE
WP 189 no pretty json logs

### DIFF
--- a/src/plugins/good-meetup-tracking.js
+++ b/src/plugins/good-meetup-tracking.js
@@ -92,8 +92,11 @@ class GoodMeetupTracking extends Stream.Transform {
 	 */
 	_transform(event, enc, next) {
 		// log the data to stdout for Stackdriver
-		console.log(event.data);
 		const eventData = JSON.parse(event.data);
+		console.log(JSON.stringify({
+			type: 'Tracking event log',
+			payload: eventData,
+		}));
 
 		const record = this._settings.schema.toBuffer(eventData);
 

--- a/src/util/apiUtils.js
+++ b/src/util/apiUtils.js
@@ -190,7 +190,11 @@ export const buildRequestArgs = externalRequestOpts =>
 			break;
 		}
 
-		console.log(`External request headers: ${JSON.stringify(externalRequestOptsQuery.headers, null, 2)}`);
+		// production logs will automatically be JSON-parsed in Stackdriver
+		console.log(JSON.stringify({
+			type: 'External request headers',
+			payload: externalRequestOptsQuery.headers
+		}));
 
 		return externalRequestOptsQuery;
 	};
@@ -385,7 +389,12 @@ export const logApiResponse = appRequest => ([response, body]) => {
 			body: body.length > 256 ? `${body.substr(0, 256)}...`: body,
 		},
 	};
-	appRequest.log(['api', 'info'], JSON.stringify(responseLog, null, 2));
+
+	// production logs will automatically be JSON-parsed in Stackdriver
+	console.log(JSON.stringify({
+		type: 'REST API response JSON',
+		payload: responseLog
+	}));
 };
 
 /**

--- a/src/util/apiUtils.js
+++ b/src/util/apiUtils.js
@@ -364,7 +364,7 @@ export const makeExternalApiRequest = (request, API_TIMEOUT) => requestOpts => {
 		.map(([response, body]) => [response, body, requestOpts.jar]);
 };
 
-export const logApiResponse = appRequest => ([response, body]) => {
+export const logApiResponse = ([response, body]) => {
 	const {
 		uri: {
 			query,
@@ -456,7 +456,7 @@ export const makeApiRequest$ = (request, API_TIMEOUT, duotoneUrls) => {
 		return Rx.Observable.defer(() => {
 			request.log(['api', 'info'], `REST API request: ${requestOpts.url}`);
 			return request$(requestOpts)
-				.do(logApiResponse(request))             // this will leak private info in API response
+				.do(logApiResponse)             // this will leak private info in API response
 				.do(injectResponseCookies(request))
 				.map(parseApiResponse(requestOpts.url))  // parse into plain object
 				.catch(errorResponse$(requestOpts.url))

--- a/src/util/apiUtils.test.js
+++ b/src/util/apiUtils.test.js
@@ -376,9 +376,6 @@ describe('apiResponseDuotoneSetter', () => {
 });
 
 describe('logApiResponse', () => {
-	const MOCK_HAPI_REQUEST = {
-		log: () => {},
-	};
 	const MOCK_INCOMINGMESSAGE_GET = {
 		elapsedTime: 1234,
 		request: {
@@ -399,41 +396,47 @@ describe('logApiResponse', () => {
 		},
 	};
 	it('emits parsed request and response data for GET request', () => {
-		spyOn(MOCK_HAPI_REQUEST, 'log');
-		logApiResponse(MOCK_HAPI_REQUEST)([MOCK_INCOMINGMESSAGE_GET, 'foo']);
-		expect(MOCK_HAPI_REQUEST.log).toHaveBeenCalled();
-		const loggedObject = JSON.parse(MOCK_HAPI_REQUEST.log.calls.mostRecent().args[1]);
+		spyOn(console, 'log');
+		logApiResponse([MOCK_INCOMINGMESSAGE_GET, 'foo']);
+		expect(console.log).toHaveBeenCalled();
+		const loggedObject = JSON.parse(console.log.calls.mostRecent().args[0]);
 		expect(loggedObject).toEqual({
-			request: {
-				query: { foo: 'bar' },
-				pathname: MOCK_INCOMINGMESSAGE_GET.request.uri.pathname,
-				method: MOCK_INCOMINGMESSAGE_GET.request.method,
-			},
-			response: {
-				elapsedTime: MOCK_INCOMINGMESSAGE_GET.elapsedTime,
-				body: jasmine.any(String),
-			},
+			type: 'REST API response JSON',
+			payload: {
+				request: {
+					query: { foo: 'bar' },
+					pathname: MOCK_INCOMINGMESSAGE_GET.request.uri.pathname,
+					method: MOCK_INCOMINGMESSAGE_GET.request.method,
+				},
+				response: {
+					elapsedTime: MOCK_INCOMINGMESSAGE_GET.elapsedTime,
+					body: jasmine.any(String),
+				},
+			}
 		});
 	});
 	it('emits parsed request and response data for POST request', () => {
-		spyOn(MOCK_HAPI_REQUEST, 'log');
-		logApiResponse(MOCK_HAPI_REQUEST)([MOCK_INCOMINGMESSAGE_POST, 'foo']);
-		expect(MOCK_HAPI_REQUEST.log).toHaveBeenCalled();
-		const loggedObject = JSON.parse(MOCK_HAPI_REQUEST.log.calls.mostRecent().args[1]);
+		spyOn(console, 'log');
+		logApiResponse([MOCK_INCOMINGMESSAGE_POST, 'foo']);
+		expect(console.log).toHaveBeenCalled();
+		const loggedObject = JSON.parse(console.log.calls.mostRecent().args[0]);
 		expect(loggedObject).toEqual({
-			request: {
-				query: {},
-				pathname: MOCK_INCOMINGMESSAGE_POST.request.uri.pathname,
-				method: MOCK_INCOMINGMESSAGE_POST.request.method,
-			},
-			response: {
-				elapsedTime: MOCK_INCOMINGMESSAGE_POST.elapsedTime,
-				body: jasmine.any(String),
+			type: 'REST API response JSON',
+			payload: {
+				request: {
+					query: {},
+					pathname: MOCK_INCOMINGMESSAGE_POST.request.uri.pathname,
+					method: MOCK_INCOMINGMESSAGE_POST.request.method,
+				},
+				response: {
+					elapsedTime: MOCK_INCOMINGMESSAGE_POST.elapsedTime,
+					body: jasmine.any(String),
+				},
 			},
 		});
 	});
 	it('handles multiple querystring vals for GET request', () => {
-		spyOn(MOCK_HAPI_REQUEST, 'log');
+		spyOn(console, 'log');
 		const response = {
 			...MOCK_INCOMINGMESSAGE_GET,
 			request: {
@@ -444,30 +447,30 @@ describe('logApiResponse', () => {
 				},
 			},
 		};
-		logApiResponse(MOCK_HAPI_REQUEST)([response, 'foo']);
-		expect(MOCK_HAPI_REQUEST.log).toHaveBeenCalled();
-		const loggedObject = JSON.parse(MOCK_HAPI_REQUEST.log.calls.mostRecent().args[1]);
-		expect(loggedObject.request.query).toEqual({
+		logApiResponse([response, 'foo']);
+		expect(console.log).toHaveBeenCalled();
+		const loggedObject = JSON.parse(console.log.calls.mostRecent().args[0]);
+		expect(loggedObject.payload.request.query).toEqual({
 			foo: 'bar',
 			baz: 'boodle',
 		});
 	});
 	it('returns the full body of the response if less than 256 characters', () => {
 		const body = 'foo';
-		spyOn(MOCK_HAPI_REQUEST, 'log');
-		logApiResponse(MOCK_HAPI_REQUEST)([MOCK_INCOMINGMESSAGE_GET, body]);
-		expect(MOCK_HAPI_REQUEST.log).toHaveBeenCalled();
-		const loggedObject = JSON.parse(MOCK_HAPI_REQUEST.log.calls.mostRecent().args[1]);
-		expect(loggedObject.response.body).toEqual(body);
+		spyOn(console, 'log');
+		logApiResponse([MOCK_INCOMINGMESSAGE_GET, body]);
+		expect(console.log).toHaveBeenCalled();
+		const loggedObject = JSON.parse(console.log.calls.mostRecent().args[0]);
+		expect(loggedObject.payload.response.body).toEqual(body);
 	});
 	it('returns a truncated response body if more than 256 characters', () => {
 		const body300 = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean egestas viverra sem vel congue. Cras vitae malesuada justo. Fusce ut finibus felis, at sagittis leo. Morbi nec velit dignissim, viverra tellus at, pretium nisi. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla turpis duis.';
-		spyOn(MOCK_HAPI_REQUEST, 'log');
-		logApiResponse(MOCK_HAPI_REQUEST)([MOCK_INCOMINGMESSAGE_GET, body300]);
-		expect(MOCK_HAPI_REQUEST.log).toHaveBeenCalled();
-		const loggedObject = JSON.parse(MOCK_HAPI_REQUEST.log.calls.mostRecent().args[1]);
-		expect(loggedObject.response.body.startsWith(body300.substr(0, 256))).toBe(true);
-		expect(loggedObject.response.body.startsWith(body300)).toBe(false);
+		spyOn(console, 'log');
+		logApiResponse([MOCK_INCOMINGMESSAGE_GET, body300]);
+		expect(console.log).toHaveBeenCalled();
+		const loggedObject = JSON.parse(console.log.calls.mostRecent().args[0]);
+		expect(loggedObject.payload.response.body.startsWith(body300.substr(0, 256))).toBe(true);
+		expect(loggedObject.payload.response.body.startsWith(body300)).toBe(false);
 	});
 });
 


### PR DESCRIPTION
Stackdriver doesn't know how to collapse/roll-up/parse multi-line JSON logs, but it has some nice automatic parsing of single-line JSON, so this PR makes our current logs more Stackdriver-friendly