### PR TITLE
scroll to top on PUSH location changes

### DIFF
--- a/src/components/SyncContainer.jsx
+++ b/src/components/SyncContainer.jsx
@@ -23,6 +23,12 @@ export class SyncContainer extends React.Component {
 	componentWillReceiveProps(nextProps) {
 		if (nextProps.location !== this.props.location) {
 			this.props.dispatchLocationChange(nextProps.location);
+			if (nextProps.history.action === 'PUSH') {
+				// new navigation - scroll to top
+				window.scrollTo(0, 0);
+			}
+			// eventually we might want to try setting up some scroll logic for 'POP'
+			// events (back button) to re-set the previous scroll position
 		}
 	}
 	/**
@@ -37,6 +43,7 @@ SyncContainer.propTypes = {
 	children: React.PropTypes.element.isRequired,
 	dispatchLocationChange: React.PropTypes.func.isRequired,
 	location: React.PropTypes.object.isRequired,
+	history: React.PropTypes.object.isRequired,
 };
 
 export default connect(null, mapDispatchToProps)(


### PR DESCRIPTION
Currently, if you scroll down a page and then navigate to a new page, the scroll position doesn't change (unless the page you're moving _to_ is initially very short, forcing the scroll back up to the top). This update forces the scroll up to the top on any PUSH navigation. Scroll position will not change for browser-back POP navigations - we can try to make that 'smarter' in the future.