### PR TITLE
stringify urlsearchparams body and update tests

### DIFF
--- a/src/util/fetchUtils.js
+++ b/src/util/fetchUtils.js
@@ -47,7 +47,7 @@ export const fetchQueries = (apiUrl, options) => (queries, meta) => {
 	};
 	if (isPost) {
 		// assume client side
-		fetchConfig.body = params;
+		fetchConfig.body = params.toString();
 	}
 	return fetch(
 		fetchUrl,

--- a/src/util/fetchUtils.test.js
+++ b/src/util/fetchUtils.test.js
@@ -104,8 +104,8 @@ describe('fetchQueries', () => {
 					const options = calledWith[1];
 					expect(url.toString()).toBe(API_URL.toString());
 					expect(options.method).toEqual('POST');
-					expect(options.body.has('queries')).toBe(true);
-					expect(options.body.has('metadata')).toBe(true);
+					expect(new URLSearchParams(options.body).has('queries')).toBe(true);
+					expect(new URLSearchParams(options.body).has('metadata')).toBe(true);
 					expect(options.headers['x-csrf-jwt']).toEqual(csrfJwt);
 				});
 		});
@@ -122,8 +122,8 @@ describe('fetchQueries', () => {
 					const options = calledWith[1];
 					expect(url.toString()).toBe(API_URL.toString());
 					expect(options.method).toEqual('POST');
-					expect(options.body.has('queries')).toBe(true);
-					expect(options.body.has('metadata')).toBe(false);
+					expect(new URLSearchParams(options.body).has('queries')).toBe(true);
+					expect(new URLSearchParams(options.body).has('metadata')).toBe(false);
 					expect(options.headers['x-csrf-jwt']).toEqual(csrfJwt);
 				});
 		});


### PR DESCRIPTION
polyfill.io doesn't automatically stringify URLSearchParams the way native chrome and node-fetch do.