### PR TITLE
clean bad cookies before fetch

### DIFF
--- a/src/util/fetchUtils.js
+++ b/src/util/fetchUtils.js
@@ -82,6 +82,10 @@ export const tryJSON = reqUrl => response => {
 	return response.text().then(text => JSON.parse(text));
 };
 
+export const stringifyCookies = cookies =>
+	Object.keys(cookies)
+			.map(name => `${name}=${cookies[name]}`)
+			.join('; ');
 /**
  * @param {String} rawCookieHeader a 'cookie' header string
  * @param {Object} newCookies an object of name-value cookies to inject
@@ -94,8 +98,17 @@ export const mergeCookies = (rawCookieHeader, newCookies) => {
 		...oldCookies,
 		...newCookies,
 	};
-	return Object.keys(mergedCookies)
-		.map(name => `${name}=${mergedCookies[name]}`)
-		.join('; ');
+	return stringifyCookies(mergedCookies);
+};
+
+export const BAD_COOKIES = [
+	'click-track'
+];
+
+export const cleanBadCookies = (cookieHeader) => {
+	const cookies = cookie.parse(cookieHeader);
+	BAD_COOKIES.forEach(badCookie => delete cookies[badCookie]);
+
+	return stringifyCookies(cookies);
 };
 

--- a/src/util/fetchUtils.js
+++ b/src/util/fetchUtils.js
@@ -72,6 +72,13 @@ export const fetchQueries = (apiUrl, options) => (queries, meta) => {
 	);
 };
 
+/**
+ * Attempt to JSON parse a Response object from a fetch call
+ *
+ * @param {String} reqUrl the URL that was requested
+ * @param {Response} response the fetch Response object
+ * @return {Promise} a Promise that resolves with the JSON-parsed text
+ */
 export const tryJSON = reqUrl => response => {
 	const { status, statusText } = response;
 	if (status >= 400) {  // status always 200: bugzilla #52128
@@ -82,10 +89,21 @@ export const tryJSON = reqUrl => response => {
 	return response.text().then(text => JSON.parse(text));
 };
 
+/**
+ * Convert an object of cookie name-value pairs into a 'Cookie' header. This
+ * is different than the serialization offered by the 'cookie' and
+ * 'tough-cookie' packages, which write cookie values in the form of a
+ * 'Set-Cookie' header, which contains more info
+ *
+ * @param {Object} cookies a name-value mapping of cookies, e.g. from
+ *   `cookie.parse`
+ * @return {String} a 'Cookie' header string
+ */
 export const stringifyCookies = cookies =>
 	Object.keys(cookies)
-			.map(name => `${name}=${cookies[name]}`)
-			.join('; ');
+		.map(name => `${name}=${cookies[name]}`)
+		.join('; ');
+
 /**
  * @param {String} rawCookieHeader a 'cookie' header string
  * @param {Object} newCookies an object of name-value cookies to inject
@@ -105,6 +123,13 @@ export const BAD_COOKIES = [
 	'click-track'
 ];
 
+/**
+ * Remove cookies that are known to have values that are invalid for `fetch`
+ * calls
+ *
+ * @param {String} cookieHeader a cookie header
+ * @return {String} a cleaned cookie header string
+ */
 export const cleanBadCookies = (cookieHeader) => {
 	const cookies = cookie.parse(cookieHeader);
 	BAD_COOKIES.forEach(badCookie => delete cookies[badCookie]);

--- a/src/util/fetchUtils.test.js
+++ b/src/util/fetchUtils.test.js
@@ -1,3 +1,4 @@
+import cookie from 'cookie';
 import {
 	mockQuery,
 } from 'meetup-web-mocks/lib/app';
@@ -67,7 +68,6 @@ describe('fetchQueries', () => {
 				.then(() => {
 					const calledWith = global.fetch.calls.mostRecent().args;
 					const url = new URL(calledWith[0]);
-					console.warn(calledWith[0]);
 					expect(url.origin).toBe(API_URL.origin);
 					expect(url.searchParams.has('queries')).toBe(true);
 					expect(url.searchParams.has('metadata')).toBe(true);
@@ -184,3 +184,23 @@ describe('mergeCookies', () => {
 	});
 });
 
+describe('cleanBadCookies', () => {
+	const goodHeader = 'foo=bar; baz=boom';
+	it('removes bad cookies from the cookie header', () => {
+		const badHeader = fetchUtils.BAD_COOKIES.reduce(
+			(badHeader, badCookie) => `${badHeader}; ${badCookie}=whatever`,
+			goodHeader
+		);
+
+		const cleanedHeader = fetchUtils.cleanBadCookies(badHeader);
+		fetchUtils.BAD_COOKIES.forEach(badCookie => {
+			// bad header _has_ bad cookie
+			expect(cookie.parse(badHeader)[badCookie]).toBeDefined();
+			// clean header does _not_ have bad cookie
+			expect(cookie.parse(cleanedHeader)[badCookie]).toBeUndefined();
+		});
+	});
+	it('leaves a clean cookie header intact', () => {
+		expect(fetchUtils.cleanBadCookies(goodHeader)).toEqual(goodHeader);
+	});
+});


### PR DESCRIPTION
the `click-track` header from Meetup Classic contains characters that are not allowed by `node-fetch` and we don't need that header for that call, so we can strip it.