### PR TITLE
WP-256 Set both CSRF cookies from server

### DIFF
--- a/src/plugins.js
+++ b/src/plugins.js
@@ -21,11 +21,16 @@ export function getCsrfPlugin(secret) {
 	const register = (server, options, next) => {
 		const cookieOptions = {
 			path: '/',
-			isHttpOnly: true,
 			isSecure: process.env.NODE_ENV === 'production',
 		};
-		server.state('x-csrf-jwt', cookieOptions);  // set by plugin
-		server.state('x-csrf-jwt-header', cookieOptions);  // set by onPreResponse
+		server.state('x-csrf-jwt', {
+			...cookieOptions,
+			isHttpOnly: true,
+		});  // set by plugin
+		server.state('x-csrf-jwt-header', {
+			...cookieOptions,
+			isHttpOnly: false,
+		});  // set by onPreResponse
 		const registration = CsrfPlugin.register(server, options, next);
 		server.ext('onPreResponse', setCsrfCookies);  // must add this extension _after_ plugin is registered
 		return registration;

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -17,22 +17,39 @@ export function setCsrfCookies(request, reply) {
 	return reply.continue();
 }
 
+/**
+ * The CSRF plugin we use - 'electrode-csrf-jwt' compares a cookie token to a
+ * header token in non-GET requests. By default, it will set the cookie token
+ * itself ('x-csrf-jwt'), and supply the corresponding header token in a custom
+ * header (also 'x-csrf-jwt'). However, we update this flow to also supply the
+ * header token as a cookie ('x-csrf-jwt-header') so that it syncs across
+ * browser tabs.
+ *
+ * In order to ensure that both cookie values have parallel settings, this
+ * function calls `server.state` for both cookie names before registering the
+ * plugin.
+ *
+ * @param {String} secret the 'salt' for encoding the CSRF tokens
+ * @return {Object} the { register, options } object for a `server.register` call.
+ */
 export function getCsrfPlugin(secret) {
 	const register = (server, options, next) => {
 		const cookieOptions = {
 			path: '/',
 			isSecure: process.env.NODE_ENV === 'production',
 		};
-		server.state('x-csrf-jwt', {
-			...cookieOptions,
-			isHttpOnly: true,
-		});  // set by plugin
-		server.state('x-csrf-jwt-header', {
-			...cookieOptions,
-			isHttpOnly: false,
-		});  // set by onPreResponse
+		server.state(
+			'x-csrf-jwt',  // set by plugin
+			{ ...cookieOptions, isHttpOnly: true }  // no client-side interaction needed
+		);
+		server.state(
+			'x-csrf-jwt-header',  // set by onPreResponse
+			{ ...cookieOptions, isHttpOnly: false } // the client must read this cookie and return as a custom header
+		);
+
 		const registration = CsrfPlugin.register(server, options, next);
-		server.ext('onPreResponse', setCsrfCookies);  // must add this extension _after_ plugin is registered
+		server.ext('onPreResponse', setCsrfCookies);  // this extension must be registered _after_ plugin is registered
+
 		return registration;
 	};
 	register.attributes = CsrfPlugin.register.attributes;

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -26,8 +26,9 @@ export function getCsrfPlugin(secret) {
 		};
 		server.state('x-csrf-jwt', cookieOptions);  // set by plugin
 		server.state('x-csrf-jwt-header', cookieOptions);  // set by onPreResponse
-		server.ext('onPreResponse', setCsrfCookies);
-		return CsrfPlugin.register(server, options, next);
+		const registration = CsrfPlugin.register(server, options, next);
+		server.ext('onPreResponse', setCsrfCookies);  // must add this extension _after_ plugin is registered
+		return registration;
 	};
 	register.attributes = CsrfPlugin.register.attributes;
 	return {

--- a/src/routes/appRoute.js
+++ b/src/routes/appRoute.js
@@ -51,6 +51,11 @@ const getApplicationRoute = renderRequestMap => ({
 		ext: {
 			onPreResponse,
 		},
+		plugins: {
+			'electrode-csrf-jwt': {
+				enabled: true,  // need to generate tokens on page request
+			}
+		},
 		state: {
 			failAction: 'ignore',  // ignore cookie validation, just accept
 		}

--- a/src/util/fetchUtils.js
+++ b/src/util/fetchUtils.js
@@ -5,8 +5,8 @@ import cookie from 'cookie';
  * @module fetchUtils
  */
 
-const CSRF_HEADER = 'x-csrf-jwt';
-const CSRF_HEADER_COOKIE = 'x-csrf-header';
+export const CSRF_HEADER = 'x-csrf-jwt';
+export const CSRF_HEADER_COOKIE = 'x-csrf-jwt-header';
 
 export const parseQueryResponse = queries => ({ responses, error, message }) => {
 	if (error) {
@@ -17,13 +17,6 @@ export const parseQueryResponse = queries => ({ responses, error, message }) => 
 		responses: responses || [],
 	};
 };
-
-function setCsrf(csrfHeader) {
-	if (csrfHeader) {
-		// set cookie with header value - this ensures all open tabs share the CSRF
-		BrowserCookies.set(CSRF_HEADER_COOKIE, csrfHeader);
-	}
-}
 
 /**
  * Wrapper around `fetch` to send an array of queries to the server. It ensures
@@ -82,10 +75,7 @@ export const fetchQueries = (apiUrl, options) => (queries, meta) => {
 		isPost ? apiUrl : fetchUrl.toString(),
 		fetchConfig
 	)
-	.then(queryResponse => {
-		setCsrf(queryResponse.headers.get(CSRF_HEADER));
-		return queryResponse.json();
-	})
+	.then(queryResponse => queryResponse.json())
 	.then(queryJSON => ({
 		...parseQueryResponse(queries)(queryJSON),
 	}))

--- a/src/util/fetchUtils.test.js
+++ b/src/util/fetchUtils.test.js
@@ -17,7 +17,7 @@ describe('fetchQueries', () => {
 	const queries = [mockQuery({})];
 	const meta = { foo: 'bar' };
 	const responses = [MOCK_GROUP];
-	const csrfJwt = 'x-csrf-header value';
+	const csrfJwt = `${fetchUtils.CSRF_HEADER_COOKIE} value`;
 	const fakeSuccess = () =>
 		Promise.resolve({
 			json: () => Promise.resolve(responses),

--- a/src/util/serverUtils.js
+++ b/src/util/serverUtils.js
@@ -3,6 +3,40 @@ import Hapi from 'hapi';
 
 import track from './tracking';
 
+/**
+ * determine whether a nested object of values contains a string that contains
+ * `.dev.meetup.`
+ * @param {String|Object} value string or nested object with
+ * values that could be URL strings
+ * @return {Boolean} whether the `value` contains a 'dev' URL string
+ */
+export function checkForDevUrl(value) {
+	switch(typeof value) {
+	case 'string':
+		return value.indexOf('.dev.meetup.') > -1;
+	case 'object':
+		return Object.keys(value).some(key => checkForDevUrl(value[key]));
+	}
+	return false;
+}
+
+export function onRequestExtension(request, reply) {
+	console.log(JSON.stringify({
+		message: `Incoming request ${request.method.toUpperCase()} ${request.url.href}`,
+		type: 'request',
+		direction: 'in',
+		info: {
+			url: request.url,
+			method: request.method,
+			headers: request.headers,
+			id: request.id,
+			referrer: request.info.referrer,
+			remoteAddress: request.info.remoteAddress,
+		}
+	}));
+	return reply.continue();
+}
+
 export function logResponse(request) {
 	const {
 		headers,
@@ -48,40 +82,6 @@ export function logResponse(request) {
 	}));
 
 	return;
-}
-
-/**
- * determine whether a nested object of values contains a string that contains
- * `.dev.meetup.`
- * @param {String|Object} value string or nested object with
- * values that could be URL strings
- * @return {Boolean} whether the `value` contains a 'dev' URL string
- */
-export function checkForDevUrl(value) {
-	switch(typeof value) {
-	case 'string':
-		return value.indexOf('.dev.meetup.') > -1;
-	case 'object':
-		return Object.keys(value).some(key => checkForDevUrl(value[key]));
-	}
-	return false;
-}
-
-export function onRequestExtension(request, reply) {
-	console.log(JSON.stringify({
-		message: `Incoming request ${request.method.toUpperCase()} ${request.url.href}`,
-		type: 'request',
-		direction: 'in',
-		info: {
-			url: request.url,
-			method: request.method,
-			headers: request.headers,
-			id: request.id,
-			referrer: request.info.referrer,
-			remoteAddress: request.info.remoteAddress,
-		}
-	}));
-	return reply.continue();
 }
 
 /**

--- a/src/util/serverUtils.test.js
+++ b/src/util/serverUtils.test.js
@@ -62,7 +62,27 @@ describe('onRequestExtension', () => {
 		spyOn(global.console, 'log');
 		serverUtils.onRequestExtension(request, reply);
 		const calledWith = console.log.calls.mostRecent().args[0];
-		expect(JSON.parse(calledWith).info.headers).toBe(request.headers);
+		expect(JSON.parse(calledWith).info.headers).toEqual(request.headers);
+		expect(JSON.parse(calledWith).info.id).toBe(request.id);
+	});
+});
+
+describe('logResponse', () => {
+	const request = {
+		headers: 'foo',
+		id: 'bar',
+		method: 'get',
+		info: {},
+		url: {},
+		response: {
+			headers: { foo: 'bar' },
+		},
+	};
+	it('calls console.log with response headers and request id', () => {
+		spyOn(global.console, 'log');
+		serverUtils.logResponse(request);
+		const calledWith = console.log.calls.mostRecent().args[0];
+		expect(JSON.parse(calledWith).info.headers).toEqual(request.response.headers);
 		expect(JSON.parse(calledWith).info.id).toBe(request.id);
 	});
 });

--- a/tests/integration/render.int.js
+++ b/tests/integration/render.int.js
@@ -1,5 +1,4 @@
 import {
-	getMockFetch,
 	getMockRenderRequestMap,
 	mockConfig,
 } from '../mocks';
@@ -28,7 +27,6 @@ const expectedOutputMessage = 'Looking good';
 
 describe('Full dummy app render', () => {
 	it('calls the handler for /{*wild}', () => {
-		spyOn(global, 'fetch').and.returnValue(getMockFetch());
 		return start(getMockRenderRequestMap(), {}, mockConfig)
 			.then(server => {
 				const request = {
@@ -37,7 +35,12 @@ describe('Full dummy app render', () => {
 					credentials: 'whatever',
 				};
 				return server.inject(request).then(
-					response => expect(response.payload).toContain(expectedOutputMessage)
+					response => {
+						expect(response.payload).toContain(expectedOutputMessage);
+						expect(
+							response.headers['set-cookie'].find(h => h.startsWith('x-csrf-jwt-header'))
+						).not.toBeUndefined();
+					}
 				)
 				.then(() => server.stop())
 				.catch(err => {


### PR DESCRIPTION
There's not really a good reason to require the client to set the `x-csrf-header` cookie - the server can use its 'set-cookie' header to take care of that.

The benefit of letting the server take care of it is

1. Easier to unit test because it doesn't rely on browser-dependent cookie-setting calls
2. the cookie can be set from the initial page load rather than waiting for an API request to return.

Blocker for #167 