### PR TITLE
WP 249 Log encoded tracking data to stdout

### DIFF
--- a/src/plugins/good-meetup-tracking.js
+++ b/src/plugins/good-meetup-tracking.js
@@ -8,7 +8,6 @@ const Stream = require('stream');
 
 const internals = {
 	defaults: {
-		// in prod, make a `request` call, otherwise no-op
 		logData: data => console.log(data),
 		// currently the schema is manually copied from
 		// https://github.dev.meetup.com/meetup/meetup/blob/master/modules/base/src/main/versioned_avro/Activity_v3.avsc

--- a/src/plugins/good-meetup-tracking.js
+++ b/src/plugins/good-meetup-tracking.js
@@ -4,48 +4,45 @@
 
 const avro = require('avsc');
 const Hoek = require('hoek');
-const request = require('request');
 const Stream = require('stream');
+
+// currently the schema is manually copied from
+// https://github.dev.meetup.com/meetup/meetup/blob/master/modules/base/src/main/versioned_avro/Activity_v3.avsc
+const schemaDef = {
+	namespace: 'com.meetup.base.avro',
+	type: 'record',
+	name: 'Activity',
+	doc: 'v3',
+	fields: [
+		{ name: 'requestId', type: 'string'},
+		{ name: 'timestamp', type: 'string'},
+		{ name: 'url', type: 'string'},
+		{ name: 'aggregratedUrl', type: 'string', default: ''},  // it's misspelled in the original spec
+		{ name: 'ip', type: 'string', default: ''},
+		{ name: 'agent', type: 'string', default: ''},
+		{ name: 'memberId', type: 'int'},
+		{ name: 'trackId', type: 'string'},
+		{ name: 'mobileWeb', type: 'boolean'},
+		{ name: 'platform', type: 'string'},
+		{ name: 'referer', type: 'string'},  // it's misspelled in the original spec
+		{ name: 'trax', type: { type: 'map', values: 'string'}},
+		{
+			name: 'platformAgent',
+			type: {
+				type: 'enum',
+				name: 'PlatformAgent',
+				symbols: ['WEB', 'NATIVE', 'NATIVE_APP_WEB_VIEW', 'THIRD_PARTY_UNKNOWN', 'UNKNOWN']
+			},
+			default:'UNKNOWN'
+		}
+	]
+};
 
 const internals = {
 	defaults: {
-
-		endpoint: 'http://log.analytics.mup-prod.mup.zone/log',
 		// in prod, make a `request` call, otherwise no-op
-		postData: process.env.NODE_ENV === 'production' ?
-			request.post.bind(request) :
-			() => {},
-		// currently the schema is manually copied from
-		// https://github.dev.meetup.com/meetup/meetup/blob/master/modules/base/src/main/versioned_avro/Activity_v3.avsc
-		schema: avro.parse({
-			namespace: 'com.meetup.base.avro',
-			type: 'record',
-			name: 'Activity',
-			doc: 'v3',
-			fields: [
-				{ name: 'requestId', type: 'string'},
-				{ name: 'timestamp', type: 'string'},
-				{ name: 'url', type: 'string'},
-				{ name: 'aggregratedUrl', type: 'string', default: ''},  // it's misspelled in the original spec
-				{ name: 'ip', type: 'string', default: ''},
-				{ name: 'agent', type: 'string', default: ''},
-				{ name: 'memberId', type: 'int'},
-				{ name: 'trackId', type: 'string'},
-				{ name: 'mobileWeb', type: 'boolean'},
-				{ name: 'platform', type: 'string'},
-				{ name: 'referer', type: 'string'},  // it's misspelled in the original spec
-				{ name: 'trax', type: { type: 'map', values: 'string'}},
-				{
-					name: 'platformAgent',
-					type: {
-						type: 'enum',
-						name: 'PlatformAgent',
-						symbols: ['WEB', 'NATIVE', 'NATIVE_APP_WEB_VIEW', 'THIRD_PARTY_UNKNOWN', 'UNKNOWN']
-					},
-					default:'UNKNOWN'
-				}
-			]
-		}),
+		logData: data => console.log(data),
+		schema: avro.parse(schemaDef),
 	},
 };
 
@@ -66,22 +63,6 @@ class GoodMeetupTracking extends Stream.Transform {
 	}
 
 	/**
-	 * @param {Error|null} err error returned from failed request
-	 * @param {http.IncomingMessage} response the response object
-	 * @param {String} body the body of the response
-	 * @return {undefined} side effects only
-	 */
-	static postDataCallback(err, response, body) {
-		if (err) {
-			console.error(err);
-			return;
-		}
-		if (response && response.statusCode !== 200) {
-			console.error(`Activity track logging error: ${body}`);
-		}
-	}
-
-	/**
 	 * Receive event data and do something with it - package into avro buffer,
 	 * send it
 	 *
@@ -91,37 +72,29 @@ class GoodMeetupTracking extends Stream.Transform {
 	 * @return {Object} the output of calling the next transform in the chain
 	 */
 	_transform(event, enc, next) {
-		// log the data to stdout for Stackdriver
 		const eventData = JSON.parse(event.data);
+
+		// log readable tracking data - non-encoded
 		console.log(JSON.stringify({
 			message: 'Tracking log',
 			payload: eventData,
 		}));
 
-		const record = this._settings.schema.toBuffer(eventData);
+		const { schema, logData } = this._settings;
+
+		const record = schema.toBuffer(eventData);
 
 		const eventDate = new Date(parseInt(eventData.timestamp, 10));
-		const data = {
-			name: 'Activity',
+		const analytics = {
 			record: record.toString('base64'),
-			version: 3,
-			schemaUrl: 'gs://meetup-logs/avro_schemas/Activity_v3.avsc',
+			schemaUrl: `gs://meetup-logs/avro_schemas/${schemaDef.name}_${schemaDef.doc}.avsc`,
 			date: eventDate.toISOString().substr(0, 10),  // YYYY-MM-DD
 		};
 
-		const body = JSON.stringify(data);
-		const headers = {
-			'Content-Type': 'application/json',
-		};
+		// log encoded data that will be picked up by fluentd
+		logData(`analytics=${JSON.stringify(analytics)}`);
 
-		// format data for avro
-		this._settings.postData(
-			this._settings.endpoint,
-			{ headers, body },
-			GoodMeetupTracking.postDataCallback
-		);
-
-		return next(null, data);
+		return next(null, analytics);
 	}
 }
 

--- a/src/plugins/good-meetup-tracking.test.js
+++ b/src/plugins/good-meetup-tracking.test.js
@@ -21,13 +21,13 @@ describe('GoodMeetupTracking', () => {
 	});
 	it('transforms input into base64-encoded avro buffer', () => {
 		const config = {
-			schema: avro.parse({
+			schema: {
 				type: 'record',
 				fields: [
 					{ name: 'requestId', type: 'string' },
 					{ name: 'timestamp', type: 'string' },
 				]
-			}),
+			},
 		};
 		const tracker = new GoodMeetupTracking(config);
 		const trackInfo = { requestId: 'foo', timestamp: new Date().getTime().toString() };
@@ -37,7 +37,7 @@ describe('GoodMeetupTracking', () => {
 			val => {
 				const utf8String = new Buffer(val.record, 'base64').toString('utf-8');
 				const avroBuffer = new Buffer(utf8String);
-				const recordedInfo = tracker._settings.schema.fromBuffer(avroBuffer);
+				const recordedInfo = avro.parse(tracker._settings.schema).fromBuffer(avroBuffer);
 				expect(recordedInfo).toEqual(trackInfo);
 			}
 		);
@@ -67,7 +67,7 @@ describe('Integration with tracking logs', () => {
 			val => {
 				const utf8String = new Buffer(val.record, 'base64').toString();
 				const avroBuffer = new Buffer(utf8String);
-				const trackedInfo = tracker._settings.schema.fromBuffer(avroBuffer);
+				const trackedInfo = avro.parse(tracker._settings.schema).fromBuffer(avroBuffer);
 				const memberId = '';  // memberId integer doesn't survive the decode-encode-decode
 				const expectedTrackInfo = {
 					...trackInfo,

--- a/src/plugins/good-meetup-tracking.test.js
+++ b/src/plugins/good-meetup-tracking.test.js
@@ -16,24 +16,6 @@ const testTransform = (tracker, trackInfo, test) =>
 	.then(test);
 
 describe('GoodMeetupTracking', () => {
-	describe('static postDataCallback', () => {
-		it('logs an error when an error occurs', () => {
-			spyOn(global.console, 'error');
-			const expectedError = new Error('nope');
-			GoodMeetupTracking.postDataCallback(expectedError, null, null);
-			expect(global.console.error).toHaveBeenCalledWith(expectedError);
-		});
-		it('logs an error when response status is not 200', () => {
-			spyOn(global.console, 'error');
-			const response = {
-				statusCode: 410,
-			};
-			const body = 'Bad Test Request';
-			GoodMeetupTracking.postDataCallback(null, response, body);
-			expect(global.console.error).toHaveBeenCalled();
-		});
-	});
-
 	it('creates a transform stream', () => {
 		expect(new GoodMeetupTracking()).toEqual(jasmine.any(Stream.Transform));
 	});
@@ -98,24 +80,21 @@ describe('Integration with tracking logs', () => {
 		);
 	});
 
-	it('calls config.postData with an endpoint string and the output of the avro transform', () => {
+	it('calls config.logData with an endpoint string and the output of the avro transform', () => {
 		const config = {
 			endpoint: 'foo',
-			postData() {},
+			logData() {},
 		};
-		spyOn(config, 'postData');
+		spyOn(config, 'logData');
 		const tracker = new GoodMeetupTracking(config);
 
 		return testTransform(
 			tracker,
 			trackInfo,
 			data => {
-				const body = JSON.stringify(data);
-				const headers = {
-					'Content-Type': 'application/json',
-				};
-				expect(config.postData)
-					.toHaveBeenCalledWith(config.endpoint, { headers, body }, jasmine.any(Function));
+				const body = `analytics=${JSON.stringify(data)}`;
+				expect(config.logData)
+					.toHaveBeenCalledWith(body);
 			}
 		);
 	});


### PR DESCRIPTION
We can now simplify our tracking setup by just sending the encoded JSON to stdout, where fluentd will pick it up and send it for processing.

The actual logic changes are pretty tiny - most of the diff is just cleaning things up to make the tracking data transformation a little easier to work with.

cc @bgruber because I know you secretly think Javascript is the best programming language.