### PR TITLE
WP 307 inFlight array of in-flight API request `ref`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.3]
+
+- **Replaced** `state.api.isFetching` has been replaced with
+  `state.api.inFlight`, which is an array of `ref`s corresponding to query
+  requests that have not yet returned. Use `state.api.inFlight.includes(fooRef)`
+  to determine whether a particular query has returned.
+
 ## [2.2]
 
 - **Deprecated** all of the Sync action creators (e.g. `syncActionCreators.apiRequest`)

--- a/docs/Queries.md
+++ b/docs/Queries.md
@@ -191,7 +191,8 @@ The sync middleware will read these two arrays and generate a separate
 #### Request failure - `API_RESP_FAIL`
 
 If the `fetch` fails entirely, no responses will be delivered to the
-application. Instead, an `API_RESP_FAIL` action will be dispatched.
+application. Instead, an `API_RESP_FAIL` action will be dispatched with an
+`Error` payload.
 
 #### Request complete - `API_RESP_COMPLETE`
 

--- a/flow-typed/platform.js
+++ b/flow-typed/platform.js
@@ -3,7 +3,7 @@ declare var Intl: Object;
 
 declare type FluxStandardAction = {
 	type: string,
-	payload: Object | Array<any>,
+	payload?: any,
 	meta?: any,
 	error?: boolean
 };

--- a/flow-typed/platform.js
+++ b/flow-typed/platform.js
@@ -3,7 +3,7 @@ declare var Intl: Object;
 
 declare type FluxStandardAction = {
 	type: string,
-	payload?: any,
+	payload: Object | Array<any>,
 	meta?: any,
 	error?: boolean
 };

--- a/src/actions/apiActionCreators.js
+++ b/src/actions/apiActionCreators.js
@@ -55,9 +55,10 @@ export function fail(err) {
 	};
 }
 
-export function complete() {
+export function complete(queries) {
 	return {
 		type: API_RESP_COMPLETE,
+		payload: queries,
 	};
 }
 

--- a/src/epics/sync.js
+++ b/src/epics/sync.js
@@ -110,24 +110,24 @@ export const apiRequestToApiReq = action$ =>
  */
 export const getFetchQueriesEpic = fetchQueriesFn => (action$, store) =>
 	action$.ofType(api.API_REQ)
-		.mergeMap(({ payload, meta }) => {           // set up the fetch call to the app server
+		.mergeMap(({ payload: queries, meta }) => {           // set up the fetch call to the app server
 			const { config } = store.getState();
 			const fetchQueries = fetchQueriesFn(config.apiUrl);
-			return Observable.fromPromise(fetchQueries(payload, meta))  // call fetch
+			return Observable.fromPromise(fetchQueries(queries, meta))  // call fetch
 				.takeUntil(action$.ofType(LOCATION_CHANGE))  // cancel this fetch when nav happens
 				.mergeMap(({ successes=[], errors=[] }) => {
 					const actions = [
 						...successes.map(api.success),  // send the successes to success
 						...errors.map(api.error),     // send errors to error
 						apiSuccess(getDeprecatedSuccessPayload(successes, errors)),  // DEPRECATED - necessary to continue populating old state
-						api.complete()
+						api.complete(queries)
 					];
 					return Observable.of(...actions);
 				})
 				.catch(err => Observable.of(
 					api.fail(err),
 					apiError(err),  // DEPRECATED
-					api.complete()
+					api.complete(queries)
 				));
 		});
 

--- a/src/epics/sync.test.js
+++ b/src/epics/sync.test.js
@@ -151,7 +151,7 @@ describe('Sync epic', () => {
 				expect(actions.map(a => a.type)).toEqual([
 					api.API_RESP_FAIL,
 					'API_ERROR',
-					api.API_RESP_COMPLETE
+					api.API_RESP_COMPLETE // DO NOT REMOVE - must _ALWAYS_ be called in order to clean up inFlight state
 				])
 			);
 	});

--- a/src/reducers/platform.js
+++ b/src/reducers/platform.js
@@ -27,7 +27,7 @@ type ApiState = {
 };
 
 export const DEFAULT_API_STATE: ApiState = { inFlight: [] };
-export const DEFAULT_APP_STATE = { isFetching: false };
+export const DEFAULT_APP_STATE = {};
 
 export const responseToState = (response: QueryResponse): { [string]: QueryResponse } =>
 	({ [response.ref]: response });
@@ -80,9 +80,8 @@ export function app(state=DEFAULT_APP_STATE, action={}) {
 		if ((action.meta || {}).logout) {
 			return DEFAULT_APP_STATE;  // clear app state during logout
 		}
-		return { ...state, isFetching: true };
+		return state;
 	case 'API_SUCCESS':
-		state.isFetching = false;  // fall through - everything else is the same as CACHE_SUCCCESS
 		// API_SUCCESS contains an array of responses, but we just need to build a single
 		// object to update state with
 		newState = action.payload.responses.reduce((s, r) => ({ ...s, ...r }), {});
@@ -92,7 +91,6 @@ export function app(state=DEFAULT_APP_STATE, action={}) {
 		return {
 			...state,
 			error: action.payload,
-			isFetching: false,
 		};
 	default:
 		return state;

--- a/src/reducers/platform.js
+++ b/src/reducers/platform.js
@@ -34,10 +34,10 @@ export const responseToState = (response: QueryResponse): { [string]: QueryRespo
 /*
  * The primary reducer for data provided by the API
  */
-export function api(state: ApiState = DEFAULT_APP_STATE, action={}) {
+export function api(state: ApiState = DEFAULT_APP_STATE, action: FluxStandardAction) {
 	switch (action.type) {
 	case API_REQ: {
-		const requestRefs = action.payload.map(({ ref }) => ref);
+		const requestRefs = (action.payload || []).map(({ ref }) => ref);
 		const inFlight = state.inFlight
 			.filter(ref => !requestRefs.includes[ref]) // clean out current duplicates
 			.concat(requestRefs); // add new requested refs
@@ -57,8 +57,8 @@ export function api(state: ApiState = DEFAULT_APP_STATE, action={}) {
 		delete state.fail;  // if there are any values, the API is not failing
 		return {
 			...state,
-			...responseToState(action.payload.response),
-			inFlight: state.inFlight.filter(ref => ref !== action.payload.response.ref),
+			...responseToState((action.payload || {}).response),
+			inFlight: state.inFlight.filter(ref => ref !== (action.payload || {}).response.ref),
 		};
 	case API_RESP_FAIL:
 		return { ...state, fail: action.payload };

--- a/src/reducers/platform.js
+++ b/src/reducers/platform.js
@@ -35,7 +35,7 @@ export const responseToState = (response: QueryResponse): { [string]: QueryRespo
 /*
  * The primary reducer for data provided by the API
  */
-export function api(state: ApiState = DEFAULT_API_STATE, action: FluxStandardAction) {
+export function api(state: ApiState = DEFAULT_API_STATE, action: FluxStandardAction): ApiState {
 	switch (action.type) {
 	case API_REQ: {
 		const requestRefs = (action.payload || []).map(({ ref }) => ref);

--- a/src/reducers/platform.js
+++ b/src/reducers/platform.js
@@ -26,7 +26,8 @@ type ApiState = {
 	[string]: QueryResponse,
 };
 
-export const DEFAULT_APP_STATE: ApiState = { inFlight: [] };
+export const DEFAULT_API_STATE: ApiState = { inFlight: [] };
+export const DEFAULT_APP_STATE = { isFetching: false };
 
 export const responseToState = (response: QueryResponse): { [string]: QueryResponse } =>
 	({ [response.ref]: response });
@@ -34,7 +35,7 @@ export const responseToState = (response: QueryResponse): { [string]: QueryRespo
 /*
  * The primary reducer for data provided by the API
  */
-export function api(state: ApiState = DEFAULT_APP_STATE, action: FluxStandardAction) {
+export function api(state: ApiState = DEFAULT_API_STATE, action: FluxStandardAction) {
 	switch (action.type) {
 	case API_REQ: {
 		const requestRefs = (action.payload || []).map(({ ref }) => ref);
@@ -44,7 +45,7 @@ export function api(state: ApiState = DEFAULT_APP_STATE, action: FluxStandardAct
 
 		if ((action.meta || {}).logout) {
 			// clear app state during logout
-			return { ...DEFAULT_APP_STATE, inFlight };
+			return { ...DEFAULT_API_STATE, inFlight };
 		}
 
 		return { ...state, inFlight };

--- a/src/reducers/platform.js
+++ b/src/reducers/platform.js
@@ -1,3 +1,4 @@
+// @flow weak
 /**
  * The root level reducer for the app.
  * @module reducer
@@ -19,45 +20,51 @@ import {
 	CACHE_SUCCESS
 } from '../actions/cacheActionCreators';
 
-export const DEFAULT_APP_STATE = { isFetching: false };
-
-export const responseToState = response => {
-	const { ref, ...data } = response;
-	return { [ref]: data };
+type ApiState = {
+	inFlight: Array<string>,
+	fail?: boolean,
+	[string]: QueryResponse,
 };
 
-/**
+export const DEFAULT_APP_STATE: ApiState = { inFlight: [] };
+
+export const responseToState = (response: QueryResponse): { [string]: QueryResponse } =>
+	({ [response.ref]: response });
+
+/*
  * The primary reducer for data provided by the API
- * `state.api` sub-tree
- *
- * @param {Object} state
- * @param {ReduxAction} action
- * @return {Object}
  */
-export function api(state=DEFAULT_APP_STATE, action={}) {
+export function api(state: ApiState = DEFAULT_APP_STATE, action={}) {
 	switch (action.type) {
-	case API_REQ:
+	case API_REQ: {
+		const requestRefs = action.payload.map(({ ref }) => ref);
+		const inFlight = state.inFlight
+			.filter(ref => !requestRefs.includes[ref]) // clean out current duplicates
+			.concat(requestRefs); // add new requested refs
+
 		if ((action.meta || {}).logout) {
 			// clear app state during logout
-			return { ...DEFAULT_APP_STATE, isFetching: true };
+			return { ...DEFAULT_APP_STATE, inFlight };
 		}
-		return { ...state, isFetching: true };
+
+		return { ...state, inFlight };
+	}
 	case API_RESP_SUCCESS:  // fall though
-	case CACHE_SUCCESS:  // fall through
 	case API_RESP_ERROR:
+	case CACHE_SUCCESS:  // fall through
 		// each of these actions provides an API response that should go into app
 		// state - error responses will contain error info
 		delete state.fail;  // if there are any values, the API is not failing
-		return { ...state, ...responseToState(action.payload.response) };
+		return {
+			...state,
+			...responseToState(action.payload.response),
+			inFlight: state.inFlight.filter(ref => ref !== action.payload.response.ref),
+		};
 	case API_RESP_FAIL:
-		state.fail = action.payload;
-		// fall through - fetch is complete
-	case API_RESP_COMPLETE:
-		return { ...state, isFetching: false };
-
-	default:
-		return state;
+		return { ...state, fail: action.payload };
 	}
+
+	return state;
 }
 
 /**

--- a/src/reducers/platform.js
+++ b/src/reducers/platform.js
@@ -59,13 +59,22 @@ export function api(state: ApiState = DEFAULT_API_STATE, action: FluxStandardAct
 		return {
 			...state,
 			...responseToState((action.payload || {}).response),
-			inFlight: state.inFlight.filter(ref => ref !== (action.payload || {}).response.ref),
 		};
 	case API_RESP_FAIL:
 		return { ...state, fail: action.payload };
+	case API_RESP_COMPLETE: {
+		// allways called - clean up inFlight
+		const refs = (action.payload || []).map(({ ref }) => ref);
+		const inFlight = state.inFlight.filter(ref => !refs.includes(ref));
+		return {
+			...state,
+			inFlight,
+		};
+	}
+	default:
+		return state;
 	}
 
-	return state;
 }
 
 /**

--- a/src/reducers/platform.test.js
+++ b/src/reducers/platform.test.js
@@ -3,10 +3,11 @@ import * as cacheActionCreators from '../actions/cacheActionCreators';
 import * as clickActionCreators from '../actions/clickActionCreators';
 import * as syncActionCreators from '../actions/syncActionCreators';
 import {
-	DEFAULT_APP_STATE,
+	DEFAULT_API_STATE,
+	DEFAULT_APP_STATE,  // DEPRECATED
 	DEFAULT_CLICK_TRACK,
 	api,
-	app,
+	app,  // DEPRECATED
 	clickTracking,
 } from './platform';
 
@@ -75,55 +76,56 @@ describe('app reducer', () => {
 });
 
 describe('api reducer', () => {
-	beforeEach(function() {
-		this.MOCK_STATE = { foo: 'bar' };
-	});
 	it('returns default state for empty action', () => {
-		expect(api({ ...DEFAULT_APP_STATE }, {})).toEqual(DEFAULT_APP_STATE);
+		expect(api({ ...DEFAULT_API_STATE }, {})).toEqual(DEFAULT_API_STATE);
 	});
-	it('re-sets api state on logout API_REQ, with isFetching:true', function() {
-		const logoutRequest = apiActions.requestAll([], { logout: true });
-		expect(api(this.MOCK_STATE, logoutRequest)).toEqual({
-			...DEFAULT_APP_STATE,
-			isFetching: true,
+	it('re-sets api state on logout API_REQ, with inFlight query', function() {
+		const ref = 'foobar';
+		const logoutRequest = apiActions.requestAll([{ ref }], { logout: true });
+		expect(api({ ...DEFAULT_API_STATE }, logoutRequest)).toEqual({
+			...DEFAULT_API_STATE,
+			inFlight: [ref],
 		});
 	});
 	it('adds success response to state tree', () => {
 		const API_RESP_SUCCESS = apiActions.success({ query: {}, response: { ref: 'bing', value: 'baz' } });
-		expect(api({ foo: 'bar'}, API_RESP_SUCCESS)).toEqual({
+		expect(api({ ...DEFAULT_API_STATE, foo: 'bar'}, API_RESP_SUCCESS)).toEqual({
 			foo: 'bar',
-			bing: { value: 'baz' }
+			bing: { ref: 'bing', value: 'baz' },
+			inFlight: [],
 		});
 	});
 	it('adds error response to state tree', () => {
-		const API_RESP_ERROR = apiActions.error({ response: { ref: 'bing', bar: 'baz' } });
-		expect(api({ foo: 'bar'}, API_RESP_ERROR)).toEqual({
+		const API_RESP_ERROR = apiActions.error({ response: { ref: 'bing', error: 'baz' } });
+		expect(api({ ...DEFAULT_API_STATE, foo: 'bar'}, API_RESP_ERROR)).toEqual({
 			foo: 'bar',
-			bing: { bar: 'baz' },
+			bing: { ref: 'bing', error: 'baz' },
+			inFlight: [],
 		});
 	});
 	it('populates an `fail` key on API_RESP_FAIL', () => {
 		const API_RESP_FAIL = apiActions.fail(new Error('this is the worst'));
-		const errorState = api({ ...DEFAULT_APP_STATE }, API_RESP_FAIL);
+		const errorState = api({ ...DEFAULT_API_STATE }, API_RESP_FAIL);
 		expect(errorState).toEqual(expect.objectContaining({ fail: API_RESP_FAIL.payload }));
 	});
-	it('sets isFetching:true on API_REQ', () => {
-		const API_REQ = apiActions.requestAll([]);
-		const appState = api({ ...DEFAULT_APP_STATE }, API_REQ);
-		expect(appState.isFetching).toBe(true);
+	it('adds query ref to inFlight array on API_REQ', () => {
+		const ref = 'foobar';
+		const API_REQ = apiActions.requestAll([{ ref }]);
+		const appState = api({ ...DEFAULT_API_STATE }, API_REQ);
+		expect(appState).toMatchObject({ inFlight: [ref] });
 	});
-	it('sets isFetching:false on API_RESP_COMPLETE', () => {
-		const API_RESP_COMPLETE = apiActions.complete();
-		[true, false, 'monkey'].forEach(isFetching => {
-			const appState = api({ isFetching }, API_RESP_COMPLETE);
-			expect(appState.isFetching).toBe(false);
-		});
-	});
-	it('does not change isFetching on CACHE_SUCCESS', () => {
-		const CACHE_SUCCESS = cacheActionCreators.cacheSuccess({ query: {}, response: { ref: 'foo' } });
-		[true, false, 'monkey'].forEach(isFetching => {
-			const appState = api({ isFetching }, CACHE_SUCCESS);
-			expect(appState.isFetching).toBe(isFetching);
+	it('removes query ref from inFlight array on {API_RESP|CACHE}_{SUCCESS|ERROR}', () => {
+		const ref = 'foobar';
+		const query = { ref };
+		const response = { ref };
+		const actions = [
+			apiActions.success({ query, response }),
+			apiActions.error({ query, response }),
+			cacheActionCreators.cacheSuccess({ query, response }),
+		];
+		actions.forEach(action => {
+			const appState = api({ ...DEFAULT_API_STATE, inFlight: [ref] }, action);
+			expect(appState).toMatchObject({ inFlight: [] });
 		});
 	});
 });

--- a/src/reducers/platform.test.js
+++ b/src/reducers/platform.test.js
@@ -1,5 +1,4 @@
 import * as apiActions from '../actions/apiActionCreators';
-import * as cacheActionCreators from '../actions/cacheActionCreators';
 import * as clickActionCreators from '../actions/clickActionCreators';
 import * as syncActionCreators from '../actions/syncActionCreators';
 import {
@@ -81,22 +80,21 @@ describe('api reducer', () => {
 	it('adds query ref to inFlight array on API_REQ', () => {
 		const ref = 'foobar';
 		const API_REQ = apiActions.requestAll([{ ref }]);
-		const appState = api({ ...DEFAULT_API_STATE }, API_REQ);
-		expect(appState).toMatchObject({ inFlight: [ref] });
+		const apiState = api({ ...DEFAULT_API_STATE }, API_REQ);
+		expect(apiState).toMatchObject({ inFlight: [ref] });
 	});
-	it('removes query ref from inFlight array on {API_RESP|CACHE}_{SUCCESS|ERROR}', () => {
-		const ref = 'foobar';
-		const query = { ref };
-		const response = { ref };
-		const actions = [
-			apiActions.success({ query, response }),
-			apiActions.error({ query, response }),
-			cacheActionCreators.cacheSuccess({ query, response }),
-		];
-		actions.forEach(action => {
-			const appState = api({ ...DEFAULT_API_STATE, inFlight: [ref] }, action);
-			expect(appState).toMatchObject({ inFlight: [] });
-		});
+	it('removes query refs from inFlight array on API_RESP_COMPLETE', () => {
+		const ref1 = 'foobar';
+		const ref2 = 'barfoo';
+		const query1 = { ref: ref1 };
+		const query2 = { ref: ref2 };
+
+		const inFlightState = [ref1, ref2, 'asdf'];
+		const expectedInFlightState = ['asdf'];
+		const completeAction = apiActions.complete([query1, query2]);
+
+		const apiState = api({ ...DEFAULT_API_STATE, inFlight: inFlightState }, completeAction);
+		expect(apiState).toMatchObject({ inFlight: expectedInFlightState });
 	});
 });
 

--- a/src/reducers/platform.test.js
+++ b/src/reducers/platform.test.js
@@ -33,7 +33,6 @@ describe('app reducer', () => {
 			foo: 'bar',
 			bar: 'baz',
 			baz: 'foo',
-			isFetching: false,
 		});
 	});
 	it('populates an `error` key on API_ERROR', () => {
@@ -43,35 +42,6 @@ describe('app reducer', () => {
 		};
 		const errorState = app(undefined, API_ERROR);
 		expect(errorState.error).toBe(API_ERROR.payload);
-	});
-	it('sets isFetching:true on API_REQUEST', () => {
-		const API_REQUEST = {
-			type: 'API_REQUEST',
-			payload: [],
-			meta: {},
-		};
-		const appState = app(undefined, API_REQUEST);
-		expect(appState.isFetching).toBe(true);
-	});
-	it('sets isFetching:false on API_SUCCESS', () => {
-		const API_SUCCESS = {
-			type: 'API_SUCCESS',
-			payload: { queries: [], responses: [] },
-		};
-		[true, false, 'monkey'].forEach(isFetching => {
-			const appState = app({ isFetching }, API_SUCCESS);
-			expect(appState.isFetching).toBe(false);
-		});
-	});
-	it('does not change isFetching on CACHE_SUCCESS', () => {
-		const CACHE_SUCCESS = {
-			type: 'CACHE_SUCCESS',
-			payload: { queries: [], responses: [] },
-		};
-		[true, false, 'monkey'].forEach(isFetching => {
-			const appState = app({ isFetching }, CACHE_SUCCESS);
-			expect(appState.isFetching).toBe(isFetching);
-		});
 	});
 });
 


### PR DESCRIPTION
After talking with @nlaz about how they would like to use `isFetching`, it looks like it would be much more useful to keep track of all in-flight API requests in an array instead of a 'dumb' boolean, which will allow for much more reliable tracking of API request state.

This PR removes `state.api.isFetching` and replaces it with `state.api.inFlight` - the old `state.app.isFetching` is still in place for legacy support.

Also, flow type annotations for the new platform api reducer.