### PR TITLE
Mw 624 cookie error

### DIFF
--- a/src/util/apiUtils.js
+++ b/src/util/apiUtils.js
@@ -12,6 +12,7 @@ import {
 import {
 	coerceBool,
 	toCamelCase,
+	removeSurroundingQuotes
 } from './stringUtils';
 
 import {
@@ -436,7 +437,7 @@ export const injectResponseCookies = request => ([response, _, jar]) => {
 
 		request.plugins.requestAuth.reply.state(
 			cookie.key,
-			cookie.value.replace(/^"|"$/g, ''),  // remove surrounding quotes from string value
+			removeSurroundingQuotes(cookie.value),
 			cookieOptions
 		);
 	});

--- a/src/util/fetchUtils.js
+++ b/src/util/fetchUtils.js
@@ -1,4 +1,5 @@
 import cookie from 'cookie';
+import { removeSurroundingQuotes } from './stringUtils';
 /**
  * A module for middleware that would like to make external calls through `fetch`
  * @module fetchUtils
@@ -83,7 +84,9 @@ export const tryJSON = reqUrl => response => {
 export const mergeCookies = (rawCookieHeader, newCookies) => {
 	// request.state has _parsed_ cookies, but we need to send raw cookies
 	// _except_ when the incoming request has been back-populated with new 'raw' cookies
-	const oldCookies = cookie.parse(rawCookieHeader.replace(/'/gi,''));
+	const oldCookies = cookie.parse(
+		removeSurroundingQuotes(rawCookieHeader)
+	);
 	const mergedCookies = {
 		...oldCookies,
 		...newCookies,

--- a/src/util/fetchUtils.js
+++ b/src/util/fetchUtils.js
@@ -83,7 +83,7 @@ export const tryJSON = reqUrl => response => {
 export const mergeCookies = (rawCookieHeader, newCookies) => {
 	// request.state has _parsed_ cookies, but we need to send raw cookies
 	// _except_ when the incoming request has been back-populated with new 'raw' cookies
-	const oldCookies = cookie.parse(rawCookieHeader);
+	const oldCookies = cookie.parse(rawCookieHeader.replace(/'/gi,''));
 	const mergedCookies = {
 		...oldCookies,
 		...newCookies,

--- a/src/util/fetchUtils.test.js
+++ b/src/util/fetchUtils.test.js
@@ -178,9 +178,5 @@ describe('mergeCookies', () => {
 		expect(fetchUtils.mergeCookies('foo=meetup', { foo: 'foo', bar: 'bar' }))
 			.toEqual('foo=foo; bar=bar');
 	});
-	it('strips single quotes from raw cookie headers', () => {
-		expect(fetchUtils.mergeCookies("'bing=bong; foo=bar'", {}))
-			.toEqual('bing=bong; foo=bar');
-	});
 });
 

--- a/src/util/fetchUtils.test.js
+++ b/src/util/fetchUtils.test.js
@@ -178,5 +178,9 @@ describe('mergeCookies', () => {
 		expect(fetchUtils.mergeCookies('foo=meetup', { foo: 'foo', bar: 'bar' }))
 			.toEqual('foo=foo; bar=bar');
 	});
+	it('strips single quotes from raw cookie headers', () => {
+		expect(fetchUtils.mergeCookies("'bing=bong; foo=bar'", {}))
+			.toEqual('bing=bong; foo=bar');
+	});
 });
 

--- a/src/util/stringUtils.js
+++ b/src/util/stringUtils.js
@@ -17,3 +17,10 @@ export function toCamelCase(s) {
 	return s.replace(/-(\w)/g, g => g[1].toUpperCase());
 }
 
+/*
+ * Remove surrounding quotes from a string (' and ").
+ */
+export function removeSurroundingQuotes(str) {
+	return str.replace(/^["|']|["|']$/g, '')
+}
+

--- a/src/util/stringUtils.test.js
+++ b/src/util/stringUtils.test.js
@@ -1,6 +1,7 @@
 import {
 	coerceBool,
 	toCamelCase,
+	removeSurroundingQuotes,
 } from './stringUtils';
 
 describe('coerceBool', () => {
@@ -25,5 +26,16 @@ describe('toCamelCase', () => {
 		expect(toCamelCase('request-id')).toEqual('requestId');
 		expect(toCamelCase('')).toEqual('');
 		expect(toCamelCase('this-is-compLICAT-ED')).toEqual('thisIsCompLICATED');
+	});
+});
+describe('removeSurroundingQuotes', () => {
+	const singleQuotedString = `'single "quotes" have more fun'`;
+	const doubleQuotedString = `"double quotes are 'better' than one"`;
+
+	it('Removes surrounding single quotes', () => {
+		expect(removeSurroundingQuotes(singleQuotedString)).toEqual(`single "quotes" have more fun`);
+	});
+	it('Removes surrounding double quotes', () => {
+		expect(removeSurroundingQuotes(doubleQuotedString)).toEqual(`double quotes are 'better' than one`);
 	});
 });


### PR DESCRIPTION
So, turns out that the single quotes around the cookie headers coming from classic meetup were the problem.

We were stripping out double quotes when sending them back, but now we're stripping both in both places, so I put something in stringUtils for that.