### PR TITLE
remove intl from browser bundle

### DIFF
--- a/src/renderers/server-render.jsx
+++ b/src/renderers/server-render.jsx
@@ -7,7 +7,7 @@ import { getServerCreateStore } from '../util/createStoreServer';
 import Dom from '../components/dom';
 import NotFound from '../components/NotFound';
 import PlatformApp from '../components/PlatformApp';
-import { polyfillNodeIntl } from '../util/localizationUtils';
+import * as polyfillNodeIntl from 'intl';
 
 import { SERVER_RENDER } from '../actions/syncActionCreators';
 import {
@@ -16,7 +16,8 @@ import {
 } from '../actions/configActionCreators';
 
 // Ensure global Intl for use with FormatJS
-polyfillNodeIntl();
+Intl.NumberFormat = IntlPolyfill.NumberFormat;
+Intl.DateTimeFormat = IntlPolyfill.DateTimeFormat;
 
 const DOCTYPE = '<!DOCTYPE html>';
 

--- a/src/util/localizationUtils.js
+++ b/src/util/localizationUtils.js
@@ -12,8 +12,6 @@ import LocaleDataPT from 'react-intl/locale-data/pt';
 
 import { addLocaleData } from 'react-intl';
 
-import * as IntlPolyfill from 'intl'
-
 
 const localeMap = {
 	'en-US': {
@@ -44,17 +42,6 @@ const localeMap = {
 		data: LocaleDataES
 	}
 };
-
-/**
- * Polyfill Node Intl APIs
- * `Intl` exists, but it doesn't have the locale data we need
- *
- * @method polyfillNodeIntl
- */
-export function polyfillNodeIntl() {
-	Intl.NumberFormat = IntlPolyfill.NumberFormat;
-	Intl.DateTimeFormat = IntlPolyfill.DateTimeFormat;
-}
 
 /**
  * Load data for given localeCode into ReactIntl

--- a/src/util/localizationUtils.js
+++ b/src/util/localizationUtils.js
@@ -12,7 +12,7 @@ import LocaleDataPT from 'react-intl/locale-data/pt';
 
 import { addLocaleData } from 'react-intl';
 
-import 'intl' as IntlPolyfill
+import * as IntlPolyfill from 'intl'
 
 
 const localeMap = {

--- a/src/util/localizationUtils.js
+++ b/src/util/localizationUtils.js
@@ -12,6 +12,8 @@ import LocaleDataPT from 'react-intl/locale-data/pt';
 
 import { addLocaleData } from 'react-intl';
 
+import 'intl' as IntlPolyfill
+
 
 const localeMap = {
 	'en-US': {
@@ -50,7 +52,6 @@ const localeMap = {
  * @method polyfillNodeIntl
  */
 export function polyfillNodeIntl() {
-	const IntlPolyfill = require('intl');
 	Intl.NumberFormat = IntlPolyfill.NumberFormat;
 	Intl.DateTimeFormat = IntlPolyfill.DateTimeFormat;
 }


### PR DESCRIPTION
Intl is being bundled into our app js even though we're polyfilling it as well. I'm trying to figure out why its being included.