### PR TITLE
Click tracking unit + integration tests, only run after cookies have been parsed

### DIFF
--- a/src/util/clickTrackingReader.js
+++ b/src/util/clickTrackingReader.js
@@ -31,7 +31,7 @@ export default function processClickTracking(request, reply) {
 			request.log(['click'], JSON.stringify(clickRecord))
 		);
 
-	reply.unstate('click-track');
+	reply.unstate('click-track', { isSecure: process.env.NODE_ENV === 'production' });
 	return;
 }
 

--- a/src/util/clickTrackingReader.js
+++ b/src/util/clickTrackingReader.js
@@ -20,7 +20,7 @@ export default function processClickTracking(request, reply) {
 		return;
 	}
 
-	const cookieJSON = decodeURIComponent(event.data);
+	const cookieJSON = decodeURIComponent(cookieValue);
 	const { history } = JSON.parse(cookieJSON);
 
 	// avro-encode value

--- a/src/util/clickTrackingReader.test.js
+++ b/src/util/clickTrackingReader.test.js
@@ -22,7 +22,11 @@ describe('processClickTracking', () => {
 	it('calls reply.unstate for click-track cookie', () => {
 		reply.unstate.mockClear();
 		processClickTracking(request, reply);
-		expect(reply.unstate).toHaveBeenCalledWith('click-track');
+		expect(reply.unstate)
+			.toHaveBeenCalledWith(
+				'click-track',
+				{ isSecure: process.env.NODE_ENV === 'production' }
+			);
 	});
 });
 

--- a/src/util/clickTrackingReader.test.js
+++ b/src/util/clickTrackingReader.test.js
@@ -1,0 +1,28 @@
+import processClickTracking from './clickTrackingReader';
+
+describe('processClickTracking', () => {
+	const clickData = {
+		history: [{ coords: [1, 2] }, { coords: [1, 2] }],
+	};
+	const request = {
+		state: {
+			'click-track': encodeURIComponent(JSON.stringify(clickData)),
+		},
+		log: jest.fn(),
+	};
+	const reply = {
+		unstate: jest.fn(),
+	};
+
+	it('calls request.log for each click record', () => {
+		request.log.mockClear();
+		processClickTracking(request, reply);
+		expect(request.log).toHaveBeenCalledTimes(clickData.history.length);
+	});
+	it('calls reply.unstate for click-track cookie', () => {
+		reply.unstate.mockClear();
+		processClickTracking(request, reply);
+		expect(reply.unstate).toHaveBeenCalledWith('click-track');
+	});
+});
+

--- a/src/util/serverUtils.js
+++ b/src/util/serverUtils.js
@@ -39,6 +39,10 @@ export function onRequestExtension(request, reply) {
 		}
 	}));
 
+	return reply.continue();
+}
+
+export function onPreHandlerExtension(request, reply) {
 	clickTrackingReader(request, reply);
 	return reply.continue();
 }
@@ -92,6 +96,7 @@ export function logResponse(request) {
 
 /**
  * Use server.ext to add functions to request/server extension points
+ * @see {@link https://hapijs.com/api#request-lifecycle}
  * @param {Object} server Hapi server
  * @return {Object} Hapi server
  */
@@ -99,6 +104,9 @@ export function registerExtensionEvents(server) {
 	server.ext([{
 		type: 'onRequest',
 		method: onRequestExtension,
+	}, {
+		type: 'onPreHandler',
+		method: onPreHandlerExtension,
 	}]);
 	server.on('response', logResponse);
 	return server;


### PR DESCRIPTION
some cookie tracking cleanup and tests that should have been part of #220 to flag an error