### PR TITLE
WP 285 lang path fixes

### DIFF
--- a/src/epics/sync.js
+++ b/src/epics/sync.js
@@ -36,8 +36,8 @@ const logoutQueryMatch = /[?&]logout(?:[=&]|$)/;
  * @param {Object} routes The application's React Router routes
  * @returns {Function} an Epic function that emits an API_REQUEST action
  */
-export const getNavEpic = routes => {
-	const findActiveQueries = activeRouteQueries(routes);
+export const getNavEpic = (routes, baseUrl) => {
+	const findActiveQueries = activeRouteQueries(routes, baseUrl);
 	let currentLocation = {};  // keep track of current route so that apiRequest can get 'referrer'
 	return (action$, store) =>
 		action$.ofType(LOCATION_CHANGE, '@@server/RENDER')
@@ -96,9 +96,9 @@ export const getFetchQueriesEpic = fetchQueriesFn => (action$, store) =>
 				.catch(err => Observable.of(apiError(err)));  // ... or apiError
 		});
 
-export default function getSyncEpic(routes, fetchQueries) {
+export default function getSyncEpic(routes, fetchQueries, baseUrl) {
 	return combineEpics(
-		getNavEpic(routes),
+		getNavEpic(routes, baseUrl),
 		// locationSyncEpic,
 		getFetchQueriesEpic(fetchQueries)
 	);

--- a/src/middleware/epic.js
+++ b/src/middleware/epic.js
@@ -15,9 +15,9 @@ import getDeleteEpic from '../epics/delete';
  * order to render the application. We may want to write a server-specific
  * middleware that doesn't include the other epics if performance is an issue
  */
-const getPlatformMiddleware = (routes, fetchQueries) => createEpicMiddleware(
+const getPlatformMiddleware = (routes, fetchQueries, baseUrl) => createEpicMiddleware(
 	combineEpics(
-		getSyncEpic(routes, fetchQueries),
+		getSyncEpic(routes, fetchQueries, baseUrl),
 		getCacheEpic(),
 		getPostEpic(fetchQueries),
 		getDeleteEpic(fetchQueries)

--- a/src/renderers/browser-render.jsx
+++ b/src/renderers/browser-render.jsx
@@ -29,7 +29,7 @@ function makeRenderer(routes, reducer, middleware=[], baseUrl='') {
 	escape.innerHTML = window.APP_RUNTIME.escapedState;
 	const unescapedStateJSON = escape.textContent;
 	const initialState = JSON.parse(unescapedStateJSON);
-	const createStore = getBrowserCreateStore(routes, middleware);
+	const createStore = getBrowserCreateStore(routes, middleware, baseUrl);
 	const store = createStore(reducer, initialState);
 
 	return (rootElId='outlet') => {

--- a/src/renderers/server-render.jsx
+++ b/src/renderers/server-render.jsx
@@ -161,7 +161,7 @@ const makeRenderer = (
 
 	// create the store
 	const initialState = {};
-	const createStore = getServerCreateStore(routes, middleware, request);
+	const createStore = getServerCreateStore(routes, middleware, request, baseUrl);
 	const store = createStore(reducer, initialState);
 
 	// load initial config

--- a/src/util/createStoreBrowser.js
+++ b/src/util/createStoreBrowser.js
@@ -19,11 +19,12 @@ export const clickTrackEnhancer = createStore => (reducer, initialState, enhance
 
 export function getBrowserCreateStore(
 	routes,
-	middleware=[]
+	middleware=[],
+	baseUrl
 ) {
 	const middlewareToApply = [
 		catchMiddleware,
-		getEpicMiddleware(routes, fetchQueries),
+		getEpicMiddleware(routes, fetchQueries, baseUrl),
 		...middleware,
 		window.mupDevTools ? window.mupDevTools() : noopMiddleware,  // must be last middleware
 	];

--- a/src/util/createStoreServer.js
+++ b/src/util/createStoreServer.js
@@ -30,11 +30,12 @@ export const serverFetchQueries = request => () => queries =>
 export function getServerCreateStore(
 	routes,
 	middleware,
-	request
+	request,
+	baseUrl
 ) {
 	const middlewareToApply = [
 		catchMiddleware,
-		getEpicMiddleware(routes, serverFetchQueries(request)),
+		getEpicMiddleware(routes, serverFetchQueries(request), baseUrl),
 		...middleware,
 	];
 

--- a/src/util/routeUtils.js
+++ b/src/util/routeUtils.js
@@ -81,7 +81,7 @@ export const matchedRouteQueriesReducer = location => (queries, { route, match }
  * @param {String} url the current URL path
  * @return {Array} the queries attached to the active routes
  */
-export const activeRouteQueries = routes => location =>
-	matchRoutes(routes, location.pathname)
+export const activeRouteQueries = (routes, baseUrl) => location =>
+	matchRoutes(routes, location.pathname.replace(baseUrl, ''))
 		.reduce(matchedRouteQueriesReducer(location), []);
 

--- a/src/util/routeUtils.test.js
+++ b/src/util/routeUtils.test.js
@@ -43,6 +43,15 @@ describe('activeRouteQueries', () => {
 		const receivedQueries = activeRouteQueries(routes)(location);
 		expect(receivedQueries.map(({ params }) => params)).toEqual(expectedParams);
 	});
+	it('passes all parsed url params into query when provided baseUrl', () => {
+		const baseUrl = '/fr-FR';
+		const param1 = 'param1value';
+		const param2 = 'param2value';
+		const location = url.parse(`${baseUrl}/${param1}/${param2}`);
+		const expectedParams = [ {}, { param1 }, { param1, param2 } ];
+		const receivedQueries = activeRouteQueries(routes, baseUrl)(location);
+		expect(receivedQueries.map(({ params }) => params)).toEqual(expectedParams);
+	});
 	it('matches utf-8 urls', () => {
 		const param1 = '驚くばかり';
 		const location = url.parse(`/${param1}`);


### PR DESCRIPTION
see https://meetup.atlassian.net/browse/WP-285

The new route-matching tool was not accounting for language-prefix 'baseUrl' configuration, which resulted in the language prefix being used as the `:urlname` parameter under certain conditions. This PR threads the `baseUrl` setting through

1. renderers - server and browser
2. createStore functions - server and browser
3. epic middleware
4. sync epic
5. `routeUtils.activeRouteQueries`