### PR TITLE
WP-229 more detailed request error logging

### DIFF
--- a/src/actions/syncActionCreators.js
+++ b/src/actions/syncActionCreators.js
@@ -17,7 +17,10 @@ export function apiSuccess({ queries, responses, csrf }) {
 }
 
 export function apiError(err) {
-	console.error('API_ERROR: ', err.stack);
+	console.error(JSON.stringify({
+		message: 'App server API error',
+		err: err.stack
+	}));
 	return {
 		type: 'API_ERROR',
 		payload: err,

--- a/src/util/apiUtils.js
+++ b/src/util/apiUtils.js
@@ -360,6 +360,19 @@ const externalRequest$ = Rx.Observable.bindNodeCallback(externalRequest);
  */
 export const makeExternalApiRequest = (request, API_TIMEOUT) => requestOpts => {
 	return externalRequest$(requestOpts)
+		.do(  // log errors
+			null,
+			err => {
+				console.error(JSON.stringify({
+					err: err.stack,
+					message: 'REST API request error',
+					request: {
+						id: request.id
+					},
+					context: requestOpts,
+				}));
+			}
+		)
 		.timeout(API_TIMEOUT)
 		.map(([response, body]) => [response, body, requestOpts.jar]);
 };


### PR DESCRIPTION
This should help with a `The header content contains invalid characters` error in the production logs by providing more error context when the `request` lib fails.