### PR TITLE
WP 215 incorrect member cookie

### DIFF
--- a/src/apiProxy/apiProxyRoutes.js
+++ b/src/apiProxy/apiProxyRoutes.js
@@ -49,6 +49,9 @@ const getApiProxyRoutes = (path, env, apiProxyFn$) => {
 					},
 				},
 			},
+			state: {
+				failAction: 'ignore',  // ignore cookie validation, just accept
+			},
 		},
 	};
 	const apiGetRoute = {

--- a/src/util/apiUtils.js
+++ b/src/util/apiUtils.js
@@ -426,9 +426,6 @@ export const injectResponseCookies = request => ([response, _, jar]) => {
 	}
 	const requestUrl = response.toJSON().request.uri.href;
 	jar.getCookies(requestUrl).forEach(cookie => {
-
-		console.warn('setting cookie\n\n', cookie.key, JSON.stringify(cookie.value));
-
 		const cookieOptions = {
 			domain: cookie.domain,
 			path: cookie.path,

--- a/src/util/apiUtils.js
+++ b/src/util/apiUtils.js
@@ -12,7 +12,7 @@ import {
 import {
 	coerceBool,
 	toCamelCase,
-	cleanRawCookies
+	removeSurroundingQuotes
 } from './stringUtils';
 
 import {
@@ -437,7 +437,7 @@ export const injectResponseCookies = request => ([response, _, jar]) => {
 
 		request.plugins.requestAuth.reply.state(
 			cookie.key,
-			cleanRawCookies(cookie.value),
+			removeSurroundingQuotes(cookie.value),
 			cookieOptions
 		);
 	});

--- a/src/util/apiUtils.js
+++ b/src/util/apiUtils.js
@@ -12,7 +12,6 @@ import {
 import {
 	coerceBool,
 	toCamelCase,
-	removeSurroundingQuotes
 } from './stringUtils';
 
 import {
@@ -427,17 +426,21 @@ export const injectResponseCookies = request => ([response, _, jar]) => {
 	}
 	const requestUrl = response.toJSON().request.uri.href;
 	jar.getCookies(requestUrl).forEach(cookie => {
+
+		console.warn('setting cookie\n\n', cookie.key, JSON.stringify(cookie.value));
+
 		const cookieOptions = {
 			domain: cookie.domain,
 			path: cookie.path,
 			isHttpOnly: cookie.httpOnly,
 			isSameSite: false,
 			isSecure: process.env.NODE_ENV === 'production',
+			strictHeader: false,  // Can't enforce RFC 6265 cookie validation on external services
 		};
 
 		request.plugins.requestAuth.reply.state(
 			cookie.key,
-			removeSurroundingQuotes(cookie.value),
+			cookie.value,
 			cookieOptions
 		);
 	});

--- a/src/util/fetchUtils.js
+++ b/src/util/fetchUtils.js
@@ -1,5 +1,4 @@
 import cookie from 'cookie';
-import { removeSurroundingQuotes } from './stringUtils';
 /**
  * A module for middleware that would like to make external calls through `fetch`
  * @module fetchUtils
@@ -84,9 +83,7 @@ export const tryJSON = reqUrl => response => {
 export const mergeCookies = (rawCookieHeader, newCookies) => {
 	// request.state has _parsed_ cookies, but we need to send raw cookies
 	// _except_ when the incoming request has been back-populated with new 'raw' cookies
-	const oldCookies = cookie.parse(
-		removeSurroundingQuotes(rawCookieHeader)
-	);
+	const oldCookies = cookie.parse(rawCookieHeader);
 	const mergedCookies = {
 		...oldCookies,
 		...newCookies,

--- a/src/util/fetchUtils.js
+++ b/src/util/fetchUtils.js
@@ -1,5 +1,5 @@
 import cookie from 'cookie';
-import { cleanRawCookies } from './stringUtils';
+import { removeSurroundingQuotes } from './stringUtils';
 /**
  * A module for middleware that would like to make external calls through `fetch`
  * @module fetchUtils
@@ -85,7 +85,7 @@ export const mergeCookies = (rawCookieHeader, newCookies) => {
 	// request.state has _parsed_ cookies, but we need to send raw cookies
 	// _except_ when the incoming request has been back-populated with new 'raw' cookies
 	const oldCookies = cookie.parse(
-		cleanRawCookies(rawCookieHeader)
+		removeSurroundingQuotes(rawCookieHeader)
 	);
 	const mergedCookies = {
 		...oldCookies,

--- a/src/util/stringUtils.js
+++ b/src/util/stringUtils.js
@@ -17,10 +17,3 @@ export function toCamelCase(s) {
 	return s.replace(/-(\w)/g, g => g[1].toUpperCase());
 }
 
-/*
- * Remove surrounding quotes from a string (' and ").
- */
-export function removeSurroundingQuotes(str) {
-	return str.replace(/^["|']|["|']$/g, '')
-}
-

--- a/src/util/stringUtils.js
+++ b/src/util/stringUtils.js
@@ -17,22 +17,10 @@ export function toCamelCase(s) {
 	return s.replace(/-(\w)/g, g => g[1].toUpperCase());
 }
 
-/**
- *
- * It appears that sometimes we add some data that shouldn't be in cookies.
- * This removes surrounding quotes, URI encodes, and then unescapes the cookie
- * separator.
- *
- * @param {String} rawCookies A cookie header from the browser
- * @return {String} Properly esacaped and formatted cookies
+/*
+ * Remove surrounding quotes from a string (' and ").
  */
-
-export function cleanRawCookies(rawCookies) {
-	return encodeURI(
-		rawCookies
-	)
-	.replace(/^[']|[']$/g, '') //replace surrounding single quotes
-	.replace(/;%20/g, '; ') //Make sure we unencode the actual cookie separator
+export function removeSurroundingQuotes(str) {
+	return str.replace(/^["|']|["|']$/g, '')
 }
-
 

--- a/src/util/stringUtils.test.js
+++ b/src/util/stringUtils.test.js
@@ -1,7 +1,6 @@
 import {
 	coerceBool,
 	toCamelCase,
-	removeSurroundingQuotes,
 } from './stringUtils';
 
 describe('coerceBool', () => {
@@ -28,14 +27,4 @@ describe('toCamelCase', () => {
 		expect(toCamelCase('this-is-compLICAT-ED')).toEqual('thisIsCompLICATED');
 	});
 });
-describe('removeSurroundingQuotes', () => {
-	const singleQuotedString = `'single "quotes" have more fun'`;
-	const doubleQuotedString = `"double quotes are 'better' than one"`;
 
-	it('Removes surrounding single quotes', () => {
-		expect(removeSurroundingQuotes(singleQuotedString)).toEqual(`single "quotes" have more fun`);
-	});
-	it('Removes surrounding double quotes', () => {
-		expect(removeSurroundingQuotes(doubleQuotedString)).toEqual(`double quotes are 'better' than one`);
-	});
-});

--- a/src/util/stringUtils.test.js
+++ b/src/util/stringUtils.test.js
@@ -1,7 +1,7 @@
 import {
 	coerceBool,
 	toCamelCase,
-	cleanRawCookies,
+	removeSurroundingQuotes,
 } from './stringUtils';
 
 describe('coerceBool', () => {
@@ -28,15 +28,14 @@ describe('toCamelCase', () => {
 		expect(toCamelCase('this-is-compLICAT-ED')).toEqual('thisIsCompLICATED');
 	});
 });
-describe('cleanRawCookies', () => {
+describe('removeSurroundingQuotes', () => {
 	const singleQuotedString = `'single "quotes" have more fun'`;
-	const cookieSeparatorString = `foo=bar; baz="something with spaces"`;
-
+	const doubleQuotedString = `"double quotes are 'better' than one"`;
 
 	it('Removes surrounding single quotes', () => {
-		expect(cleanRawCookies(singleQuotedString)).toEqual(`single%20%22quotes%22%20have%20more%20fun`);
+		expect(removeSurroundingQuotes(singleQuotedString)).toEqual(`single "quotes" have more fun`);
 	});
-	it('Doesn\'t encode the cookie separator', () => {
-		expect(cleanRawCookies(cookieSeparatorString)).toEqual(`foo=bar; baz=%22something%20with%20spaces%22`);
+	it('Removes surrounding double quotes', () => {
+		expect(removeSurroundingQuotes(doubleQuotedString)).toEqual(`double quotes are 'better' than one`);
 	});
 });

--- a/src/util/tracking.js
+++ b/src/util/tracking.js
@@ -10,7 +10,7 @@ const COOKIE_OPTS = {
 	isSecure: isProd,
 };
 
-export const MEMBER_ID_COOKIE = isProd ? 'MEETUP_MEMBER' : 'MEETUP_MEMBER_DEV';
+export const MEMBER_ID_COOKIE = isProd ? 'MEETUP_MEMBER_ID' : 'MEETUP_MEMBER_ID_DEV';
 export const TRACK_ID_COOKIE = isProd ? 'TRACK_ID' : 'TRACK_ID_DEV';
 export const SESSION_ID_COOKIE = isProd ? 'SESSION_ID' : 'SESSION_ID_DEV';
 


### PR DESCRIPTION
This started with a simple fix to the member cookie, but that exposed the fact that we were setting a URL-encoded version of the `MEETUP_MEMBER` cookie returned by the API, so I went ahead and had another look at the `Invalid cookie value` issue and found some ways to prevent Hapi from choking on cookies that aren't _just so_. It turns out we can just tell it to ignore the validation step and it will pass along the 'real' MEETUP_MEMBER cookie without an issue.

I've rolled back the `cleanRawCookies` utility @willh-meetup 