### PR TITLE
WP-178 Refresh login page on LOGIN_SUCCESS

### DIFF
--- a/src/epics/sync.js
+++ b/src/epics/sync.js
@@ -57,16 +57,19 @@ export const getNavEpic = routes => {
  */
 export const locationSyncEpic = (action$, store) =>
 	action$.ofType('LOGIN_SUCCESS')
-		.do(() => {
+		.map(() => {
 			const location = {
 				...store.getState().routing.locationBeforeTransitions
 			};
 			delete location.query.logout;
+			return location;
+		})
+		.do(location => {
 			useBasename(() => browserHistory)({
 				basename: location.basename
-			}).replace(location);  // this will trigger a LOCATION_CHANGE
+			}).replace(location);  // this will not trigger a LOCATION_CHANGE
 		})
-		.ignoreElements();
+		.map(location => ({ type: LOCATION_CHANGE, payload: location }));
 
 /**
  * Listen for actions that provide queries to send to the api - mainly

--- a/src/plugins/requestAuthPlugin.js
+++ b/src/plugins/requestAuthPlugin.js
@@ -31,14 +31,14 @@ function verifyAuth(auth) {
 const handleLogout = request => {
 	request.log(['info', 'auth'], 'Logout received, clearing cookies to re-authenticate');
 	return removeAuthState(
-		[getMemberCookieName(request), 'oauth_token', 'refresh_token'],
+		[getMemberCookieName(request.server), 'oauth_token', 'refresh_token'],
 		request,
 		request.plugins.requestAuth.reply
 	);
 };
 
 function getAuthType(request) {
-	const memberCookie = getMemberCookieName(request);
+	const memberCookie = getMemberCookieName(request.server);
 	const allowedAuthTypes = [memberCookie, 'oauth_token', '__internal_oauth_token'];
 	// search for a request.state cookie name that matches an allowed auth type
 	return allowedAuthTypes.reduce(

--- a/src/plugins/requestAuthPlugin.test.js
+++ b/src/plugins/requestAuthPlugin.test.js
@@ -20,6 +20,7 @@ const MOCK_SERVER = {
 	},
 	ext: () => {},
 	state: () => {},
+	app: {}
 };
 const MOCK_HEADERS = {};
 const MOCK_REPLY_FN = () => {};

--- a/src/util/authUtils.js
+++ b/src/util/authUtils.js
@@ -69,21 +69,26 @@ export function validateSecret(secret) {
 	return value;
 }
 
+export const getMemberCookieName = server =>
+	server.app.isDevConfig ? 'MEETUP_MEMBER_DEV' : 'MEETUP_MEMBER';
+
 /**
  * apply default cookie options for auth-related cookies
  */
 export const configureAuthCookies = (server, options) => {
 	const password = validateSecret(options.COOKIE_ENCRYPT_SECRET);
+	const isSecure = process.env.NODE_ENV === 'production';
 	const authCookieOptions = {
 		encoding: 'iron',
 		password,
-		isSecure: process.env.NODE_ENV === 'production',
+		isSecure,
 		path: '/',
 		isHttpOnly: true,
 		clearInvalid: true,
 	};
 	server.state('oauth_token', authCookieOptions);
 	server.state('refresh_token', authCookieOptions);
+	server.state(getMemberCookieName(server), { isSecure, isHttpOnly: true });
 };
 
 export const setPluginState = (request, reply) => {
@@ -94,7 +99,4 @@ export const setPluginState = (request, reply) => {
 
 	return reply.continue();
 };
-
-export const getMemberCookieName = request =>
-	request.server.app.isDevConfig ? 'MEETUP_MEMBER_DEV' : 'MEETUP_MEMBER';
 

--- a/src/util/authUtils.test.js
+++ b/src/util/authUtils.test.js
@@ -10,6 +10,7 @@ import {
 describe('configureAuthCookies', () => {
 	const serverWithState = {
 		state: () => {},
+		app: {},
 	};
 	it('calls server.state for each auth cookie name', () => {
 		const goodOptions = {


### PR DESCRIPTION
It appears that react-router-redux does not pick up programmatic navigation using `browserHistory.replace`, so the sync epic needs to manually emit a LOCATION_CHANGE action with the current location in order for the corresponding API_REQUEST + data refresh to occur.

This PR fixes that issue, but in working on it I also discovered that login doesn't appear to be working - the REST API may not be returning a valid MEETUP_MEMBER cookie any more, but I'm unsure why. Investigation/Defect ticket filed here: https://meetup.atlassian.net/browse/WP-215 (it might just be an environment issue)