### PR TITLE
update cache to ignore non-gets

### DIFF
--- a/src/util/cacheUtils.js
+++ b/src/util/cacheUtils.js
@@ -56,6 +56,11 @@ export const cacheReader = cache => query =>
  * @param {Object} response plain object API response for the query
  * @return {Promise}
  */
-export const cacheWriter = cache => (query, response) =>
-	cache.set(JSON.stringify(query), response);
+export const cacheWriter = cache => (query, response) => {
+	const method = (query.meta || {}).method || 'get';
+	if (method.toLowerCase() !== 'get') {
+		return Promise.resolve(true);
+	}
+	return cache.set(JSON.stringify(query), response);
+};
 

--- a/src/util/cacheUtils.test.js
+++ b/src/util/cacheUtils.test.js
@@ -41,6 +41,15 @@ describe('cache utils', () => {
 			.then(cachedResponse => expect(cachedResponse).toEqual(response));
 	});
 
+	it('cacheWriter does not write non-GET queries to cache', function() {
+		const cache = makeCache();
+		const query = { foo: 'baz', meta: { method: 'post' } };
+		const response = 'bar';
+		return cacheWriter(cache)(query, response)
+			.then(() => cache.get(JSON.stringify(query)))
+			.then(cachedResponse => expect(cachedResponse).toEqual(undefined));
+	});
+
 	it('cacheReader reads from cache and returns result with query', function() {
 		const cache = makeCache();
 		const requestCache = cacheReader(cache);


### PR DESCRIPTION
**Blocked by #231 - this update requires that all non-GET queries have a `meta.method` by the time they reach the cache**

We shouldn't cache non-GET queries, because mutations shouldn't be cached.