### PR TITLE
Linkify - Add protocol to links w/o one

### DIFF
--- a/src/util/linkify.js
+++ b/src/util/linkify.js
@@ -12,8 +12,9 @@ const createLink = options => href => {
 	const target = options.target || '';
 	const targetAttr = `target="${target}"`;
 	const relAttr = target === '_blank' ? 'rel="noopener noreferrer"' : '';
+	const link = (href.search('www.') === 0) ? `http://${href}` : href;
 
-	return `<a class="link" href="${href}" title="${href}" ${targetAttr} ${relAttr}>${href}</a>`;
+	return `<a class="link" href="${link}" title="${href}" ${targetAttr} ${relAttr}>${href}</a>`;
 }
 
 /**

--- a/src/util/linkify.js
+++ b/src/util/linkify.js
@@ -12,7 +12,8 @@ const createLink = options => href => {
 	const target = options.target || '';
 	const targetAttr = `target="${target}"`;
 	const relAttr = target === '_blank' ? 'rel="noopener noreferrer"' : '';
-	const link = (href.search('www.') === 0) ? `http://${href}` : href;
+	const hasProtocolRE = /^(?:https?:|ws:|ftp:)?\/\//;
+	const link = hasProtocolRE.test(href) ? href : `http://${href}`;
 
 	return `<a class="link" href="${link}" title="${href}" ${targetAttr} ${relAttr}>${href}</a>`;
 }

--- a/src/util/linkify.test.js
+++ b/src/util/linkify.test.js
@@ -32,4 +32,14 @@ describe('linkify', () => {
 		const expectedParagraphLink = `Did you know ${expectedLink} is a cool site?`;
 		expect(linkify(paragraphTextBase)).toBe(expectedParagraphLink);
 	});
+	it('should turn a text with a link into text with an HTML anchor', () => {
+		const paragraphTextBase = `Did you know ${httpBase} is a cool site?`;
+		const expectedParagraphLink = `Did you know ${expectedLink} is a cool site?`;
+		expect(linkify(paragraphTextBase)).toBe(expectedParagraphLink);
+	});
+	it('should prefix a plain link with a protocol', () => {
+		const plainBase = 'www.meetup.com';
+		const expectedLink = '<a class="link" href="http://www.meetup.com" title="www.meetup.com" target="" >www.meetup.com</a>';
+		expect(linkify(plainBase)).toBe(expectedLink);
+	});
 });

--- a/src/util/linkify.test.js
+++ b/src/util/linkify.test.js
@@ -32,11 +32,6 @@ describe('linkify', () => {
 		const expectedParagraphLink = `Did you know ${expectedLink} is a cool site?`;
 		expect(linkify(paragraphTextBase)).toBe(expectedParagraphLink);
 	});
-	it('should turn a text with a link into text with an HTML anchor', () => {
-		const paragraphTextBase = `Did you know ${httpBase} is a cool site?`;
-		const expectedParagraphLink = `Did you know ${expectedLink} is a cool site?`;
-		expect(linkify(paragraphTextBase)).toBe(expectedParagraphLink);
-	});
 	it('should prefix a plain link with a protocol', () => {
 		const plainBase = 'www.meetup.com';
 		const expectedLink = '<a class="link" href="http://www.meetup.com" title="www.meetup.com" target="" >www.meetup.com</a>';


### PR DESCRIPTION
#### Description
This PR fixes an issue with the linkify method that creates links for urls without protocols. This is because the library being used matches urls that don't have protocols. The solution was to check for `www.` at the beginning of the matched url and add the `http` protocol to the beginning. If we want  to support more complex urls, it might be better to use our own regex again.

#### Related Issues
Fixes https://meetup.atlassian.net/browse/MUP-8457