### PR TITLE
defer dispatching click action until after all other event listeners are done

### DIFF
--- a/src/util/clickTracking.js
+++ b/src/util/clickTracking.js
@@ -136,8 +136,9 @@ function getTrackClick(store) {
 			data: data
 		});
 
-		// 3. dispatch the action
-		store.dispatch(clickTrackAction);
+		// 3. dispatch the action - must be deferred until after click event has
+		//    been processed by all other listeners
+		setTimeout(() => store.dispatch(clickTrackAction), 0);
 
 		return clickTrackAction;
 	}


### PR DESCRIPTION
This fixes a bug that Jason was seeing with checkboxes, which wouldn't update because the click tracker was re-rendering the application in it's "pre-clicked" state before the checkbox click handler could be called. Silly.