### PR TITLE
MW 622 hanging integration

### DIFF
--- a/tests/integration/api.int.js
+++ b/tests/integration/api.int.js
@@ -4,11 +4,12 @@ import * as apiProxyHandler from '../../src/apiProxy/apiProxyHandler';
 jest.mock('request', () => {
 	const mock = jest.fn(
 		(requestOpts, cb) =>
-			setTimeout(() =>
+			setTimeout(() => {
+				console.log('calling callback');
 				cb(null, {
 					headers: {},
 					statusCode: 200,
-					elapsedTime: 234,
+					elapsedTime: 2,
 					request: {
 						uri: {
 							query: 'foo=bar',
@@ -16,7 +17,8 @@ jest.mock('request', () => {
 						},
 						method: 'get',
 					},
-				}, '{}'), 234)
+				}, '{}');
+			}, 2)
 	);
 	mock.post = jest.fn();
 	return mock;
@@ -26,6 +28,7 @@ describe('API proxy endpoint integration tests', () => {
 	const random32 = 'asdfasdfasdfasdfasdfasdfasdfasdf';
 	const mockConfig = () => Promise.resolve({
 		API_HOST: 'www.api.meetup.com',
+		API_TIMEOUT: 10,
 		CSRF_SECRET: random32,
 		COOKIE_ENCRYPT_SECRET: random32,
 		oauth: {
@@ -53,15 +56,7 @@ describe('API proxy endpoint integration tests', () => {
 				.then(() => server.stop());
 			});
 	});
-	it.only('returns a formatted array of responses from GET /mu_api', () => {
-
-
-
-		// THE API_TIMEOUT IS BEING INVOKED - RESPONSE IS NOT BEING DELIVERED AS EXPECTED
-
-
-
-
+	it('returns a formatted array of responses from GET /mu_api', () => {
 		const expectedResponse = JSON.stringify({
 			responses: [{
 				foo: {

--- a/tests/integration/api.int.js
+++ b/tests/integration/api.int.js
@@ -53,7 +53,15 @@ describe('API proxy endpoint integration tests', () => {
 				.then(() => server.stop());
 			});
 	});
-	it('returns a formatted array of responses from GET /mu_api', () => {
+	it.only('returns a formatted array of responses from GET /mu_api', () => {
+
+
+
+		// THE API_TIMEOUT IS BEING INVOKED - RESPONSE IS NOT BEING DELIVERED AS EXPECTED
+
+
+
+
 		const expectedResponse = JSON.stringify({
 			responses: [{
 				foo: {

--- a/tests/integration/api.int.js
+++ b/tests/integration/api.int.js
@@ -1,4 +1,7 @@
 import start from '../../src/server';
+import {
+	mockConfig,
+} from '../mocks';
 import * as apiProxyHandler from '../../src/apiProxy/apiProxyHandler';
 
 jest.mock('request', () => {
@@ -25,19 +28,6 @@ jest.mock('request', () => {
 });
 
 describe('API proxy endpoint integration tests', () => {
-	const random32 = 'asdfasdfasdfasdfasdfasdfasdfasdf';
-	const mockConfig = () => Promise.resolve({
-		API_HOST: 'www.api.meetup.com',
-		API_TIMEOUT: 10,
-		OAUTH_ACCESS_URL: 'http://example.com/access',
-		OAUTH_AUTH_URL: 'http://example.com/auth',
-		CSRF_SECRET: random32,
-		COOKIE_ENCRYPT_SECRET: random32,
-		oauth: {
-			key: random32,
-			secret: random32,
-		}
-	});
 	it('calls the GET handler for /mu_api', () => {
 		const spyable = {
 			handler: (request, reply) => reply('okay'),

--- a/tests/integration/api.post.int.js
+++ b/tests/integration/api.post.int.js
@@ -1,6 +1,10 @@
 import Boom from 'boom';
 import csrf from 'electrode-csrf-jwt/lib/csrf';
 import uuid from 'uuid';
+
+import {
+	mockConfig,
+} from '../mocks';
 import start from '../../src/server';
 import * as apiProxyHandler from '../../src/apiProxy/apiProxyHandler';
 
@@ -29,10 +33,9 @@ const mockPostPayload = {
 	queries: JSON.stringify([mockQuery])
 };
 
-const random32 = 'asdfasdfasdfasdfasdfasdfasdfasdf';
 function getCsrfHeaders() {
 	const options = {
-		secret: random32,
+		secret:  'asdfasdfasdfasdfasdfasdfasdfasdf',
 	};
 	const id = uuid.v4();
 	const headerPayload = {type: 'header', uuid: id};
@@ -69,18 +72,6 @@ const runTest = (test, payload=mockPostPayload, csrfHeaders=getCsrfHeaders) => s
 
 
 describe('API proxy POST endpoint integration tests', () => {
-	const mockConfig = () => Promise.resolve({
-		API_HOST: 'www.api.meetup.com',
-		API_TIMEOUT: 10,
-		OAUTH_ACCESS_URL: 'http://example.com/access',
-		OAUTH_AUTH_URL: 'http://example.com/auth',
-		CSRF_SECRET: random32,
-		COOKIE_ENCRYPT_SECRET: random32,
-		oauth: {
-			key: random32,
-			secret: random32,
-		}
-	});
 	it('calls the POST handler for /mu_api', () => {
 		const spyable = {
 			handler: (request, reply) => reply('okay'),

--- a/tests/integration/api.post.int.js
+++ b/tests/integration/api.post.int.js
@@ -1,8 +1,6 @@
 import Boom from 'boom';
-import csrf from 'electrode-csrf-jwt/lib/csrf';
-import uuid from 'uuid';
-
 import {
+	getCsrfHeaders,
 	mockConfig,
 } from '../mocks';
 import start from '../../src/server';
@@ -33,20 +31,6 @@ const mockPostPayload = {
 	queries: JSON.stringify([mockQuery])
 };
 
-function getCsrfHeaders() {
-	const options = {
-		secret:  'asdfasdfasdfasdfasdfasdfasdfasdf',
-	};
-	const id = uuid.v4();
-	const headerPayload = {type: 'header', uuid: id};
-	const cookiePayload = {type: 'cookie', uuid: id};
-
-	return csrf.create(headerPayload, options)
-		.then(headerToken => {
-			return csrf.create(cookiePayload, options)
-				.then(cookieToken => ([headerToken, cookieToken]));
-		});
-}
 const runTest = (test, payload=mockPostPayload, csrfHeaders=getCsrfHeaders) => server =>
 	csrfHeaders()
 		.then(([headerToken, cookieToken]) => {

--- a/tests/integration/api.post.int.js
+++ b/tests/integration/api.post.int.js
@@ -11,14 +11,14 @@ jest.mock('request', () => {
 				cb(null, {
 					headers: {},
 					statusCode: 200,
-					elapsedTime: 234,
+					elapsedTime: 2,
 					request: {
 						uri: {
 							pathname: '/foo',
 						},
 						method: 'post',
 					},
-				}, '{}'), 234)
+				}, '{}'), 2)
 	);
 	mock.post = jest.fn();
 	return mock;
@@ -71,6 +71,7 @@ const runTest = (test, payload=mockPostPayload, csrfHeaders=getCsrfHeaders) => s
 describe('API proxy POST endpoint integration tests', () => {
 	const mockConfig = () => Promise.resolve({
 		API_HOST: 'www.api.meetup.com',
+		API_TIMEOUT: 10,
 		CSRF_SECRET: random32,
 		COOKIE_ENCRYPT_SECRET: random32,
 		oauth: {

--- a/tests/integration/render.int.js
+++ b/tests/integration/render.int.js
@@ -11,7 +11,7 @@ jest.mock('request', () =>
 				cb(null, {
 					headers: {},
 					statusCode: 200,
-					elapsedTime: 234,
+					elapsedTime: 2,
 					request: {
 						uri: {
 							query: 'foo=bar',
@@ -19,7 +19,7 @@ jest.mock('request', () =>
 						},
 						method: 'get',
 					},
-				}, '{}'), 234)
+				}, '{}'), 2)
 	)
 );
 
@@ -67,6 +67,7 @@ describe('Full dummy app render', () => {
 	const random32 = 'asdfasdfasdfasdfasdfasdfasdfasdf';
 	const mockConfig = () => Promise.resolve({
 		API_HOST: 'www.api.meetup.com',
+		API_TIMEOUT: 10,
 		CSRF_SECRET: random32,
 		COOKIE_ENCRYPT_SECRET: random32,
 		oauth: {

--- a/tests/integration/render.int.js
+++ b/tests/integration/render.int.js
@@ -1,3 +1,4 @@
+import { mockConfig } from '../mocks';
 import React from 'react';
 import makeRenderer from '../../src/renderers/server-render';
 import makeRootReducer from '../../src/reducers/platform';
@@ -64,19 +65,6 @@ const getMockRenderRequestMap = () => {
 };
 
 describe('Full dummy app render', () => {
-	const random32 = 'asdfasdfasdfasdfasdfasdfasdfasdf';
-	const mockConfig = () => Promise.resolve({
-		API_HOST: 'www.api.meetup.com',
-		API_TIMEOUT: 10,
-		OAUTH_ACCESS_URL: 'http://example.com/access',
-		OAUTH_AUTH_URL: 'http://example.com/auth',
-		CSRF_SECRET: random32,
-		COOKIE_ENCRYPT_SECRET: random32,
-		oauth: {
-			key: random32,
-			secret: random32,
-		}
-	});
 	it('calls the handler for /{*wild}', () => {
 		spyOn(global, 'fetch').and.returnValue(getMockFetch());
 		return start(getMockRenderRequestMap(), {}, mockConfig)

--- a/tests/integration/render.int.js
+++ b/tests/integration/render.int.js
@@ -1,8 +1,8 @@
-import { mockConfig } from '../mocks';
-import React from 'react';
-import makeRenderer from '../../src/renderers/server-render';
-import makeRootReducer from '../../src/reducers/platform';
-
+import {
+	getMockFetch,
+	getMockRenderRequestMap,
+	mockConfig,
+} from '../mocks';
 import start from '../../src/server';
 
 jest.mock('request', () =>
@@ -24,45 +24,7 @@ jest.mock('request', () =>
 	)
 );
 
-const getMockFetch = (mockResponseValue=[{}], headers={}) =>
-	Promise.resolve({
-		text: () => Promise.resolve(JSON.stringify(mockResponseValue)),
-		json: () => Promise.resolve(mockResponseValue),
-		headers: {
-			get: key => headers[key],
-		},
-	});
-
 const expectedOutputMessage = 'Looking good';
-
-const getMockRenderRequestMap = () => {
-	const clientFilename = 'client.whatever.js';
-	const assetPublicPath = '//whatever';
-
-	const TestRenderComponent = props => <div>{expectedOutputMessage}</div>;
-
-	const routes = {
-		path: '/ny-tech',
-		component: TestRenderComponent,
-		query: () => ({}),
-	};
-	const reducer = makeRootReducer();
-
-	const basename = '/';
-
-	const renderRequest$ = makeRenderer(
-		routes,
-		reducer,
-		clientFilename,
-		assetPublicPath,
-		[],
-		basename
-	);
-
-	return {
-		'en-US': renderRequest$,
-	};
-};
 
 describe('Full dummy app render', () => {
 	it('calls the handler for /{*wild}', () => {

--- a/tests/integration/requestAuthPlugin.int.js
+++ b/tests/integration/requestAuthPlugin.int.js
@@ -19,6 +19,7 @@ const makeMockFetchResponse = responseObj => Promise.resolve({
 const random32 = 'asdfasdfasdfasdfasdfasdfasdfasdf';
 const options = {
 	API_HOST: 'www.api.meetup.com',
+	API_TIMEOUT: 10,
 	CSRF_SECRET: random32,
 	COOKIE_ENCRYPT_SECRET: random32,
 	OAUTH_AUTH_URL: 'https://secure.dev.meetup.com/oauth2/authorize',

--- a/tests/integration/server.int.js
+++ b/tests/integration/server.int.js
@@ -1,19 +1,8 @@
+import { mockConfig } from '../mocks';
 import start from '../../src/server';
 import * as appRouteHandler from '../../src/routes/appRouteHandler';
 
 describe('General server startup tests', () => {
-	const random32 = 'asdfasdfasdfasdfasdfasdfasdfasdf';
-	const mockConfig = () => Promise.resolve({
-		API_HOST: 'www.api.meetup.com',
-		OAUTH_ACCESS_URL: 'http://example.com/access',
-		OAUTH_AUTH_URL: 'http://example.com/auth',
-		CSRF_SECRET: random32,
-		COOKIE_ENCRYPT_SECRET: random32,
-		oauth: {
-			key: random32,
-			secret: random32,
-		}
-	});
 	it('starts the server', () => {
 		const fooRoute = {
 			method: 'get',

--- a/tests/mocks.js
+++ b/tests/mocks.js
@@ -1,3 +1,10 @@
+import csrf from 'electrode-csrf-jwt/lib/csrf';
+import React from 'react';
+import uuid from 'uuid';
+
+import makeRenderer from '../src/renderers/server-render';
+import makeRootReducer from '../src/reducers/platform';
+
 const random32 = 'asdfasdfasdfasdfasdfasdfasdfasdf';
 export const mockConfig = () => Promise.resolve({
 	API_HOST: 'www.api.meetup.com',
@@ -11,4 +18,59 @@ export const mockConfig = () => Promise.resolve({
 		secret: random32,
 	}
 });
+
+export const getMockFetch = (mockResponseValue=[{}], headers={}) =>
+	Promise.resolve({
+		text: () => Promise.resolve(JSON.stringify(mockResponseValue)),
+		json: () => Promise.resolve(mockResponseValue),
+		headers: {
+			get: key => headers[key],
+		},
+	});
+
+export function getCsrfHeaders() {
+	const options = {
+		secret:  'asdfasdfasdfasdfasdfasdfasdfasdf',
+	};
+	const id = uuid.v4();
+	const headerPayload = {type: 'header', uuid: id};
+	const cookiePayload = {type: 'cookie', uuid: id};
+
+	return csrf.create(headerPayload, options)
+		.then(headerToken => {
+			return csrf.create(cookiePayload, options)
+				.then(cookieToken => ([headerToken, cookieToken]));
+		});
+}
+
+const expectedOutputMessage = 'Looking good';
+export const getMockRenderRequestMap = () => {
+	const clientFilename = 'client.whatever.js';
+	const assetPublicPath = '//whatever';
+
+	const TestRenderComponent = props => <div>{expectedOutputMessage}</div>;
+
+	const routes = {
+		path: '/ny-tech',
+		component: TestRenderComponent,
+		query: () => ({}),
+	};
+	const reducer = makeRootReducer();
+
+	const basename = '/';
+
+	const renderRequest$ = makeRenderer(
+		routes,
+		reducer,
+		clientFilename,
+		assetPublicPath,
+		[],
+		basename
+	);
+
+	return {
+		'en-US': renderRequest$,
+	};
+};
+
 

--- a/tests/mocks.js
+++ b/tests/mocks.js
@@ -1,0 +1,14 @@
+const random32 = 'asdfasdfasdfasdfasdfasdfasdfasdf';
+export const mockConfig = () => Promise.resolve({
+	API_HOST: 'www.api.meetup.com',
+	API_TIMEOUT: 10,
+	OAUTH_ACCESS_URL: 'http://example.com/access',
+	OAUTH_AUTH_URL: 'http://example.com/auth',
+	CSRF_SECRET: random32,
+	COOKIE_ENCRYPT_SECRET: random32,
+	oauth: {
+		key: random32,
+		secret: random32,
+	}
+});
+


### PR DESCRIPTION
Complete discussion is in the Jira ticket: https://meetup.atlassian.net/browse/MW-622

tl;dr: the RxJS `.timeout` operator doesn't cancel the internal `setTimeout` when the associated observable completes, so Jest won't exit until the `API_TIMEOUT` is reached for each test that touches `.timeout`

This is an RxJS issue, but we can speed things up by setting a shorter API_TIMEOUT interval until this PR merges: https://github.com/ReactiveX/rxjs/pull/2135