### PR TITLE
always call apiSuccess or apiError for posts and deletes

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,11 +225,14 @@ http://localhost:8000/ny-tech/?__nocache
 `POST` API requests are handled by `PostMiddleware`, which provides a generalized
 interface for sending data to the API and handling return values. The middleware
 only responds to actions that have a `POST_` prefix or a `_POST` suffix in the
-action `type`. Furthermore, the `action.payload` must have a Query object (with
-a `type`, `ref`, and `params`) as well as `onSuccess` and `onError` actionCreators
-to receive the data response from the API - they _must_ be actionCreators because
-their return values will be `dispatch`ed by the middleware in the API success/error
-case.
+action `type`.
+
+The `action.payload` must have a `query` property containing a Query object (with
+a `type`, `ref`, and `params`). Optionally, it may supply `onSuccess` and/or
+`onError` properties, which must be actionCreator functions that will be called
+in addition to `apiSuccess` and `apiError`, respectively. The `onSuccess` and
+`onError` action creators will receive the same arguments as `apiSuccess`
+(`{ queries, responses }`) and `apiError` (`err`). 
 
 Use reducers to parse the response and update application state.
 

--- a/src/epics/delete.js
+++ b/src/epics/delete.js
@@ -1,6 +1,7 @@
 import Rx from 'rxjs';
 import {
-	apiSuccess
+	apiSuccess,
+	apiError,
 } from '../actions/syncActionCreators';
 /**
  * DeleteEpic provides a generic interface for triggering DELETE requests and
@@ -55,14 +56,21 @@ const getDeleteQueryFetch = (fetchQueries, store) =>
  */
 const doDelete$ = fetchDeleteQuery => ({ query, onSuccess, onError }) =>
 	Rx.Observable.fromPromise(fetchDeleteQuery(query))  // make the fetch call
-		.flatMap(responses =>
-			// success! return API_SUCCESS and whatever the DELETE action wants to do onSuccess
-			Rx.Observable.of(
-				apiSuccess(responses),
-				onSuccess && onSuccess(responses)
-			)
-		)
-		.catch(err => Rx.Observable.of(onError(err)));
+		.flatMap(responses => {
+			// success! return API_SUCCESS and whatever the POST action wants to do onSuccess
+			const actions = [apiSuccess(responses)];
+			if (onSuccess) {
+				actions.push(onSuccess(responses));
+			}
+			return Rx.Observable.from(actions);
+		})
+		.catch(err => {
+			const actions = [apiError(err)];
+			if (onError) {
+				actions.push(onError(err));
+			}
+			return Rx.Observable.from(actions);
+		});
 
 const getDeleteEpic = fetchQueries => (action$, store) =>
 	action$.filter(({ type }) => type.endsWith('_DELETE') || type.startsWith('DELETE_'))

--- a/src/epics/delete.test.js
+++ b/src/epics/delete.test.js
@@ -51,6 +51,17 @@ describe('getDeleteEpic', () => {
 				expect(syncActionCreators.apiSuccess).toHaveBeenCalledWith(response);
 			});
 	});
+	it('Returns error from fetchQueries as argument to API_ERROR', function() {
+		const err = new Error('boo');
+		spyOn(fetchUtils, 'fetchQueries').and.callFake(() => () => Promise.reject(err));
+		spyOn(syncActionCreators, 'apiError');
+		// The promises resolve async, but resolution is not accessible to test, so
+		// we use a setTimeout to make sure execution has completed
+		const action$ = ActionsObservable.of(MOCK_DELETE_ACTION);
+		return getDeleteEpic(fetchUtils.fetchQueries)(action$, store)
+			.do(() => expect(syncActionCreators.apiError).toHaveBeenCalledWith(err))
+			.toPromise();
+	});
 	it('Returns response from fetchqueries as argument to API_SUCCESS and action\'s onSuccess', function() {
 		const response = 'success';
 		fetchUtils.fetchQueries = jest.fn(() => () => Promise.resolve(response));

--- a/src/epics/post.test.js
+++ b/src/epics/post.test.js
@@ -51,6 +51,17 @@ describe('getPostEpic', () => {
 				expect(syncActionCreators.apiSuccess).toHaveBeenCalledWith(response);
 			});
 	});
+	it('Returns error from fetchQueries as argument to API_ERROR', function() {
+		const err = new Error('boo');
+		spyOn(fetchUtils, 'fetchQueries').and.callFake(() => () => Promise.reject(err));
+		spyOn(syncActionCreators, 'apiError');
+		// The promises resolve async, but resolution is not accessible to test, so
+		// we use a setTimeout to make sure execution has completed
+		const action$ = ActionsObservable.of(MOCK_POST_ACTION);
+		return getPostEpic(fetchUtils.fetchQueries)(action$, store)
+			.do(() => expect(syncActionCreators.apiError).toHaveBeenCalledWith(err))
+			.toPromise();
+	});
 	it('Returns response from fetchqueries as argument to API_SUCCESS and action\'s onSuccess', function() {
 		const response = 'success';
 		fetchUtils.fetchQueries = jest.fn(() => () => Promise.resolve(response));


### PR DESCRIPTION
`onSuccess` and `onError` handlers for _POST and _DELETE actions are now truly optional - redundant `apiSuccess`/`apiError` calls can be avoided