### PR TITLE
Duotones - Fix values

### DIFF
--- a/src/util/apiUtils.js
+++ b/src/util/apiUtils.js
@@ -308,7 +308,7 @@ export function parseRequest(request) {
  * @return {Object} the mutated group object
  */
 export const groupDuotoneSetter = duotoneUrls => group => {
-	const photo = group.key_photo || group.group_photo || {};
+	const photo = group.key_photo || {};
 	const duotoneKey = group.photo_gradient && duotoneRef(
 			group.photo_gradient.light_color,
 			group.photo_gradient.dark_color

--- a/src/util/duotone.js
+++ b/src/util/duotone.js
@@ -22,11 +22,11 @@ export function duotoneRef(light, dark) {
 const HYPERCOLOR = ['ff7900', '7700c8'];
 const SIZZURP = ['48ffcb', '8a00eb'];
 const JUNIOR_VARSITY = ['ffc600', '2737ff'];
-const MIGHTY_DUCKS = ['00d8ff', 'fa002f'];
+const MIGHTY_DUCKS = ['00a8ff', 'fa002f'];
 const MERMAID = ['36c200', '002fff'];
-const GINGER_BEER = ['ffde00', '55005a'];
+const GINGER_BEER = ['ffae00', 'ff005a'];
 const BUBBLICIOUS = ['ff646a', '000ddf'];
-const LEMON_LIME = ['fed239', '36c200'];
+const LEMON_LIME = ['bdb202', '24a601'];
 
 /**
  * Supported duotone color pairs (hex)


### PR DESCRIPTION
#### Description 🔵🔴
This PR updates the duotone values because they didn't match the db table. For some reason, they were updated in the database and not in our documentation. The duotone table:
![screen shot 2017-03-24 at 6 19 09 pm](https://cloud.githubusercontent.com/assets/2153230/24315851/17cf83f4-10c0-11e7-8d24-b75b49f50f08.png)

Please doublecheck these new values are right. Hex codes are hard to read some times.

Additionally, this PR removes the `group_photo` from being duotone'd. The group photo shouldn't be shown in duotone colors, just the key photo.
