### PR TITLE
WP 308 Support variants service through API headers

### DIFF
--- a/docs/Queries.md
+++ b/docs/Queries.md
@@ -47,7 +47,7 @@ A Query is just a plain object with the following shape:
     method: 'get',  // generally not needed
     variants: {
       'my-member-experiment': 1234,  // memberId
-      'my-group-experiment: 5678,    // chapterId
+      'my-group-experiment': 5678,    // chapterId
     },
   },
 }

--- a/docs/Queries.md
+++ b/docs/Queries.md
@@ -25,6 +25,9 @@ A Query is just a plain object with the following shape:
   meta?: {
     flags?: string[],
     method?: string
+    variants: {
+      [string]: string | string[],  // e.g. { experiment1: chapterId }
+    },
   },
 }
 ```
@@ -64,12 +67,12 @@ array or a singleton.
 - `comment`
 - feature-specific objects like `home`, `conversations`
 
-#### `flags`
+#### `meta`
+
+##### `flags`
 
 An array of feature flag (Runtime Flag) names that should be returned
 alongside the main request.
-
-#### `meta`
 
 ##### `method`
 
@@ -81,6 +84,13 @@ different `method`s.
 Alternatively, you can use method-specific action creators to automatically
 assingn the method and make the request for individual requests.
 
+##### `variants`
+
+You can request variant names for particular experiments with particular
+contexts by populating `meta.variants` with an object containing keys that are
+experiment names and values that are string IDs (member ID or chapter ID
+depending on the experiment)
+
 ### Query Response
 
 A query response is also a plain object
@@ -90,8 +100,14 @@ A query response is also a plain object
   ref: string,
   value: any,
   type?: string,
-  flags?: array,
-  meta?: object,
+  meta?: {
+    flags?: string[],
+    variants?: {
+      [string]: {  // experiment
+        [string]: string  // context: variant
+      },
+    },
+  },
 }
 ```
 

--- a/docs/Queries.md
+++ b/docs/Queries.md
@@ -32,6 +32,27 @@ A Query is just a plain object with the following shape:
 }
 ```
 
+**Example**
+
+```js
+{
+  ref: 'foobar',
+  endpoint: 'foo/bar',
+  params: {
+    memberId: 1234,
+  },
+  type: 'foo',  // generally not needed
+  meta: {
+    flags: ['thisflag', 'thatflag'],
+    method: 'get',  // generally not needed
+    variants: {
+      'my-member-experiment': 1234,  // memberId
+      'my-group-experiment: 5678,    // chapterId
+    },
+  },
+}
+```
+
 #### `ref`
 
 A unique string reference to the query. The `ref` is used to uniquely identify

--- a/docs/Queries.md
+++ b/docs/Queries.md
@@ -26,7 +26,7 @@ A Query is just a plain object with the following shape:
     flags?: string[],
     method?: string
     variants: {
-      [string]: string | string[],  // e.g. { experiment1: chapterId }
+      [string]: string | number | string[] | number[],  // e.g. { experiment1: chapterId }
     },
   },
 }
@@ -110,7 +110,7 @@ assingn the method and make the request for individual requests.
 You can request variant names for particular experiments with particular
 contexts by populating `meta.variants` with an object containing keys that are
 experiment names and values that are string IDs (member ID or chapter ID
-depending on the experiment)
+depending on the experiment).
 
 ### Query Response
 
@@ -131,6 +131,14 @@ A query response is also a plain object
   },
 }
 ```
+
+#### `meta`
+
+#### `variants`
+
+If a query contains a `meta.variants` request, the query response _might not
+contain a corresponding `variants` response_ if the variants service fails -
+you must test for the existence of `meta.variants` before reading from it.
 
 ## Usage
 

--- a/src/util/apiUtils.js
+++ b/src/util/apiUtils.js
@@ -65,7 +65,7 @@ export const parseVariantsHeader = variantsHeader =>
 			const [experiment, val] = keyval.split('=');
 			variants[experiment] = variants[experiment] || {};
 			const [context, variant] = val.split('|');
-			variants[experiment][context] = variant;
+			variants[experiment][context] = variant || null;
 			return variants;
 		}, {});
 

--- a/src/util/apiUtils.test.js
+++ b/src/util/apiUtils.test.js
@@ -32,6 +32,7 @@ import {
 	parseApiValue,
 	parseLoginAuth,
 	parseMetaHeaders,
+	parseVariantsHeader,
 	groupDuotoneSetter,
 } from './apiUtils';
 
@@ -251,6 +252,22 @@ describe('parseMetaHeaders', () => {
 	it('returns empty object for empty headers', () => {
 		expect(parseMetaHeaders({}))
 			.toEqual({});
+	});
+});
+
+describe('parseVariantsHeader', () => {
+	it('parses a variants header into a nested object', () => {
+		const header = 'binge-pilot=123|variant critical-mass=1|control critical-mass=2|sendemail';
+		const expectedObj = {
+			'binge-pilot': {
+				123: 'variant',
+			},
+			'critical-mass': {
+				1: 'control',
+				2: 'sendemail',
+			},
+		};
+		expect(parseVariantsHeader(header)).toEqual(expectedObj);
 	});
 });
 

--- a/src/util/apiUtils.test.js
+++ b/src/util/apiUtils.test.js
@@ -269,6 +269,15 @@ describe('parseVariantsHeader', () => {
 		};
 		expect(parseVariantsHeader(header)).toEqual(expectedObj);
 	});
+	it('sets `null` variant for missing variant', () => {
+		const header = 'binge-pilot=123|';
+		const expectedObj = {
+			'binge-pilot': {
+				123: null,
+			},
+		};
+		expect(parseVariantsHeader(header)).toEqual(expectedObj);
+	});
 });
 
 describe('buildRequestArgs', () => {

--- a/src/util/validation.js
+++ b/src/util/validation.js
@@ -1,5 +1,8 @@
 import Joi from 'joi';
 
+const stringOrArray = Joi.alternatives()
+	.try([Joi.string(), Joi.array().items(Joi.string())]);
+
 export const querySchema = Joi.object({
 	endpoint: Joi.string().required(),
 	ref: Joi.string().required(),
@@ -9,6 +12,9 @@ export const querySchema = Joi.object({
 	type: Joi.string(),
 	meta: Joi.object({
 		method: Joi.string().valid('get', 'post', 'delete', 'patch').insensitive(),
+		flags: Joi.array(),
+		variants: Joi.object()
+			.pattern(/\w+/, stringOrArray)
 	}),
 });
 


### PR DESCRIPTION
This updates the Query `meta` object with a `variants` property that can be used to request 'variants' from the variants service integrated into the REST API: https://meetup.atlassian.net/wiki/display/MUP/X-Meetup-Variants

Docs included

```js
// request Query
{
  ...
  meta: {
    variants: {
      'my-experiment': memberId
    } 
  }
}

// query response
{
  ...
  meta: {
    variants: {
      'my-experiment': {
        [memberId]: 'variantname',
      }
    }
  }
}

// access from Redux state
const variant = state.api[ref].meta.variants['my-experiment'][memberId];
```

