### PR TITLE
assign better logging function based on response statusCode

### DIFF
--- a/src/util/apiUtils.js
+++ b/src/util/apiUtils.js
@@ -389,18 +389,26 @@ export const makeExternalApiRequest = request => requestOpts => {
 
 export const logApiResponse = request => ([response, body]) => {
 	const {
-		id,
-		uri: {
-			query,
-			pathname,
-			href,
+		elapsedTime,
+		request :{
+			id,
+			uri: {
+				query,
+				pathname,
+				href,
+			},
+			method,
 		},
-		method,
-	} = response.request;
+		statusCode
+	} = response;
 
 	// production logs will automatically be JSON-parsed in Stackdriver
-	console.log(JSON.stringify({
-		message: `Incoming response ${method.toUpperCase()} ${pathname}`,
+	const log = statusCode >= 400 && console.error ||
+		statusCode >= 300 && console.warn ||
+		console.log;
+
+	log(JSON.stringify({
+		message: `Incoming response ${method.toUpperCase()} ${pathname} ${response.statusCode}`,
 		type: 'response',
 		direction: 'in',
 		info: {
@@ -413,8 +421,8 @@ export const logApiResponse = request => ([response, body]) => {
 			method,
 			id,
 			originRequestId: request.id,
-			statusCode: response.statusCode,
-			time: response.elapsedTime,
+			statusCode: statusCode,
+			time: elapsedTime,
 			body: body.length > 256 ? `${body.substr(0, 256)}...`: body,
 		}
 	}));

--- a/src/util/serverUtils.js
+++ b/src/util/serverUtils.js
@@ -62,7 +62,11 @@ function onPreResponseExtension(request, reply) {
 		return reply.continue();
 	}
 
-	console.log(JSON.stringify({
+	const log = response.statusCode >= 400 && console.error ||
+		response.statusCode >= 300 && console.warn ||
+		console.log;
+
+	log(JSON.stringify({
 		message: `Outgoing response ${method.toUpperCase()} ${url.pathname} ${response.statusCode}`,
 		type: 'response',
 		direction: 'out',


### PR DESCRIPTION
Will make it much easier to see error responses (incoming from API and outgoing from server) in our logs