### PR TITLE
send transformed data to next transform - stdout

### DIFF
--- a/src/plugins.js
+++ b/src/plugins.js
@@ -62,7 +62,8 @@ export function getConsoleLogPlugin() {
 						}],
 					}, {
 						module: GoodMeetupTracking,
-					}
+					},
+					'stdout'
 				],
 			}
 		}

--- a/src/plugins/good-meetup-tracking.js
+++ b/src/plugins/good-meetup-tracking.js
@@ -8,7 +8,6 @@ const Stream = require('stream');
 
 const internals = {
 	defaults: {
-		logData: data => console.log(data),
 		// currently the schema is manually copied from
 		// https://github.dev.meetup.com/meetup/meetup/blob/master/modules/base/src/main/versioned_avro/Activity_v3.avsc
 		schema: {
@@ -77,7 +76,7 @@ class GoodMeetupTracking extends Stream.Transform {
 			payload: eventData,
 		}));
 
-		const { schema, logData } = this._settings;
+		const { schema } = this._settings;
 
 		const record = avro.parse(schema).toBuffer(eventData);
 
@@ -88,10 +87,8 @@ class GoodMeetupTracking extends Stream.Transform {
 			date: eventDate.toISOString().substr(0, 10),  // YYYY-MM-DD
 		};
 
-		// log encoded data that will be picked up by fluentd
-		logData(`analytics=${JSON.stringify(analytics)}`);
-
-		return next(null, analytics);
+		// send the encoded data for logging to stdout
+		return next(null, `analytics=${JSON.stringify(analytics)}`);
 	}
 }
 


### PR DESCRIPTION
The `console.log` calls from the good-meetup-tracking Stream.Transform were not appearing in production logs - it appears that `console.log` from inside a `good` Stream Transform works differently than `console.log` in other parts of the code (perhaps it's considered some sort of child process? I don't know much about Node Streams).

However, the normal way for `good` console streams to work is for them to pipe to `stdout` in the plugin config, and this output _does_ appear correctly in production logs, so this PR changes the behavior of the tracking stream to send the encoded data to `stdout`