### PR TITLE
WP 260 parse Link header

### DIFF
--- a/src/util/apiUtils.js
+++ b/src/util/apiUtils.js
@@ -87,9 +87,19 @@ export const parseMetaHeaders = headers => {
 		return meta;
 	}, {});
 
+	const linkHeader = headers.link && headers.link.split(',')
+		.reduce((links, link) => {
+			const [urlString, relString] = link.split(';');
+			const url = urlString.replace(/<|>/g, '').trim();
+			var rel = relString.replace(/rel="([^"]+)"/, '$1').trim();
+			links[rel] = url;
+			return links;
+		}, {});
+
 	return {
 		...meetupHeaders,
 		...xHeaders,
+		link: linkHeader || undefined,
 	};
 };
 

--- a/src/util/apiUtils.test.js
+++ b/src/util/apiUtils.test.js
@@ -224,15 +224,30 @@ describe('parseLoginAuth', () => {
 describe('parseMetaHeaders', () => {
 	it('returns x-meetup-flags as flags object with real booleans camelcased', () => {
 		expect(parseMetaHeaders({ 'x-meetup-foo-bar': 'whatwhat' }))
-			.toEqual({ fooBar: 'whatwhat' });
+			.toMatchObject({ fooBar: 'whatwhat' });
 	});
 	it('returns x-meetup-flags as flags object with real booleans', () => {
 		expect(parseMetaHeaders({ 'x-meetup-flags': 'foo=true,bar=false' }))
-			.toEqual({ flags: { foo: true, bar: false } });
+			.toMatchObject({ flags: { foo: true, bar: false } });
 	});
 	it('parses specified x- headers', () => {
 		expect(parseMetaHeaders({ 'x-total-count': 'whatwhat' }))
-			.toEqual({ totalCount: 'whatwhat' });
+			.toMatchObject({ totalCount: 'whatwhat' });
+	});
+	it('parses Link header', () => {
+		const next = 'http://example.com/next';
+		const prev = 'http://example.com/prev';
+
+		// both 'next' and 'prev'
+		expect(parseMetaHeaders({ link: `<${next}>; rel="next", <${prev}>; rel="prev"` }))
+			.toMatchObject({ link: { next, prev } });
+		// just 'next'
+		expect(parseMetaHeaders({ link: `<${next}>; rel="next"` }))
+			.toMatchObject({ link: { next } });
+	});
+	it('returns empty object for empty headers', () => {
+		expect(parseMetaHeaders({}))
+			.toEqual({});
 	});
 });
 


### PR DESCRIPTION
The Link header contains all the info we need for paged API requests - just need to parse and store it in the query response object.