### PR TITLE
set configuration on server.app instead of passing around as arg

### DIFF
--- a/src/apiProxy/api-proxy.js
+++ b/src/apiProxy/api-proxy.js
@@ -33,30 +33,26 @@ import {
  * query-specific options.
  *
  * @param {Request} request Hapi request object
- * @param {Object} baseUrl API server base URL for all API requests
  * @return Array$ contains all API responses corresponding to the provided queries
  */
-const apiProxy$ = ({ API_TIMEOUT=8000, baseUrl='', duotoneUrls={} }) => {
+const apiProxy$ = request => {
+	request.log(['api', 'info'], 'Parsing api endpoint request');
+	// 1. get the queries and the 'universal' `externalRequestOpts` from the request
+	const parsedRequest = parseRequest(request);
 
-	return request => {
-		request.log(['api', 'info'], 'Parsing api endpoint request');
-		// 1. get the queries and the 'universal' `externalRequestOpts` from the request
-		const { queries, externalRequestOpts } = parseRequest(request, baseUrl);
+	// 2. curry a function that uses `externalRequestOpts` as a base from which
+	// to build the query-specific API request options object
+	const queryToRequestOpts = buildRequestArgs(parsedRequest.externalRequestOpts);
 
-		// 2. curry a function that uses `externalRequestOpts` as a base from which
-		// to build the query-specific API request options object
-		const queryToRequestOpts = buildRequestArgs(externalRequestOpts);
+	request.log(['api', 'info'], JSON.stringify(parsedRequest.queries));
+	// 3. map the queries onto an array of api request observables
+	const apiRequests$ = parsedRequest.queries
+		.map(queryToRequestOpts)
+		.map((opts, i) => ([opts, parsedRequest.queries[i]]))  // zip the query back into the opts
+		.map(makeApiRequest$(request));
 
-		request.log(['api', 'info'], JSON.stringify(queries));
-		// 3. map the queries onto an array of api request observables
-		const apiRequests$ = queries
-			.map(queryToRequestOpts)
-			.map((opts, i) => ([opts, queries[i]]))  // zip the query back into the opts
-			.map(makeApiRequest$(request, API_TIMEOUT, duotoneUrls));
-
-		// 4. zip them together to send them parallel and return responses in order
-		return Rx.Observable.zip(...apiRequests$);
-	};
+	// 4. zip them together to send them parallel and return responses in order
+	return Rx.Observable.zip(...apiRequests$);
 };
 
 export default apiProxy$;

--- a/src/apiProxy/api-proxy.test.js
+++ b/src/apiProxy/api-proxy.test.js
@@ -20,6 +20,11 @@ describe('apiProxy$', () => {
 			state: {
 				oauth_token: 'foo',
 			},
+			server: {
+				app: {
+					API_SERVER_ROOT_URL: 'http://example.com'
+				}
+			},
 			log: () => {},
 		};
 		const requestResult = {
@@ -33,7 +38,7 @@ describe('apiProxy$', () => {
 			requestResult,
 			requestResult,
 		];
-		return apiProxy$({})(getRequest)
+		return apiProxy$(getRequest)
 			.toPromise()
 			.then(results => expect(results).toEqual(expectedResults));
 	});

--- a/src/apiProxy/apiProxyRoutes.js
+++ b/src/apiProxy/apiProxyRoutes.js
@@ -8,8 +8,6 @@ const validApiPayloadSchema = Joi.object({
 });
 
 const getApiProxyRoutes = (path, apiProxyFn$) => {
-	const proxyApiRequest$ = apiProxyFn$;
-
 	/**
 	 * This handler converts the application-supplied queries into external API
 	 * calls, and converts the API call responses into a standard format that
@@ -20,7 +18,7 @@ const getApiProxyRoutes = (path, apiProxyFn$) => {
 	 */
 	const routeBase = {
 		path,
-		handler: getApiProxyRouteHandler(proxyApiRequest$),
+		handler: getApiProxyRouteHandler(apiProxyFn$),
 		config: {
 			plugins: {
 				'electrode-csrf-jwt': {

--- a/src/apiProxy/apiProxyRoutes.js
+++ b/src/apiProxy/apiProxyRoutes.js
@@ -1,8 +1,4 @@
 import Joi from 'joi';
-import {
-	duotones,
-	getDuotoneUrls
-} from '../util/duotone';
 import { getApiProxyRouteHandler } from './apiProxyHandler';
 
 const validApiPayloadSchema = Joi.object({
@@ -11,12 +7,8 @@ const validApiPayloadSchema = Joi.object({
 	logout: Joi.any(),
 });
 
-const getApiProxyRoutes = (path, env, apiProxyFn$) => {
-	const proxyApiRequest$ = apiProxyFn$({
-		API_TIMEOUT: env.API_TIMEOUT,
-		baseUrl: env.API_SERVER_ROOT_URL,
-		duotoneUrls: getDuotoneUrls(duotones, env.PHOTO_SCALER_SALT),
-	});
+const getApiProxyRoutes = (path, apiProxyFn$) => {
+	const proxyApiRequest$ = apiProxyFn$;
 
 	/**
 	 * This handler converts the application-supplied queries into external API

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -75,10 +75,9 @@ export function getConsoleLogPlugin() {
  * configure and return the plugin that will allow requests to get anonymous
  * oauth tokens to communicate with the API
  */
-export function getRequestAuthPlugin(options) {
+export function getRequestAuthPlugin() {
 	return {
 		register: requestAuthPlugin,
-		options,
 	};
 }
 

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -75,9 +75,10 @@ export function getConsoleLogPlugin() {
  * configure and return the plugin that will allow requests to get anonymous
  * oauth tokens to communicate with the API
  */
-export function getRequestAuthPlugin() {
+export function getRequestAuthPlugin(options) {
 	return {
 		register: requestAuthPlugin,
+		options,
 	};
 }
 

--- a/src/plugins/requestAuthPlugin.js
+++ b/src/plugins/requestAuthPlugin.js
@@ -237,12 +237,11 @@ export const getAuthenticate = authorizeRequest$ => (request, reply) => {
  * @param {Object} options the options passed to `server.auth.strategy`for the
  *   auth stategy instance
  */
-export const oauthScheme = (server, options) => {
-	server.app = options;
+export const oauthScheme = server => {
 	configureAuthCookies(server);       // apply default config for auth cookies
 	server.ext('onPreAuth', setPluginState);     // provide a reference to `reply` on the request
-
-	const authorizeRequest$ = applyRequestAuthorizer$(getRequestAuthorizer$(server.app));
+	const pluginConfig = server.plugins.requestAuth.config;
+	const authorizeRequest$ = applyRequestAuthorizer$(getRequestAuthorizer$(pluginConfig));
 
 	return {
 		authenticate: getAuthenticate(authorizeRequest$),
@@ -260,6 +259,7 @@ export const oauthScheme = (server, options) => {
  * {@link http://hapijs.com/tutorials/plugins}
  */
 export default function register(server, options, next) {
+	server.expose('config', options);
 	server.auth.scheme('oauth', oauthScheme);
 	next();
 }

--- a/src/plugins/requestAuthPlugin.js
+++ b/src/plugins/requestAuthPlugin.js
@@ -238,10 +238,11 @@ export const getAuthenticate = authorizeRequest$ => (request, reply) => {
  *   auth stategy instance
  */
 export const oauthScheme = (server, options) => {
-	configureAuthCookies(server, options);       // apply default config for auth cookies
+	server.app = options;
+	configureAuthCookies(server);       // apply default config for auth cookies
 	server.ext('onPreAuth', setPluginState);     // provide a reference to `reply` on the request
 
-	const authorizeRequest$ = applyRequestAuthorizer$(getRequestAuthorizer$(options));
+	const authorizeRequest$ = applyRequestAuthorizer$(getRequestAuthorizer$(server.app));
 
 	return {
 		authenticate: getAuthenticate(authorizeRequest$),

--- a/src/plugins/requestAuthPlugin.js
+++ b/src/plugins/requestAuthPlugin.js
@@ -240,8 +240,8 @@ export const getAuthenticate = authorizeRequest$ => (request, reply) => {
 export const oauthScheme = server => {
 	configureAuthCookies(server);       // apply default config for auth cookies
 	server.ext('onPreAuth', setPluginState);     // provide a reference to `reply` on the request
-	const pluginConfig = server.plugins.requestAuth.config;
-	const authorizeRequest$ = applyRequestAuthorizer$(getRequestAuthorizer$(pluginConfig));
+	const options = server.plugins.requestAuth.config;
+	const authorizeRequest$ = applyRequestAuthorizer$(getRequestAuthorizer$(options));
 
 	return {
 		authenticate: getAuthenticate(authorizeRequest$),
@@ -259,8 +259,12 @@ export const oauthScheme = server => {
  * {@link http://hapijs.com/tutorials/plugins}
  */
 export default function register(server, options, next) {
+	// allow plugin to access config at server.plugins.requestAuth.config
 	server.expose('config', options);
+
+	// register the plugin's auth scheme
 	server.auth.scheme('oauth', oauthScheme);
+
 	next();
 }
 register.attributes = {

--- a/src/plugins/requestAuthPlugin.test.js
+++ b/src/plugins/requestAuthPlugin.test.js
@@ -223,7 +223,7 @@ describe('register', () => {
 	const spyable = {
 		next() {}
 	};
-	const options = {
+	const app = {
 		OAUTH_AUTH_URL: '',
 		OAUTH_ACCESS_URL: '',
 		oauth: {
@@ -233,13 +233,16 @@ describe('register', () => {
 	};
 	it('calls next', () => {
 		spyOn(spyable, 'next');
-		register(MOCK_SERVER, options, spyable.next);
+		register({
+			...MOCK_SERVER,
+			app
+		}, {}, spyable.next);
 		expect(spyable.next).toHaveBeenCalled();
 	});
 });
 
 describe('oauthScheme', () => {
-	const options = {
+	const app = {
 		OAUTH_AUTH_URL,
 		OAUTH_ACCESS_URL,
 		oauth: {
@@ -247,11 +250,16 @@ describe('oauthScheme', () => {
 			secret: 'abcd',
 		},
 		COOKIE_ENCRYPT_SECRET: 'asdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdf',
+		duotoneUrls: ['http://example.com'],
 	};
 	it('calls server.ext with an \'onPreAuth\' function', () => {
-		spyOn(MOCK_SERVER, 'ext');
-		oauthScheme(MOCK_SERVER, options);
-		expect(MOCK_SERVER.ext).toHaveBeenCalledWith('onPreAuth', jasmine.any(Function));
+		const server = {
+			...MOCK_SERVER,
+			app
+		};
+		spyOn(server, 'ext');
+		oauthScheme(server);
+		expect(server.ext).toHaveBeenCalledWith('onPreAuth', jasmine.any(Function));
 	});
 });
 

--- a/src/plugins/requestAuthPlugin.test.js
+++ b/src/plugins/requestAuthPlugin.test.js
@@ -20,7 +20,9 @@ const MOCK_SERVER = {
 	},
 	ext: () => {},
 	state: () => {},
-	app: {}
+	app: {},
+	expose: () => {},
+	plugins: { requestAuth: { config: { COOKIE_ENCRYPT_SECRET: 'asdfasdfasdfasdfasdfasdfasdfasdfasdf' } } }
 };
 const MOCK_HEADERS = {};
 const MOCK_REPLY_FN = () => {};
@@ -242,7 +244,7 @@ describe('register', () => {
 });
 
 describe('oauthScheme', () => {
-	const app = {
+	const config = {
 		OAUTH_AUTH_URL,
 		OAUTH_ACCESS_URL,
 		oauth: {
@@ -252,10 +254,11 @@ describe('oauthScheme', () => {
 		COOKIE_ENCRYPT_SECRET: 'asdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdf',
 		duotoneUrls: ['http://example.com'],
 	};
+	const plugins = { requestAuth: { config } };
 	it('calls server.ext with an \'onPreAuth\' function', () => {
 		const server = {
 			...MOCK_SERVER,
-			app
+			plugins
 		};
 		spyOn(server, 'ext');
 		oauthScheme(server);

--- a/src/routes.test.js
+++ b/src/routes.test.js
@@ -1,21 +1,20 @@
 import querystring from 'qs';
+import Rx from 'rxjs';
 import {
 	MOCK_API_RESULT,
 	MOCK_renderRequestMap,
-	MOCK_API_PROXY$,
 	MOCK_RENDER_RESULT,
-	MOCK_VALID_CONFIG,
 } from 'meetup-web-mocks/lib/app';
 
 import getRoutes from './routes';
 import { getServer } from './util/testUtils';
 
 function getResponse(injectRequest, server=getServer()) {
+	const MOCK_API_PROXY$ = () => Rx.Observable.of(MOCK_API_RESULT);
 	// a Promise that returns the server instance after it has been
 	// configured with the routes being tested
 	const routes = getRoutes(
 		MOCK_renderRequestMap,
-		MOCK_VALID_CONFIG,
 		MOCK_API_PROXY$
 	);
 	server.route(routes);

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -5,14 +5,14 @@ import apiProxy$ from '../apiProxy/api-proxy';
 import getApiProxyRoutes from '../apiProxy/apiProxyRoutes';
 import getApplicationRoute from './appRoute';
 
-export default function getRoutes(renderRequestMap, env, apiProxyFn$ = apiProxy$) {
+export default function getRoutes(renderRequestMap, apiProxyFn$=apiProxy$) {
 
 	console.log(
 		chalk.green(`Supported languages:\n${Object.keys(renderRequestMap).join('\n')}`)
 	);
 
 	return [
-		...getApiProxyRoutes('/mu_api', env, apiProxyFn$),
+		...getApiProxyRoutes('/mu_api', apiProxyFn$),
 		getApplicationRoute(renderRequestMap),
 	];
 }

--- a/src/server.js
+++ b/src/server.js
@@ -39,7 +39,7 @@ export default function start(
 	return config()
 		.then(configureEnv)
 		.then(config => {
-			const baseRoutes = getRoutes(renderRequestMap, config);
+			const baseRoutes = getRoutes(renderRequestMap);
 			const finalRoutes = [ ...routes, ...baseRoutes ];
 
 			const connection = {

--- a/src/util/apiUtils.js
+++ b/src/util/apiUtils.js
@@ -17,7 +17,9 @@ import {
 import {
 	querySchema
 } from './validation';
-import { duotoneRef } from './duotone';
+import {
+	duotoneRef,
+} from './duotone';
 
 const MOCK_RESPONSE_OK = {  // minimal representation of http.IncomingMessage
 	statusCode: 200,
@@ -273,7 +275,8 @@ export function parseRequestQueries(request) {
  * Parse request for queries and request options
  * @return {Object} { queries, externalRequestOpts }
  */
-export function parseRequest(request, baseUrl) {
+export function parseRequest(request) {
+	const baseUrl = request.server.app.API_SERVER_ROOT_URL;
 	return {
 		externalRequestOpts: {
 			baseUrl,
@@ -358,7 +361,7 @@ const externalRequest$ = Rx.Observable.bindNodeCallback(externalRequest);
 /**
  * Make a real external API request, return response body string
  */
-export const makeExternalApiRequest = (request, API_TIMEOUT) => requestOpts => {
+export const makeExternalApiRequest = request => requestOpts => {
 	return externalRequest$(requestOpts)
 		.do(  // log errors
 			null,
@@ -373,7 +376,7 @@ export const makeExternalApiRequest = (request, API_TIMEOUT) => requestOpts => {
 				}));
 			}
 		)
-		.timeout(API_TIMEOUT)
+		.timeout(request.server.app.API_TIMEOUT)
 		.map(([response, body]) => [response, body, requestOpts.jar]);
 };
 
@@ -460,12 +463,12 @@ export const injectResponseCookies = request => ([response, _, jar]) => {
  * Make an API request and parse the response into the expected `response`
  * object shape
  */
-export const makeApiRequest$ = (request, API_TIMEOUT, duotoneUrls) => {
-	const setApiResponseDuotones = apiResponseDuotoneSetter(duotoneUrls);
+export const makeApiRequest$ = request => {
+	const setApiResponseDuotones = apiResponseDuotoneSetter(request.server.app.duotoneUrls);
 	return ([requestOpts, query]) => {
 		const request$ = query.mockResponse ?
 			makeMockRequest(query.mockResponse) :
-			makeExternalApiRequest(request, API_TIMEOUT);
+			makeExternalApiRequest(request);
 
 		return Rx.Observable.defer(() => {
 			request.log(['api', 'info'], `REST API request: ${requestOpts.url}`);

--- a/src/util/apiUtils.mockRequest.test.js
+++ b/src/util/apiUtils.mockRequest.test.js
@@ -45,22 +45,23 @@ describe('createCookieJar', () => {
 
 describe('makeExternalApiRequest', () => {
 	it('calls externalRequest with requestOpts', () => {
+		const API_TIMEOUT = 5000;
 		const requestOpts = {
 			foo: 'bar',
 			url: 'http://example.com',
 		};
-		return makeExternalApiRequest({}, 5000)(requestOpts)
+		return makeExternalApiRequest({ server: { app: { API_TIMEOUT } } })(requestOpts)
 			.toPromise()
 			.then(() => require('request').mock.calls.pop()[0])
 			.then(arg => expect(arg).toBe(requestOpts));
 	});
 	it('throws an error when the API times out', () => {
-		const timeout = 100;
+		const API_TIMEOUT = 100;
 		const requestOpts = {
 			foo: 'bar',
 			url: 'http://example.com',
 		};
-		return makeExternalApiRequest({}, timeout)(requestOpts)
+		return makeExternalApiRequest({ server: { app: { API_TIMEOUT } } })(requestOpts)
 			.toPromise()
 			.then(
 				() => expect(true).toBe(false),  // should not be called
@@ -68,13 +69,13 @@ describe('makeExternalApiRequest', () => {
 			);
 	});
 	it('returns the requestOpts jar at array index 2', () => {
-		const timeout = 5000;
+		const API_TIMEOUT = 5000;
 		const requestOpts = {
 			foo: 'bar',
 			url: 'http://example.com',
 			jar: 'fooJar',
 		};
-		return makeExternalApiRequest({}, timeout)(requestOpts)
+		return makeExternalApiRequest({ server: { app: { API_TIMEOUT } } })(requestOpts)
 			.toPromise()
 			.then(([response, body, jar]) => expect(jar).toBe(requestOpts.jar));
 	});
@@ -84,14 +85,14 @@ describe('makeApiRequest$', () => {
 	const endpoint = 'foo';
 	it('makes a GET request', () => {
 		const query = { ...mockQuery(MOCK_RENDERPROPS) };
-		return makeApiRequest$({ log: () => {} }, 5000, {})([{ method: 'get', url: endpoint }, query])
+		return makeApiRequest$({ server: { app: {} }, log: () => {} }, 5000, {})([{ method: 'get', url: endpoint }, query])
 			.toPromise()
 			.then(() => require('request').mock.calls.pop()[0])
 			.then(arg => expect(arg.method).toBe('get'));
 	});
 	it('makes a POST request', () => {
 		const query = { ...mockQuery(MOCK_RENDERPROPS) };
-		return makeApiRequest$({ log: () => {} }, 5000, {})([{ method: 'post', url: endpoint }, query])
+		return makeApiRequest$({ server: { app: {} }, log: () => {} }, 5000, {})([{ method: 'post', url: endpoint }, query])
 			.toPromise()
 			.then(() => require('request').mock.calls.pop()[0])
 			.then(arg => expect(arg.method).toBe('post'));
@@ -109,7 +110,7 @@ describe('makeApiRequest$', () => {
 				value: mockResponse,
 			}
 		};
-		return makeApiRequest$({ log: () => {} }, 5000, {})([{ url: endpoint }, query])
+		return makeApiRequest$({ server: { app: {} }, log: () => {} }, 5000, {})([{ url: endpoint }, query])
 			.toPromise()
 			.then(response => expect(response).toEqual(expectedResponse));
 	});

--- a/src/util/apiUtils.mockRequest.test.js
+++ b/src/util/apiUtils.mockRequest.test.js
@@ -85,14 +85,14 @@ describe('makeApiRequest$', () => {
 	const endpoint = 'foo';
 	it('makes a GET request', () => {
 		const query = { ...mockQuery(MOCK_RENDERPROPS) };
-		return makeApiRequest$({ server: { app: {} }, log: () => {} }, 5000, {})([{ method: 'get', url: endpoint }, query])
+		return makeApiRequest$({ server: { app: {} }, log: () => {} })([{ method: 'get', url: endpoint }, query])
 			.toPromise()
 			.then(() => require('request').mock.calls.pop()[0])
 			.then(arg => expect(arg.method).toBe('get'));
 	});
 	it('makes a POST request', () => {
 		const query = { ...mockQuery(MOCK_RENDERPROPS) };
-		return makeApiRequest$({ server: { app: {} }, log: () => {} }, 5000, {})([{ method: 'post', url: endpoint }, query])
+		return makeApiRequest$({ server: { app: {} }, log: () => {} })([{ method: 'post', url: endpoint }, query])
 			.toPromise()
 			.then(() => require('request').mock.calls.pop()[0])
 			.then(arg => expect(arg.method).toBe('post'));
@@ -110,7 +110,7 @@ describe('makeApiRequest$', () => {
 				value: mockResponse,
 			}
 		};
-		return makeApiRequest$({ server: { app: {} }, log: () => {} }, 5000, {})([{ url: endpoint }, query])
+		return makeApiRequest$({ server: { app: {} }, log: () => {} })([{ url: endpoint }, query])
 			.toPromise()
 			.then(response => expect(response).toEqual(expectedResponse));
 	});

--- a/src/util/apiUtils.test.js
+++ b/src/util/apiUtils.test.js
@@ -486,6 +486,11 @@ describe('parseRequest', () => {
 			state: {
 				oauth_token: 'foo',
 			},
+			server: {
+				app: {
+					API_SERVER_ROOT_URL: 'http://example.com',
+				},
+			},
 		};
 		expect(parseRequest(getRequest, 'http://dummy.api.meetup.com').queries).toEqual(queries);
 	});
@@ -497,6 +502,11 @@ describe('parseRequest', () => {
 			payload: data,
 			state: {
 				oauth_token: 'foo',
+			},
+			server: {
+				app: {
+					API_SERVER_ROOT_URL: 'http://example.com',
+				},
 			},
 		};
 		expect(parseRequest(postRequest, 'http://dummy.api.meetup.com').queries).toEqual(queries);
@@ -510,6 +520,11 @@ describe('parseRequest', () => {
 			query: data,
 			state: {
 				oauth_token: 'foo',
+			},
+			server: {
+				app: {
+					API_SERVER_ROOT_URL: 'http://example.com',
+				},
 			},
 		};
 		expect(() => parseRequest(getRequest, 'http://dummy.api.meetup.com')).toThrow();

--- a/src/util/authUtils.js
+++ b/src/util/authUtils.js
@@ -76,7 +76,7 @@ export const getMemberCookieName = server =>
  * apply default cookie options for auth-related cookies
  */
 export const configureAuthCookies = server => {
-	const password = validateSecret(server.app.COOKIE_ENCRYPT_SECRET);
+	const password = validateSecret(server.plugins.requestAuth.config.COOKIE_ENCRYPT_SECRET);
 	const isSecure = process.env.NODE_ENV === 'production';
 	const authCookieOptions = {
 		encoding: 'iron',

--- a/src/util/authUtils.js
+++ b/src/util/authUtils.js
@@ -75,8 +75,8 @@ export const getMemberCookieName = server =>
 /**
  * apply default cookie options for auth-related cookies
  */
-export const configureAuthCookies = (server, options) => {
-	const password = validateSecret(options.COOKIE_ENCRYPT_SECRET);
+export const configureAuthCookies = server => {
+	const password = validateSecret(server.app.COOKIE_ENCRYPT_SECRET);
 	const isSecure = process.env.NODE_ENV === 'production';
 	const authCookieOptions = {
 		encoding: 'iron',

--- a/src/util/authUtils.test.js
+++ b/src/util/authUtils.test.js
@@ -13,11 +13,14 @@ describe('configureAuthCookies', () => {
 		app: {},
 	};
 	it('calls server.state for each auth cookie name', () => {
-		const goodOptions = {
+		const app = {
 			COOKIE_ENCRYPT_SECRET: 'asdklfjahsdflkjasdfhlkajsdfkljasdlkasdjhfalksdjfbalkjsdhfalsdfasdlkfasd',
 		};
 		spyOn(serverWithState, 'state');
-		configureAuthCookies(serverWithState, goodOptions);
+		configureAuthCookies({
+			...serverWithState,
+			app,
+		});
 		const callArgs = serverWithState.state.calls.allArgs();
 		expect(callArgs.length).toBeGreaterThan(0);
 		callArgs.forEach(args => {
@@ -26,14 +29,20 @@ describe('configureAuthCookies', () => {
 		});
 	});
 	it('throws an error when secret is missing', () => {
-		const missingSecretOpts = {};
-		expect(() => configureAuthCookies(serverWithState, missingSecretOpts)).toThrow();
+		const app = {};
+		expect(() => configureAuthCookies({
+			...serverWithState,
+			app,
+		})).toThrow();
 	});
 	it('throws an error when secret is too short', () => {
-		const shortSecretOpts = {
+		const app = {
 			COOKIE_ENCRYPT_SECRET: 'less than 32 characters',
 		};
-		expect(() => configureAuthCookies(serverWithState, shortSecretOpts)).toThrow();
+		expect(() => configureAuthCookies({
+			...serverWithState,
+			app,
+		})).toThrow();
 	});
 });
 

--- a/src/util/authUtils.test.js
+++ b/src/util/authUtils.test.js
@@ -13,13 +13,14 @@ describe('configureAuthCookies', () => {
 		app: {},
 	};
 	it('calls server.state for each auth cookie name', () => {
-		const app = {
+		const config = {
 			COOKIE_ENCRYPT_SECRET: 'asdklfjahsdflkjasdfhlkajsdfkljasdlkasdjhfalksdjfbalkjsdhfalsdfasdlkfasd',
 		};
+		const plugins = { requestAuth: { config } };
 		spyOn(serverWithState, 'state');
 		configureAuthCookies({
 			...serverWithState,
-			app,
+			plugins,
 		});
 		const callArgs = serverWithState.state.calls.allArgs();
 		expect(callArgs.length).toBeGreaterThan(0);
@@ -29,19 +30,21 @@ describe('configureAuthCookies', () => {
 		});
 	});
 	it('throws an error when secret is missing', () => {
-		const app = {};
+		const config = {};
+		const plugins = { requestAuth: { config } };
 		expect(() => configureAuthCookies({
 			...serverWithState,
-			app,
+			plugins,
 		})).toThrow();
 	});
 	it('throws an error when secret is too short', () => {
-		const app = {
+		const config = {
 			COOKIE_ENCRYPT_SECRET: 'less than 32 characters',
 		};
+		const plugins = { requestAuth: { config } };
 		expect(() => configureAuthCookies({
 			...serverWithState,
-			app,
+			plugins,
 		})).toThrow();
 	});
 });

--- a/src/util/config.js
+++ b/src/util/config.js
@@ -1,4 +1,8 @@
 import Joi from 'joi';
+import {
+	duotones,
+	getDuotoneUrls
+} from './duotone';
 /**
  * Start the server with a config
  *
@@ -35,6 +39,7 @@ export default function getConfig(overrideConfig) {
 			key: process.env.MUPWEB_OAUTH_KEY,
 		},
 	};
+	config.duotoneUrls = getDuotoneUrls(duotones, config.PHOTO_SCALER_SALT);
 	config.API_SERVER_ROOT_URL = `${config.API_PROTOCOL}://${config.API_HOST}`;
 
 	// currently all config is available syncronously, so resolve immediately
@@ -64,6 +69,7 @@ function validateConfig(config) {
 			secret: Joi.string().min(1).required().error(oauthError),
 			key: Joi.string().min(1).required().error(oauthError),
 		}).required(),
+		duotoneUrls: Joi.array().items(Joi.string().uri()),
 	}).required();
 
 	const result = Joi.validate(config, configSchema);

--- a/src/util/config.test.js
+++ b/src/util/config.test.js
@@ -5,7 +5,8 @@ const validConfig = {
 	oauth: {
 		key: '1234',
 		secret: 'asdf',
-	}
+	},
+	duotoneUrls: ['http://example.com'],
 };
 describe('getConfig', function() {
 	it(

--- a/src/util/serverUtils.js
+++ b/src/util/serverUtils.js
@@ -66,10 +66,12 @@ export function server(routes, connection, plugins, platform_agent, config) {
 	// https://hapijs.com/api#serverapp
 	server.app = {
 		isDevConfig: checkForDevUrl(config),  // indicates dev API or prod API
+		...config
 	};
 	server.decorate('reply', 'track', track(platform_agent));
 
-	return server.connection(connection)
+	const appConnection = server.connection(connection);
+	return appConnection
 		.register(plugins)
 		.then(() => registerExtensionEvents(server))
 		.then(() => server.auth.strategy('default', 'oauth', true, config))

--- a/src/util/serverUtils.js
+++ b/src/util/serverUtils.js
@@ -74,7 +74,7 @@ export function server(routes, connection, plugins, platform_agent, config) {
 	return appConnection
 		.register(plugins)
 		.then(() => registerExtensionEvents(server))
-		.then(() => server.auth.strategy('default', 'oauth', true, config))
+		.then(() => server.auth.strategy('default', 'oauth', true))
 		.then(() => server.log(['start'], `${plugins.length} plugins registered, assigning routes...`))
 		.then(() => server.route(routes))
 		.then(() => server.log(['start'], `${routes.length} routes assigned, starting server...`))

--- a/tests/integration/requestAuthPlugin.int.js
+++ b/tests/integration/requestAuthPlugin.int.js
@@ -17,7 +17,7 @@ const makeMockFetchResponse = responseObj => Promise.resolve({
 
 
 const random32 = 'asdfasdfasdfasdfasdfasdfasdfasdf';
-const options = {
+const app = {
 	API_HOST: 'www.api.meetup.com',
 	API_TIMEOUT: 10,
 	CSRF_SECRET: random32,
@@ -27,7 +27,8 @@ const options = {
 	oauth: {
 		key: random32,
 		secret: random32,
-	}
+	},
+	duotoneUrls: ['http://example.com/duotone.jpg']
 };
 const getEncryptedToken = token => new Promise((resolve, reject) =>
 	Iron.seal(token, random32, Iron.defaults, (err, sealed) => resolve(sealed))
@@ -38,12 +39,12 @@ const expectedResponse = 'barfoo';
 
 const testAuth = (cookies, test, makeRequest=cookieRequest) => {
 	spyOn(global, 'fetch').and.callFake((url, opts) => {
-		if (url.includes(options.OAUTH_AUTH_URL)) {
+		if (url.includes(app.OAUTH_AUTH_URL)) {
 			return makeMockFetchResponse({
 				code: 'foo',
 			});
 		}
-		if (url.includes(options.OAUTH_ACCESS_URL)) {
+		if (url.includes(app.OAUTH_ACCESS_URL)) {
 			return makeMockFetchResponse({
 				oauth_token: expectedOauthToken,
 				refresh_token: 'whatever',
@@ -57,11 +58,12 @@ const testAuth = (cookies, test, makeRequest=cookieRequest) => {
 		handler: (request, reply) => reply(expectedResponse)
 	};
 	const server = new Hapi.Server();
-	return server
-		.connection()
+	server.app = app;
+	const testConnection = server.connection();
+	return testConnection
 		.register(requestAuthPlugin)
-		.then(() => server.route(fooRoute))
-		.then(() => server.auth.strategy('default', 'oauth', true, options))
+		.then(() => testConnection.route(fooRoute))
+		.then(() => server.auth.strategy('default', 'oauth', 'required', server.app))
 		.then(() => server.inject(makeRequest(cookies)))
 		.then(test)
 		.then(() => server.stop());

--- a/tests/mocks.js
+++ b/tests/mocks.js
@@ -16,7 +16,9 @@ export const mockConfig = () => Promise.resolve({
 	oauth: {
 		key: random32,
 		secret: random32,
-	}
+	},
+	duotoneUrls: ['http://example.com/duotone.jpg'],
+	API_SERVER_ROOT_URL: 'http://localhost',
 });
 
 export const getMockFetch = (mockResponseValue=[{}], headers={}) =>


### PR DESCRIPTION
_This is a precursor to [WP-241](https://meetup.atlassian.net/browse/WP-241) - it makes that refactor more straightforward_

This is a change to how configuration info is passed around the application, and is intended to make it significantly simpler.

TL;DR: instead of passing config properties down through the server application manually, we can just assign the config as a property of `server.app` and read from it directly wherever we have access to `request.server` or `server`.