### PR TITLE
WP 301 fix member id track

### DIFF
--- a/src/util/clickTrackingReader.js
+++ b/src/util/clickTrackingReader.js
@@ -1,5 +1,8 @@
+import { parseMemberCookie } from './cookieUtils';
+
 const isProd = process.env.NODE_ENV === 'production';
-export const MEMBER_ID_COOKIE = isProd ? 'MEETUP_MEMBER_ID' : 'MEETUP_MEMBER_ID_DEV';
+
+export const MEMBER_ID_COOKIE = isProd ? 'MEETUP_MEMBER' : 'MEETUP_MEMBER_DEV';
 export const clickCookieOptions = {
 	isSecure: isProd,
 	isHttpOnly: false,
@@ -10,7 +13,7 @@ export const clickToClickRecord = request => click => {
 	return {
 		timestamp: click.timestamp,
 		requestId: request.id,
-		memberId: parseInt(request.state[MEMBER_ID_COOKIE], 10) || 0,
+		memberId: parseInt(parseMemberCookie(request.state).id, 10) || 0,
 		lineage: click.lineage,
 		linkText: click.linkText || '',
 		coordX: click.coords[0],

--- a/src/util/clickTrackingReader.js
+++ b/src/util/clickTrackingReader.js
@@ -2,7 +2,6 @@ import { parseMemberCookie } from './cookieUtils';
 
 const isProd = process.env.NODE_ENV === 'production';
 
-export const MEMBER_ID_COOKIE = isProd ? 'MEETUP_MEMBER' : 'MEETUP_MEMBER_DEV';
 export const clickCookieOptions = {
 	isSecure: isProd,
 	isHttpOnly: false,

--- a/src/util/clickTrackingReader.js
+++ b/src/util/clickTrackingReader.js
@@ -12,7 +12,7 @@ export const clickToClickRecord = request => click => {
 	return {
 		timestamp: click.timestamp,
 		requestId: request.id,
-		memberId: parseInt(parseMemberCookie(request.state).id, 10) || 0,
+		memberId: parseMemberCookie(request.state).id,
 		lineage: click.lineage,
 		linkText: click.linkText || '',
 		coordX: click.coords[0],

--- a/src/util/cookieUtils.js
+++ b/src/util/cookieUtils.js
@@ -1,0 +1,8 @@
+import querystring from 'qs';
+
+const isProd = process.env.NODE_ENV === 'production';
+export const MEMBER_COOKIE = isProd ? 'MEETUP_MEMBER' : 'MEETUP_MEMBER_DEV';
+
+export const parseMemberCookie = state =>
+	querystring.parse(state[MEMBER_COOKIE]);
+

--- a/src/util/cookieUtils.js
+++ b/src/util/cookieUtils.js
@@ -3,6 +3,14 @@ import querystring from 'qs';
 const isProd = process.env.NODE_ENV === 'production';
 export const MEMBER_COOKIE = isProd ? 'MEETUP_MEMBER' : 'MEETUP_MEMBER_DEV';
 
-export const parseMemberCookie = state =>
-	querystring.parse(state[MEMBER_COOKIE]);
+export const parseMemberCookie = state => {
+	if (!state[MEMBER_COOKIE]) {
+		console.warn('No member cookie found - there might be a problem with auth');
+		// no member cookie - always return id=0
+		return { id: 0 };
+	}
+	const member = querystring.parse(state[MEMBER_COOKIE]);
+	member.id = parseInt(member.id, 10) || 0;
+	return member;
+};
 

--- a/src/util/cookieUtils.test.js
+++ b/src/util/cookieUtils.test.js
@@ -1,0 +1,31 @@
+import { MEMBER_COOKIE, parseMemberCookie } from './cookieUtils';
+
+describe('parseMemberCookie', () => {
+	it('returns the parsed cookie', () => {
+		const requestState = { [MEMBER_COOKIE]: 'foo=bar&baz=bing' };
+		expect(parseMemberCookie(requestState)).toEqual({ foo: 'bar', baz: 'bing', id: 0 });
+	});
+	it('returns an integer id', () => {
+		const values = [
+			'foo=bar&baz=bing',  // no id
+			'id=fabulous',
+			'id=0',
+			'id=1234',
+			''
+		];
+		values.map(v => ({ [MEMBER_COOKIE]: v }))
+			.forEach(state =>
+				expect(parseMemberCookie(state).id).toEqual(expect.any(Number))
+			);
+	});
+	it('returns an integer id', () => {
+		const ids = [1,0,'fabulous'];
+
+		const resultIds = ids
+			.map(id => ({ [MEMBER_COOKIE]: `id=${id}` }))
+			.map(parseMemberCookie)
+			.map(member => member.id);
+
+		expect(resultIds).toEqual(ids.map(id => parseInt(id.toString(), 10) || 0));
+	});
+});

--- a/src/util/cookieUtils.test.js
+++ b/src/util/cookieUtils.test.js
@@ -28,4 +28,7 @@ describe('parseMemberCookie', () => {
 
 		expect(resultIds).toEqual(ids.map(id => parseInt(id.toString(), 10) || 0));
 	});
+	it('returns {id:0} for no-cookie case', () => {
+		expect(parseMemberCookie({})).toEqual({ id: 0 });
+	});
 });

--- a/src/util/tracking.js
+++ b/src/util/tracking.js
@@ -66,7 +66,7 @@ export const trackLogout = log => response =>
 		response,
 		{
 			description: 'logout',
-			memberId: parseInt(parseMemberCookie(response.request.state).id, 10) || 0,
+			memberId: parseMemberCookie(response.request.state).id,
 			trackIdFrom: response.request.state[TRACK_ID_COOKIE] || '',
 			trackId: updateTrackId(response, true),
 			sessionId: response.request.state[SESSION_ID_COOKIE],
@@ -87,7 +87,7 @@ export const trackNav = log => (response, queryResponses, url, referrer) => {
 		response,
 		{
 			description: 'nav',
-			memberId: parseInt(parseMemberCookie(response.request.state).id, 10) || 0,
+			memberId: parseMemberCookie(response.request.state).id,
 			trackId: response.request.state[TRACK_ID_COOKIE] || '',
 			sessionId: response.request.state[SESSION_ID_COOKIE] || '',
 			url: url || '',
@@ -122,7 +122,7 @@ export const trackLogin = log => (response, memberId) =>
 		response,
 		{
 			description: 'login',
-			memberId: parseInt(parseMemberCookie(response.request.state).id, 10) || 0,
+			memberId: parseMemberCookie(response.request.state).id,
 			trackIdFrom: response.request.state[TRACK_ID_COOKIE] || '',
 			trackId: updateTrackId(response, true),
 			sessionId: response.request.state[SESSION_ID_COOKIE],
@@ -139,7 +139,7 @@ export const trackSession = log => response => {
 		response,
 		{
 			description: 'session',
-			memberId: parseInt(parseMemberCookie(response.request.state).id, 10) || 0,
+			memberId: parseMemberCookie(response.request.state).id,
 			trackId: updateTrackId(response),
 			sessionId: newSessionId(response),
 			url: response.request.url.path,

--- a/src/util/tracking.js
+++ b/src/util/tracking.js
@@ -1,4 +1,5 @@
 import uuid from 'uuid';
+import { parseMemberCookie } from './cookieUtils';
 
 const isProd = process.env.NODE_ENV === 'production';
 
@@ -10,7 +11,6 @@ const COOKIE_OPTS = {
 	isSecure: isProd,
 };
 
-export const MEMBER_ID_COOKIE = isProd ? 'MEETUP_MEMBER_ID' : 'MEETUP_MEMBER_ID_DEV';
 export const TRACK_ID_COOKIE = isProd ? 'TRACK_ID' : 'TRACK_ID_DEV';
 export const SESSION_ID_COOKIE = isProd ? 'SESSION_ID' : 'SESSION_ID_DEV';
 
@@ -29,26 +29,6 @@ export const newSessionId = response => {
 		COOKIE_OPTS
 	);
 	return sessionId;
-};
-
-/**
- * getter/setter for memberId cookie: if memberId is not passed, the cookie
- * will be unset
- */
-export const updateMemberId = (response, memberId) => {
-	if (!memberId) {
-		response.unstate(MEMBER_ID_COOKIE);
-		return response.request.state[MEMBER_ID_COOKIE];
-	}
-	response.state(
-		MEMBER_ID_COOKIE,
-		memberId,
-		{
-			...COOKIE_OPTS,
-			ttl: YEAR_IN_MS * 20,
-		}
-	);
-	return memberId;
 };
 
 /**
@@ -86,7 +66,7 @@ export const trackLogout = log => response =>
 		response,
 		{
 			description: 'logout',
-			memberId: parseInt(updateMemberId(response), 10) || 0,
+			memberId: parseInt(parseMemberCookie(response.request.state).id, 10) || 0,
 			trackIdFrom: response.request.state[TRACK_ID_COOKIE] || '',
 			trackId: updateTrackId(response, true),
 			sessionId: response.request.state[SESSION_ID_COOKIE],
@@ -107,7 +87,7 @@ export const trackNav = log => (response, queryResponses, url, referrer) => {
 		response,
 		{
 			description: 'nav',
-			memberId: parseInt(response.request.state[MEMBER_ID_COOKIE], 10) || 0,
+			memberId: parseInt(parseMemberCookie(response.request.state).id, 10) || 0,
 			trackId: response.request.state[TRACK_ID_COOKIE] || '',
 			sessionId: response.request.state[SESSION_ID_COOKIE] || '',
 			url: url || '',
@@ -142,7 +122,7 @@ export const trackLogin = log => (response, memberId) =>
 		response,
 		{
 			description: 'login',
-			memberId: parseInt(updateMemberId(response, memberId), 10) || 0,
+			memberId: parseInt(parseMemberCookie(response.request.state).id, 10) || 0,
 			trackIdFrom: response.request.state[TRACK_ID_COOKIE] || '',
 			trackId: updateTrackId(response, true),
 			sessionId: response.request.state[SESSION_ID_COOKIE],
@@ -159,7 +139,7 @@ export const trackSession = log => response => {
 		response,
 		{
 			description: 'session',
-			memberId: parseInt(response.request.state[MEMBER_ID_COOKIE], 10) || 0,
+			memberId: parseInt(parseMemberCookie(response.request.state).id, 10) || 0,
 			trackId: updateTrackId(response),
 			sessionId: newSessionId(response),
 			url: response.request.url.path,


### PR DESCRIPTION
The member id tracking was reliant on a separate MEMBER_ID cookie that wasn't behaving correctly - it's something that we might want to come back to when we fully develop a login system, but probably best not to hack together support for a hypothetical use case