### PR TITLE
update mocks and fix missing rxjs operators

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,13 +55,13 @@
     "uuid": "3.0.1"
   },
   "peerDependencies": {
-    "react": "^15.4.2",
-    "react-helmet": ">=3.3.2",
+    "react": "^15.5.4",
+    "react-helmet": "^5.0.3",
     "react-intl": "^2.2.3",
-    "react-redux": "^5.0.3",
-    "react-router-dom": "^4.0.0",
+    "react-redux": "^5.0.4",
+    "react-router-dom": "^4.1.1",
     "redux": "^3.6.0",
-    "rxjs": "^5.2.0"
+    "rxjs": "^5.3.0"
   },
   "devDependencies": {
     "babel-cli": "6.24.1",
@@ -75,7 +75,7 @@
     "intl-relativeformat": "1.3.0",
     "iron": "4.0.4",
     "jest-cli": "19.0.2",
-    "meetup-web-mocks": "1.0.182",
+    "meetup-web-mocks": "1.0.183",
     "react": "15.5.4",
     "react-addons-test-utils": "15.5.1",
     "react-helmet": "5.0.3",

--- a/src/apiProxy/api-proxy.test.js
+++ b/src/apiProxy/api-proxy.test.js
@@ -1,4 +1,6 @@
-import Rx from 'rxjs';
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/observable/of';
+import 'rxjs/add/operator/toPromise';
 import rison from 'rison';
 import * as apiUtils from '../util/apiUtils';
 import {
@@ -33,7 +35,7 @@ describe('apiProxy$', () => {
 			value: { foo: 'bar' },
 		};
 		spyOn(apiUtils, 'makeApiRequest$').and.returnValue(
-			() => Rx.Observable.of(requestResult)
+			() => Observable.of(requestResult)
 		);
 		const expectedResults = [
 			requestResult,

--- a/src/epics/cache.test.js
+++ b/src/epics/cache.test.js
@@ -1,4 +1,5 @@
 import { ActionsObservable } from 'redux-observable';
+import 'rxjs/add/operator/toPromise';
 
 import {
 	mockQuery,

--- a/src/epics/mutate.js
+++ b/src/epics/mutate.js
@@ -1,7 +1,9 @@
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/observable/of';
+import 'rxjs/add/observable/from';
 import 'rxjs/add/observable/fromPromise';
 import 'rxjs/add/operator/catch';
+import 'rxjs/add/operator/do';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/filter';
 import 'rxjs/add/operator/mergeMap';

--- a/src/epics/mutate.test.js
+++ b/src/epics/mutate.test.js
@@ -1,4 +1,6 @@
 import { ActionsObservable } from 'redux-observable';
+import 'rxjs/add/operator/toArray';
+import 'rxjs/add/operator/toPromise';
 
 import { getDeprecatedSuccessPayload } from '../util/fetchUtils';
 

--- a/src/epics/sync.js
+++ b/src/epics/sync.js
@@ -2,9 +2,10 @@ import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/observable/from';
 import 'rxjs/add/observable/fromPromise';
 import 'rxjs/add/observable/of';
-import 'rxjs/add/operator/takeUntil';
-import 'rxjs/add/operator/mergeMap';
 import 'rxjs/add/operator/catch';
+import 'rxjs/add/operator/map';
+import 'rxjs/add/operator/mergeMap';
+import 'rxjs/add/operator/takeUntil';
 
 import { combineEpics } from 'redux-observable';
 import * as api from '../actions/apiActionCreators';

--- a/src/epics/sync.test.js
+++ b/src/epics/sync.test.js
@@ -1,4 +1,5 @@
-import 'rxjs/Observable';
+import 'rxjs/add/operator/toArray';
+import 'rxjs/add/operator/toPromise';
 import { ActionsObservable } from 'redux-observable';
 
 import fetch from 'node-fetch';

--- a/src/util/apiUtils.js
+++ b/src/util/apiUtils.js
@@ -11,7 +11,10 @@ import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/observable/of';
 import 'rxjs/add/observable/bindNodeCallback';
 import 'rxjs/add/observable/defer';
+import 'rxjs/add/operator/catch';
 import 'rxjs/add/operator/do';
+import 'rxjs/add/operator/map';
+import 'rxjs/add/operator/timeout';
 
 import {
 	removeAuthState,

--- a/src/util/apiUtils.mockRequest.test.js
+++ b/src/util/apiUtils.mockRequest.test.js
@@ -1,3 +1,5 @@
+import 'rxjs/add/operator/toPromise';
+
 import {
 	mockQuery,
 	MOCK_RENDERPROPS,

--- a/src/util/apiUtils.test.js
+++ b/src/util/apiUtils.test.js
@@ -1,3 +1,5 @@
+import 'rxjs/add/operator/toPromise';
+
 import externalRequest from 'request';
 import rison from 'rison';
 

--- a/src/util/createStoreServer.test.js
+++ b/src/util/createStoreServer.test.js
@@ -9,7 +9,11 @@ import {
 
 jest.mock(
 	'../apiProxy/api-proxy',
-	() => jest.fn((request, queries) => require('rxjs').Observable.of('response'))
+	() => jest.fn((request, queries) => {
+		const { Observable } = require('rxjs/Observable');
+		require('rxjs/add/observable/of');
+		return Observable.of('response');
+	})
 );
 
 const MOCK_ROUTES = {};

--- a/src/util/testUtils.js
+++ b/src/util/testUtils.js
@@ -3,6 +3,7 @@ import Cookie from 'tough-cookie';
 
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/observable/of';
+import 'rxjs/add/operator/do';
 import { ActionsObservable } from 'redux-observable';
 
 import {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2813,9 +2813,9 @@ makeerror@1.0.x:
   dependencies:
     tmpl "1.0.x"
 
-meetup-web-mocks@1.0.182:
-  version "1.0.182"
-  resolved "https://registry.yarnpkg.com/meetup-web-mocks/-/meetup-web-mocks-1.0.182.tgz#ffa416fe115c772c05e86c7c900df716bac778b7"
+meetup-web-mocks@1.0.183:
+  version "1.0.183"
+  resolved "https://registry.yarnpkg.com/meetup-web-mocks/-/meetup-web-mocks-1.0.183.tgz#288f306d9ba77de08395e38e4eafa9d0b2a8f2c5"
   dependencies:
     rxjs "5.3.0"
 


### PR DESCRIPTION
meetup-web-mocks was masking a lot of missing rxjs operators, which allowed tests to pass for modules with missing dependencies.

I'll leave this open for a little bit, but since this is blocking platform updates in consumer apps, I'll merge by EOD