### PR TITLE
WP 232 catch reducer errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "react-router-redux": "4.0.8",
     "react-side-effect": "1.0.2",
     "redbox-react": "1.3.3",
-    "redux-observable": "0.12.2",
+    "redux-observable": "0.13.0",
     "request": "2.79.0",
     "source-map-support": "0.4.11",
     "tough-cookie": "2.3.2",
@@ -63,7 +63,7 @@
     "react-redux": "^5.0.3",
     "react-router": "^3.0.2",
     "redux": "^3.5.2",
-    "rxjs": "^5.0.3"
+    "rxjs": "^5.2.0"
   },
   "devDependencies": {
     "babel-cli": "6.22.2",
@@ -85,7 +85,7 @@
     "react-redux": "5.0.3",
     "react-router": "3.0.2",
     "redux": "3.5.2",
-    "rxjs": "5.0.3",
+    "rxjs": "5.2.0",
     "tough-cookie": "2.3.2"
   }
 }

--- a/src/middleware/catch.js
+++ b/src/middleware/catch.js
@@ -5,7 +5,7 @@
  */
 const catchMiddleware = store => next => action => {
 	try {
-		next(action);
+		return next(action);
 	} catch(err) {
 		console.error(JSON.stringify({
 			err: err.stack,

--- a/src/middleware/catch.js
+++ b/src/middleware/catch.js
@@ -7,7 +7,13 @@ const catchMiddleware = store => next => action => {
 	try {
 		next(action);
 	} catch(err) {
-		console.error(err);
+		console.error(JSON.stringify({
+			err: err.stack,
+			message: `Catch middleware - runtime error ${err.message}`,
+			info: {
+				action,
+			},
+		}));
 		return err;
 	}
 };

--- a/src/middleware/catch.js
+++ b/src/middleware/catch.js
@@ -1,0 +1,16 @@
+/**
+ * @param {Object} store Redux store
+ * @return {Function} the function that handles calling the next middleware
+ *   with each action
+ */
+const catchMiddleware = store => next => action => {
+	try {
+		next(action);
+	} catch(err) {
+		console.error(err);
+		return err;
+	}
+};
+
+export default catchMiddleware;
+

--- a/src/middleware/catch.test.js
+++ b/src/middleware/catch.test.js
@@ -1,0 +1,14 @@
+import catchMiddleware from './catch';
+
+describe('catchMiddleware', () => {
+	it('logs an error when the `next` function throws an error', () => {
+		spyOn(console, 'error');
+
+		const theError = new Error('bad news');
+		const errorThrower = () => { throw theError; };
+		const receivedError = catchMiddleware()(errorThrower)({});
+		expect(console.error).toHaveBeenCalled();
+		expect(receivedError).toBe(theError);
+	});
+});
+

--- a/src/middleware/catch.test.js
+++ b/src/middleware/catch.test.js
@@ -10,5 +10,14 @@ describe('catchMiddleware', () => {
 		expect(console.error).toHaveBeenCalled();
 		expect(receivedError).toBe(theError);
 	});
+	it('does nothing when the store operates normally (no errors)', () => {
+		spyOn(console, 'error');
+
+		const action = { foo: 'bar' };
+		const next = x => x;
+		const receivedError = catchMiddleware()(next)(action);
+		expect(console.error).not.toHaveBeenCalled();
+		expect(receivedError).toBe(next(action));
+	});
 });
 

--- a/src/util/createStoreBrowser.js
+++ b/src/util/createStoreBrowser.js
@@ -2,7 +2,8 @@ import { applyMiddleware, createStore, compose } from 'redux';
 
 import { fetchQueries } from '../util/fetchUtils';
 import getClickTracker from './clickTracking';
-import getPlatformMiddleware from '../middleware/epic';
+import getEpicMiddleware from '../middleware/epic';
+import catchMiddleware from '../middleware/catch';
 
 
 const noopMiddleware = store => next => action => next(action);
@@ -21,7 +22,8 @@ export function getBrowserCreateStore(
 	middleware=[]
 ) {
 	const middlewareToApply = [
-		getPlatformMiddleware(routes, fetchQueries),
+		catchMiddleware,
+		getEpicMiddleware(routes, fetchQueries),
 		...middleware,
 		window.mupDevTools ? window.mupDevTools() : noopMiddleware,  // must be last middleware
 	];

--- a/src/util/createStoreServer.js
+++ b/src/util/createStoreServer.js
@@ -1,6 +1,7 @@
 import { applyMiddleware, createStore } from 'redux';
 import { parseQueryResponse } from './fetchUtils';
-import getPlatformMiddleware from '../middleware/epic';
+import getEpicMiddleware from '../middleware/epic';
+import catchMiddleware from '../middleware/catch';
 import apiProxy$ from '../apiProxy/api-proxy';
 
 /**
@@ -26,22 +27,14 @@ export const serverFetchQueries = request => () => queries =>
  * @param {Array} middleware additional middleware to inject into store
  * @param {Object} request the Hapi request for this store
  */
-export function getPlatformMiddlewareEnhancer(routes, middleware, fetchQueriesFn) {
-	// **All** middleware gets added here
-	const middlewareToApply = [
-		getPlatformMiddleware(routes, fetchQueriesFn),
-		...middleware,
-	];
-	return applyMiddleware(...middlewareToApply);
-}
-
 export function getServerCreateStore(
 	routes,
 	middleware,
 	request
 ) {
 	const middlewareToApply = [
-		getPlatformMiddleware(routes, serverFetchQueries(request)),
+		catchMiddleware,
+		getEpicMiddleware(routes, serverFetchQueries(request)),
 		...middleware,
 	];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3361,9 +3361,9 @@ redbox-react@1.3.3:
     error-stack-parser "^1.3.6"
     object-assign "^4.0.1"
 
-redux-observable@0.12.2:
-  version "0.12.2"
-  resolved "https://registry.yarnpkg.com/redux-observable/-/redux-observable-0.12.2.tgz#4bc1657c7eedace577e114b74ffe6f6fb2b36ccf"
+redux-observable@0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/redux-observable/-/redux-observable-0.13.0.tgz#35b26c2cdbb71e499b31ca9961da0581c2973909"
 
 redux@3.5.2:
   version "3.5.2"
@@ -3522,6 +3522,12 @@ rx-lite@^3.1.2:
 rxjs@5.0.3:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.0.3.tgz#fc8bdf464ebf938812748e4196788f392fef9754"
+  dependencies:
+    symbol-observable "^1.0.1"
+
+rxjs@5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.2.0.tgz#db537de8767c05fa73721587a29e0085307d318b"
   dependencies:
     symbol-observable "^1.0.1"
 


### PR DESCRIPTION
Platform apps currently fail silently when a reducer throws an error. Reducer errors are _always_ dev errors, so we need to catch and log them. This middleware based on https://github.com/PlatziDev/redux-catch will catch and log the errors which letting the rest of the application to continue operating normally.