### PR TITLE
move error logging closer to fetch call

### DIFF
--- a/src/actions/syncActionCreators.js
+++ b/src/actions/syncActionCreators.js
@@ -17,10 +17,6 @@ export function apiSuccess({ queries, responses, csrf }) {
 }
 
 export function apiError(err) {
-	console.error(JSON.stringify({
-		message: 'App server API error',
-		err: err.stack
-	}));
 	return {
 		type: 'API_ERROR',
 		payload: err,

--- a/src/util/fetchUtils.js
+++ b/src/util/fetchUtils.js
@@ -60,7 +60,15 @@ export const fetchQueries = (apiUrl, options) => (queries, meta) => {
 				responses: responses || [],
 				csrf: queryResponse.headers.get('x-csrf-jwt'),
 			};
-		})
+		}),
+		err => {
+			console.error(JSON.stringify({
+				err: err.stack,
+				message: 'App server API fetch error',
+				context: fetchConfig,
+			}));
+			throw err;
+		}
 	);
 };
 


### PR DESCRIPTION
The `The header content contains invalid characters` error actually appears to be coming from the 'internal' `fetch` call that the server generates when the app route calls the `/mu_api` route, so this update moves the error logging closer to that call, where it can also log the fetch configuration used to make the invalid fetch call