### PR TITLE
Wp 282 deprecate POST and DELETE middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [2.1]
+
+- **Deprecated** POSTing and DELETEing through custom `POST_...` or `DELETE_...`
+  actions has been deprecated - a warning will be printed in the server logs.
+  Use the `meta.method` field in your Query objects to determine the request
+  method, and use `componentWillReceiveProps` to process the API result [as
+  described in the
+  docs](https://github.com/meetup/meetup-web-platform/blob/master/docs/Queries.md#recipes)
+
 ## [2.0]
 
 - **Refactor** Upgrade to React Router v4. Routes definitions change - the root

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CI_BUILD_NUMBER ?= $(USER)-snapshot
-VERSION ?= 2.0.$(CI_BUILD_NUMBER)
+VERSION ?= 2.1.$(CI_BUILD_NUMBER)
 
 version:
 	@echo $(VERSION)

--- a/src/epics/mutate.js
+++ b/src/epics/mutate.js
@@ -80,7 +80,7 @@ const doFetch$ = fetchQuery => ({ query, onSuccess, onError }) =>
 const getMethodEpic = method => fetchQueries => (action$, store) =>
 	action$.filter(({ type }) =>
 		type.endsWith(`_${method.toUpperCase()}`) || type.startsWith(`${method.toUpperCase()}_`))
-		.do(({ type, query: { endpoint } }) => {
+		.do(({ type, payload: { query: { endpoint } } }) => {
 			if (endpoint.indexOf('.dev.') > -1) {
 				// using a dev endpoint, render a deprecation warning
 				console.warn(`This application is using Post/Delete middleware through ${type}.

--- a/src/epics/mutate.js
+++ b/src/epics/mutate.js
@@ -80,9 +80,9 @@ const doFetch$ = fetchQuery => ({ query, onSuccess, onError }) =>
 const getMethodEpic = method => fetchQueries => (action$, store) =>
 	action$.filter(({ type }) =>
 		type.endsWith(`_${method.toUpperCase()}`) || type.startsWith(`${method.toUpperCase()}_`))
-		.do(({ type }) => {
-			if (process && process.pid) {
-				// on the server, render a deprecation warning
+		.do(({ type, query: { endpoint } }) => {
+			if (endpoint.indexOf('.dev.') > -1) {
+				// using a dev endpoint, render a deprecation warning
 				console.warn(`This application is using Post/Delete middleware through ${type}.
 See the platform Queries Recipes docs for refactoring options:
 https://github.com/meetup/meetup-web-platform/blob/master/docs/Queries.md#recipes`);

--- a/src/epics/mutate.js
+++ b/src/epics/mutate.js
@@ -26,6 +26,7 @@ import {
  * alongside the POST/DELETE action creator, with the expectation that all response
  * processing can be done there
  *
+ * @deprecated
  * @module MutateEpic
  */
 
@@ -79,6 +80,14 @@ const doFetch$ = fetchQuery => ({ query, onSuccess, onError }) =>
 const getMethodEpic = method => fetchQueries => (action$, store) =>
 	action$.filter(({ type }) =>
 		type.endsWith(`_${method.toUpperCase()}`) || type.startsWith(`${method.toUpperCase()}_`))
+		.do(({ type }) => {
+			if (process && process.pid) {
+				// on the server, render a deprecation warning
+				console.warn(`This application is using Post/Delete middleware through ${type}.
+See the platform Queries Recipes docs for refactoring options:
+https://github.com/meetup/meetup-web-platform/blob/master/docs/Queries.md#recipes`);
+			}
+		})
 		.map(({ payload }) => payload)
 		.flatMap(
 			doFetch$(

--- a/src/middleware/epic.js
+++ b/src/middleware/epic.js
@@ -6,7 +6,7 @@ import getCacheEpic from '../epics/cache';
 import {
 	getPostEpic,
 	getDeleteEpic
-} from '../epics/mutate';
+} from '../epics/mutate';  // DEPRECATED
 
 /**
  * The middleware is exported as a getter because it needs the application's
@@ -21,8 +21,8 @@ const getPlatformMiddleware = (routes, fetchQueries, baseUrl) => createEpicMiddl
 	combineEpics(
 		getSyncEpic(routes, fetchQueries, baseUrl),
 		getCacheEpic(),
-		getPostEpic(fetchQueries),
-		getDeleteEpic(fetchQueries)
+		getPostEpic(fetchQueries),  // DEPRECATED
+		getDeleteEpic(fetchQueries)  // DEPRECATED
 	)
 );
 


### PR DESCRIPTION
See https://meetup.atlassian.net/browse/WP-282

These epics can be removed now that we have a simpler alternative pattern for creating POST, DELETE, and PATCH requests from queries. To avoid a breaking change, this PR just adds deprecation notices