### PR TITLE
remove 'options' from fetchQueries call

### DIFF
--- a/src/epics/delete.js
+++ b/src/epics/delete.js
@@ -41,8 +41,10 @@ import {
  */
 const getDeleteQueryFetch = (fetchQueries, store) =>
 	query => {
+		// force presence of 'delete' method
+		query.meta = { ...(query.meta || {}), method: 'delete' };
 		const { config: { apiUrl } } = store.getState();
-		return fetchQueries(apiUrl, { method: 'DELETE' })([query]);
+		return fetchQueries(apiUrl)([query]);
 	};
 
 /**

--- a/src/epics/delete.test.js
+++ b/src/epics/delete.test.js
@@ -24,16 +24,15 @@ MOCK_APP_STATE.config = {
 const store = createFakeStore(MOCK_APP_STATE);
 describe('getDeleteEpic', () => {
 	it('does not pass through arbitrary actions', epicIgnoreAction(getDeleteEpic(fetchUtils.fetchQueries)));
-	it('calls fetchQueries with `method: "DELETE"`', function() {
-		const response = 'success';
-		spyOn(fetchUtils, 'fetchQueries').and.callFake(() => () => Promise.resolve(response));
+	it('sets query.meta.method = "delete"', function() {
+		const innerFetchQueries = jest.fn();
+		fetchUtils.fetchQueries = jest.fn(() => innerFetchQueries);
 		const action$ = ActionsObservable.of(MOCK_DELETE_ACTION);
 		return getDeleteEpic(fetchUtils.fetchQueries)(action$, store)
 			.do(() => {
-				expect(fetchUtils.fetchQueries.calls.count()).toBe(1);
-				const fetchArgs = fetchUtils.fetchQueries.calls.argsFor(0);
-				expect(fetchArgs[1].method).toEqual('DELETE');
-				expect(fetchArgs[0]).toEqual(MOCK_APP_STATE.config.apiUrl);
+				const fetchedQueries = innerFetchQueries.mock.calls[0][0];
+				expect(fetchedQueries[0].meta)
+					.toEqual(expect.objectContaining({ method: 'delete' }));
 			})
 			.toPromise();
 	});

--- a/src/epics/post.js
+++ b/src/epics/post.js
@@ -41,6 +41,8 @@ import {
  */
 const getPostQueryFetch = (fetchQueries, store) =>
 	query => {
+		// force presence of 'post' method
+		query.meta = { ...(query.meta || {}), method: 'post' };
 		const { config: { apiUrl } } = store.getState();
 		return fetchQueries(apiUrl, { method: 'POST' })([query]);
 	};

--- a/src/epics/post.test.js
+++ b/src/epics/post.test.js
@@ -24,19 +24,19 @@ MOCK_APP_STATE.config = {
 const store = createFakeStore(MOCK_APP_STATE);
 describe('getPostEpic', () => {
 	it('does not pass through arbitrary actions', epicIgnoreAction(getPostEpic(fetchUtils.fetchQueries)));
-	it('calls fetchQueries with `method: "POST"`', function() {
-		const response = 'success';
-		spyOn(fetchUtils, 'fetchQueries').and.callFake(() => () => Promise.resolve(response));
+	it('sets query.meta.method = "post"', function() {
+		const innerFetchQueries = jest.fn();
+		fetchUtils.fetchQueries = jest.fn(() => innerFetchQueries);
 		const action$ = ActionsObservable.of(MOCK_POST_ACTION);
 		return getPostEpic(fetchUtils.fetchQueries)(action$, store)
 			.do(() => {
-				expect(fetchUtils.fetchQueries.calls.count()).toBe(1);
-				const fetchArgs = fetchUtils.fetchQueries.calls.argsFor(0);
-				expect(fetchArgs[1].method).toEqual('POST');
-				expect(fetchArgs[0]).toEqual(MOCK_APP_STATE.config.apiUrl);
+				const fetchedQueries = innerFetchQueries.mock.calls[0][0];
+				expect(fetchedQueries[0].meta)
+					.toEqual(expect.objectContaining({ method: 'post' }));
 			})
 			.toPromise();
 	});
+
 	it('Returns response from fetchqueries as argument to API_SUCCESS', function() {
 		const response = 'success';
 		fetchUtils.fetchQueries = jest.fn(() => () => Promise.resolve(response));

--- a/src/util/fetchUtils.js
+++ b/src/util/fetchUtils.js
@@ -34,22 +34,15 @@ export const parseQueryResponse = queries => ({ responses, error, message }) => 
  *
  * @param {String} apiUrl the general-purpose endpoint for API calls to the
  *   application server
- * @param {Object} options {
- *     method: "get", "post", "delete", or "patch",
- *   }
  * @param {Array} queries the queries to send - must all use the same `method`
  * @param {Object} meta additional characteristics of the request, e.g. logout,
  *   click tracking data
  * @return {Object} { url, config } arguments for a fetch call
  */
-export const getFetchArgs = (apiUrl, options, queries, meta) => {
-	const {
-		headers={},
-	} = options;
-
+export const getFetchArgs = (apiUrl, queries, meta) => {
+	const headers = {};
 	const method = (
 		(queries[0].meta || {}).method ||
-			options.method ||  // fallback to options
 			'get'  // fallback to 'get'
 	).toLowerCase();
 
@@ -120,15 +113,12 @@ export const getFetchArgs = (apiUrl, options, queries, meta) => {
  *
  * @param {String} apiUrl the general-purpose endpoint for API calls to the
  *   application server
- * @param {Object} options {
- *     method: "get", "post", "delete", or "patch",
- *   }
  * @param {Array} queries the queries to send - must all use the same `method`
  * @param {Object} meta additional characteristics of the request, e.g. logout,
  *   click tracking data
  * @return {Promise} resolves with a `{queries, responses}` object
  */
-export const fetchQueries = (apiUrl, options={}) => (queries, meta) => {
+export const fetchQueries = (apiUrl) => (queries, meta) => {
 	if (
 		typeof window === 'undefined' &&  // not in browser
 		typeof test === 'undefined'  // not in testing env (global set by Jest)
@@ -139,7 +129,7 @@ export const fetchQueries = (apiUrl, options={}) => (queries, meta) => {
 	const {
 		url,
 		config,
-	} = getFetchArgs(apiUrl, options, queries, meta);
+	} = getFetchArgs(apiUrl, queries, meta);
 
 	return fetch(url, config)
 		.then(queryResponse => queryResponse.json())

--- a/src/util/fetchUtils.test.js
+++ b/src/util/fetchUtils.test.js
@@ -25,11 +25,10 @@ jest.mock('js-cookie', () => {
 describe('fetchQueries', () => {
 	const API_URL = new URL('http://api.example.com/');
 	const csrfJwt = `${fetchUtils.CSRF_HEADER_COOKIE} value`;
-	const queries = [mockQuery({ params: {} })];
+	const getQueries = [mockQuery({ params: {} })];
+	const postQueries = [{ ...mockQuery({ params: {} }), meta: { method: 'post' }}];
 	const meta = { foo: 'bar', clickTracking: { history: [] } };
 	const responses = [MOCK_GROUP];
-	const getRequest = { method: 'get', headers: {} };
-	const postRequest = { method: 'post', csrf: csrfJwt, headers: {} };
 	const fakeSuccess = () =>
 		Promise.resolve({
 			json: () => Promise.resolve(responses),
@@ -53,7 +52,7 @@ describe('fetchQueries', () => {
 	it('returns an object with queries and responses arrays', () => {
 		spyOn(global, 'fetch').and.callFake(fakeSuccess);
 
-		return fetchUtils.fetchQueries(API_URL.toString(), getRequest)(queries)
+		return fetchUtils.fetchQueries(API_URL.toString())(getQueries)
 			.then(response => {
 				expect(response.queries).toEqual(jasmine.any(Array));
 				expect(response.responses).toEqual(jasmine.any(Array));
@@ -62,7 +61,7 @@ describe('fetchQueries', () => {
 	it('returns a promise that will reject when response contains error prop', () => {
 		spyOn(global, 'fetch').and.callFake(fakeSuccessError);
 
-		return fetchUtils.fetchQueries(API_URL.toString(), getRequest)(queries)
+		return fetchUtils.fetchQueries(API_URL.toString())(getQueries)
 			.then(
 				response => expect(true).toBe(false),
 				err => expect(err).toEqual(jasmine.any(Error))
@@ -75,7 +74,7 @@ describe('fetchQueries', () => {
 
 		const methodTest = method => () => {
 			query.meta = { method };
-			return fetchUtils.fetchQueries(API_URL.toString(), getRequest)(queries)
+			return fetchUtils.fetchQueries(API_URL.toString())(queries)
 				.then(response => {
 					const [, config] = global.fetch.calls.mostRecent().args;
 					expect(config.method).toEqual(method);
@@ -89,10 +88,8 @@ describe('fetchQueries', () => {
 		it('GET calls fetch with API url and queries, metadata, logout querystring params', () => {
 			spyOn(global, 'fetch').and.callFake(fakeSuccess);
 
-			return fetchUtils.fetchQueries(
-				API_URL.toString(),
-				getRequest
-			)(queries, { ...meta, logout: true })
+			return fetchUtils
+				.fetchQueries(API_URL.toString())(getQueries, { ...meta, logout: true })
 				.then(() => {
 					const calledWith = global.fetch.calls.mostRecent().args;
 					const url = new URL(calledWith[0]);
@@ -111,10 +108,8 @@ describe('fetchQueries', () => {
 			spyOn(global, 'fetch').and.callFake(fakeSuccess);
 			JSCookie.set.mockClear();
 
-			return fetchUtils.fetchQueries(
-				API_URL.toString(),
-				getRequest
-			)(queries, { ...meta, clickTracking, logout: true })
+			return fetchUtils
+				.fetchQueries(API_URL.toString())(getQueries, { ...meta, clickTracking, logout: true })
 				.then(() => {
 					const calledWith = JSCookie.set.mock.calls[0];
 					expect(calledWith[0])
@@ -125,27 +120,24 @@ describe('fetchQueries', () => {
 		it('GET without meta calls fetch without metadata querystring params', () => {
 			spyOn(global, 'fetch').and.callFake(fakeSuccess);
 
-			return fetchUtils.fetchQueries(
-				API_URL.toString(),
-				getRequest
-			)(queries).then(() => {
-				const calledWith = global.fetch.calls.mostRecent().args;
-				const url = new URL(calledWith[0]);
-				expect(url.origin).toBe(API_URL.origin);
-				expect(url.searchParams.has('queries')).toBe(true);
-				expect(url.searchParams.has('metadata')).toBe(false);
-				expect(calledWith[1].method).toEqual('get');
-			});
+			return fetchUtils
+				.fetchQueries(API_URL.toString())(getQueries)
+				.then(() => {
+					const calledWith = global.fetch.calls.mostRecent().args;
+					const url = new URL(calledWith[0]);
+					expect(url.origin).toBe(API_URL.origin);
+					expect(url.searchParams.has('queries')).toBe(true);
+					expect(url.searchParams.has('metadata')).toBe(false);
+					expect(calledWith[1].method).toEqual('get');
+				});
 		});
 	});
 	describe('POST', () => {
 		it('POST calls fetch with API url; csrf header; queries and metadata body params', () => {
 			spyOn(global, 'fetch').and.callFake(fakeSuccess);
 
-			return fetchUtils.fetchQueries(
-				API_URL.toString(),
-				postRequest
-			)(queries, meta)
+			return fetchUtils
+				.fetchQueries(API_URL.toString())(postQueries, meta)
 				.then(() => {
 					const calledWith = global.fetch.calls.mostRecent().args;
 					const url = new URL(calledWith[0]);
@@ -162,10 +154,7 @@ describe('fetchQueries', () => {
 		it('POST without meta calls fetch without metadata body params', () => {
 			spyOn(global, 'fetch').and.callFake(fakeSuccess);
 
-			return fetchUtils.fetchQueries(
-				API_URL.toString(),
-				postRequest
-			)(queries)
+			return fetchUtils.fetchQueries(API_URL.toString())(postQueries)
 				.then(() => {
 					const calledWith = global.fetch.calls.mostRecent().args;
 					const url = new URL(calledWith[0]);
@@ -188,13 +177,10 @@ describe('fetchQueries', () => {
 				}
 			};
 			FormData.prototype.append = jest.fn();
-			const formQueries = [mockQuery({ params: new FormData() })];
+			const formQueries = [{ ...mockQuery({ params: new FormData() }), meta: { method: 'post' }}];
 			spyOn(global, 'fetch').and.callFake(fakeSuccess);
 
-			return fetchUtils.fetchQueries(
-				API_URL.toString(),
-				postRequest
-			)(formQueries)
+			return fetchUtils.fetchQueries(API_URL.toString())(formQueries)
 				.then(() => {
 					const calledWith = global.fetch.calls.mostRecent().args;
 					const url = new URL(calledWith[0]);


### PR DESCRIPTION
now that queries can carry their own `method` info, we never need to supply that information to the `fetchQueries` outside of the query.

There was also some outdated mocked CSRF config that I cleaned up here.