### PR TITLE
Deprecate browser render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,31 @@
+## [2.4]
+
+- **Deprecated** `renderers/browser-render.jsx` has been deprecated - consumer
+  applications should use vanilla React render methods to render a `<BrowserApp
+  />`, which is the new entry point for a platform-based applications, at
+  `src/components/BrowserApp.jsx`. The browser entry point should contain the
+  following code:
+
+    ```jsx
+    import ReactDOM from 'react-dom';
+    import {
+      getInitialState,
+      getBrowserCreateStore
+    } from '../util/createStoreBrowser';
+
+    const routes = ...;
+    const reducer = ...;
+    const middleware = ... || [];
+    const basename = ... || '';
+
+		const createStore = getBrowserCreateStore(routes, middleware, basename);
+		const store = createStore(reducer, getInitialState(window.APP_RUNTIME));
+		ReactDOM.render(
+			<BrowserApp routes={routes} store={store} basename={basename} />,
+			document.getElementById('outlet')  // this is a hard-coded id
+		);
+    ```
+
 ## [2.3]
 
 - **Replaced** `state.api.isFetching` has been replaced with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,12 @@
     const middleware = ... || [];
     const basename = ... || '';
 
-		const createStore = getBrowserCreateStore(routes, middleware, basename);
-		const store = createStore(reducer, getInitialState(window.APP_RUNTIME));
-		ReactDOM.render(
-			<BrowserApp routes={routes} store={store} basename={basename} />,
-			document.getElementById('outlet')  // this is a hard-coded id
-		);
+    const createStore = getBrowserCreateStore(routes, middleware, basename);
+    const store = createStore(reducer, getInitialState(window.APP_RUNTIME));
+    ReactDOM.render(
+      <BrowserApp routes={routes} store={store} basename={basename} />,
+      document.getElementById('outlet')  // this is a hard-coded id
+    );
     ```
 
 ## [2.3]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CI_BUILD_NUMBER ?= $(USER)-snapshot
-VERSION ?= 2.2.$(CI_BUILD_NUMBER)
+VERSION ?= 2.4.$(CI_BUILD_NUMBER)
 
 version:
 	@echo $(VERSION)

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "joi": "10.4.1",
     "js-cookie": "2.1.4",
     "node-fetch": "1.6.3",
+    "prop-types": "15.5.8",
     "qs": "6.4.0",
     "react-dom": "15.5.4",
     "react-side-effect": "1.1.0",

--- a/src/components/BrowserApp.jsx
+++ b/src/components/BrowserApp.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { getBrowserCreateStore } from '../util/createStoreBrowser';
+import BrowserRouter from 'react-router-dom/BrowserRouter';
+import PlatformApp from '../components/PlatformApp';
+
+/**
+ * This function creates a 'renderer', which is just a function that, when
+ * called, will call ReactDOM.render() to render the application
+ *
+ * The routes, reducer, and app-specific middleware are provided by the
+ * application - everything else is general to the meetup web platform
+ *
+ * @param {Object} routes the React Router routes object
+ * @param {Function} reducer the root Redux reducer for the app
+ * @param {Function} middleware (optional) any app-specific middleware that
+ *   should be applied to the store
+ * @param {String} baseUrl an optional baseUrl to serve the site from,
+ * 	_including_ surrounding slashes, e.g. '/en-US/'
+ *
+ * @returns {Function} a function that results in a ReactDOM.render call - can
+ *   use a custom root element ID or default to `'outlet'`
+ */
+class BrowserApp extends React.Component {
+	constructor(props) {
+		super(props);
+		// the initial state is delivered in the HTML from the server as a plain object
+		// containing the HTML-escaped JSON string in `window.INITIAL_STATE.escapedState`.
+		// unescape the text using native `textarea.textContent` unescaping
+		const escape = document.createElement('textarea');
+		escape.innerHTML = window.APP_RUNTIME.escapedState;
+		const unescapedStateJSON = escape.textContent;
+		const initialState = JSON.parse(unescapedStateJSON);
+		const createStore = getBrowserCreateStore(props.routes, props.middleware, props.baseUrl);
+		this.store = createStore(props.reducer, initialState);
+	}
+	render() {
+		const { baseUrl, routes } = this.props;
+		return (
+			<BrowserRouter basename={baseUrl}>
+				<PlatformApp store={this.store} routes={routes} />
+			</BrowserRouter>
+		);
+	}
+}
+
+BrowserApp.propTypes = {
+	routes: PropTypes.array.isRequired,
+	reducer: PropTypes.func.isRequired,
+	middleware: PropTypes.array.isRequired,
+	baseUrl: PropTypes.string.isRequired,
+};
+BrowserApp.defaultProps = {
+	middleware: [],
+	baseUrl: '',
+};
+
+export default BrowserApp;
+

--- a/src/components/BrowserApp.jsx
+++ b/src/components/BrowserApp.jsx
@@ -20,10 +20,10 @@ class BrowserApp extends React.Component {
 BrowserApp.propTypes = {
 	routes: PropTypes.array.isRequired,
 	store: PropTypes.object.isRequired,
-	baseUrl: PropTypes.string.isRequired,
+	basename: PropTypes.string.isRequired,
 };
 BrowserApp.defaultProps = {
-	baseUrl: '',
+	basename: '',
 };
 
 export default BrowserApp;

--- a/src/components/BrowserApp.jsx
+++ b/src/components/BrowserApp.jsx
@@ -1,44 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { getBrowserCreateStore } from '../util/createStoreBrowser';
 import BrowserRouter from 'react-router-dom/BrowserRouter';
 import PlatformApp from '../components/PlatformApp';
 
 /**
- * This function creates a 'renderer', which is just a function that, when
- * called, will call ReactDOM.render() to render the application
- *
- * The routes, reducer, and app-specific middleware are provided by the
- * application - everything else is general to the meetup web platform
- *
- * @param {Object} routes the React Router routes object
- * @param {Function} reducer the root Redux reducer for the app
- * @param {Function} middleware (optional) any app-specific middleware that
- *   should be applied to the store
- * @param {String} baseUrl an optional baseUrl to serve the site from,
- * 	_including_ surrounding slashes, e.g. '/en-US/'
- *
- * @returns {Function} a function that results in a ReactDOM.render call - can
- *   use a custom root element ID or default to `'outlet'`
+ * A simple component to wrap the base PlatformApp with the BrowserRouter
  */
 class BrowserApp extends React.Component {
-	constructor(props) {
-		super(props);
-		// the initial state is delivered in the HTML from the server as a plain object
-		// containing the HTML-escaped JSON string in `window.INITIAL_STATE.escapedState`.
-		// unescape the text using native `textarea.textContent` unescaping
-		const escape = document.createElement('textarea');
-		escape.innerHTML = window.APP_RUNTIME.escapedState;
-		const unescapedStateJSON = escape.textContent;
-		const initialState = JSON.parse(unescapedStateJSON);
-		const createStore = getBrowserCreateStore(props.routes, props.middleware, props.baseUrl);
-		this.store = createStore(props.reducer, initialState);
-	}
 	render() {
-		const { baseUrl, routes } = this.props;
+		const { basename, store, routes } = this.props;
 		return (
-			<BrowserRouter basename={baseUrl}>
-				<PlatformApp store={this.store} routes={routes} />
+			<BrowserRouter basename={basename}>
+				<PlatformApp store={store} routes={routes} />
 			</BrowserRouter>
 		);
 	}
@@ -46,12 +19,10 @@ class BrowserApp extends React.Component {
 
 BrowserApp.propTypes = {
 	routes: PropTypes.array.isRequired,
-	reducer: PropTypes.func.isRequired,
-	middleware: PropTypes.array.isRequired,
+	store: PropTypes.object.isRequired,
 	baseUrl: PropTypes.string.isRequired,
 };
 BrowserApp.defaultProps = {
-	middleware: [],
 	baseUrl: '',
 };
 

--- a/src/components/BrowserApp.test.jsx
+++ b/src/components/BrowserApp.test.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import TestUtils from 'react-dom/test-utils';
+import BrowserApp from './BrowserApp';
+
+const renderer = TestUtils.createRenderer();
+
+describe('BrowserApp', function() {
+	const routes = [];
+	const baseUrl = '';
+	const browserApp = (
+		<BrowserApp routes={routes} store={{}} baseUrl={baseUrl} />
+	);
+	renderer.render(
+		browserApp
+	);
+	const app = renderer.getRenderOutput();  // this actually returns the <BrowserRouter> instance
+	it('exists', function() {
+		expect(app).not.toBeNull();
+	});
+});
+

--- a/src/renderers/browser-render.jsx
+++ b/src/renderers/browser-render.jsx
@@ -4,12 +4,18 @@ import { getInitialState, getBrowserCreateStore } from '../util/createStoreBrows
 import BrowserApp from '../components/BrowserApp';
 
 /**
+ * @module browser-render
+ * @deprecated see CHANGELOG v2.4
+ */
+
+/**
  * This function creates a 'renderer', which is just a function that, when
  * called, will call ReactDOM.render() to render the application
  *
  * The routes, reducer, and app-specific middleware are provided by the
  * application - everything else is general to the meetup web platform
  *
+ * @deprecated
  * @param {Object} routes the React Router routes object
  * @param {Function} reducer the root Redux reducer for the app
  * @param {Function} middleware (optional) any app-specific middleware that

--- a/src/renderers/browser-render.jsx
+++ b/src/renderers/browser-render.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { getBrowserCreateStore } from '../util/createStoreBrowser';
-import BrowserRouter from 'react-router-dom/BrowserRouter';
-import PlatformApp from '../components/PlatformApp';
+import BrowserApp from '../components/BrowserApp';
 
 /**
  * This function creates a 'renderer', which is just a function that, when
@@ -22,24 +20,12 @@ import PlatformApp from '../components/PlatformApp';
  *   use a custom root element ID or default to `'outlet'`
  */
 function makeRenderer(routes, reducer, middleware=[], baseUrl='') {
-	// the initial state is delivered in the HTML from the server as a plain object
-	// containing the HTML-escaped JSON string in `window.INITIAL_STATE.escapedState`.
-	// unescape the text using native `textarea.textContent` unescaping
-	const escape = document.createElement('textarea');
-	escape.innerHTML = window.APP_RUNTIME.escapedState;
-	const unescapedStateJSON = escape.textContent;
-	const initialState = JSON.parse(unescapedStateJSON);
-	const createStore = getBrowserCreateStore(routes, middleware, baseUrl);
-	const store = createStore(reducer, initialState);
-
 	return (rootElId='outlet') => {
-		ReactDOM.render(
-			<BrowserRouter basename={baseUrl}>
-				<PlatformApp store={store} routes={routes} />
-			</BrowserRouter>,
+		const app = ReactDOM.render(
+			<BrowserApp routes={routes} reducer={reducer} middleware={middleware} baseUrl={baseUrl} />,
 			document.getElementById(rootElId)
 		);
-		return store;
+		return app.store;
 	};
 }
 

--- a/src/renderers/browser-render.jsx
+++ b/src/renderers/browser-render.jsx
@@ -1,17 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { getBrowserCreateStore } from '../util/createStoreBrowser';
+import { getInitialState, getBrowserCreateStore } from '../util/createStoreBrowser';
 import BrowserApp from '../components/BrowserApp';
-
-const getInitialState = APP_RUNTIME => {
-	// the initial state is delivered in the HTML from the server as a plain object
-	// containing the HTML-escaped JSON string in `window.INITIAL_STATE.escapedState`.
-	// unescape the text using native `textarea.textContent` unescaping
-	const escape = document.createElement('textarea');
-	escape.innerHTML = APP_RUNTIME.escapedState;
-	const unescapedStateJSON = escape.textContent;
-	return JSON.parse(unescapedStateJSON);
-};
 
 /**
  * This function creates a 'renderer', which is just a function that, when
@@ -32,9 +22,8 @@ const getInitialState = APP_RUNTIME => {
  */
 function makeRenderer(routes, reducer, middleware=[], baseUrl='') {
 	return (rootElId='outlet') => {
-		const initialState = getInitialState(window.APP_RUNTIME);
 		const createStore = getBrowserCreateStore(routes, middleware, baseUrl);
-		const store = createStore(reducer, initialState);
+		const store = createStore(reducer, getInitialState(window.APP_RUNTIME));
 		ReactDOM.render(
 			<BrowserApp routes={routes} store={store} basename={baseUrl} />,
 			document.getElementById(rootElId)

--- a/src/util/createStoreBrowser.js
+++ b/src/util/createStoreBrowser.js
@@ -17,6 +17,19 @@ export const clickTrackEnhancer = createStore => (reducer, initialState, enhance
 	return store;
 };
 
+export const getInitialState = APP_RUNTIME => {
+	// the initial state is delivered in the HTML from the server as a plain object
+	// containing the HTML-escaped JSON string in `window.INITIAL_STATE.escapedState`.
+	// unescape the text using native `textarea.textContent` unescaping
+	if (!APP_RUNTIME) {
+		return;
+	}
+	const escape = document.createElement('textarea');
+	escape.innerHTML = APP_RUNTIME.escapedState;
+	const unescapedStateJSON = escape.textContent;
+	return JSON.parse(unescapedStateJSON);
+};
+
 export function getBrowserCreateStore(
 	routes,
 	middleware=[],

--- a/src/util/createStoreBrowser.js
+++ b/src/util/createStoreBrowser.js
@@ -1,3 +1,4 @@
+// @flow weak
 import { applyMiddleware, createStore, compose } from 'redux';
 
 import { fetchQueries } from '../util/fetchUtils';
@@ -5,6 +6,7 @@ import getClickTracker from './clickTracking';
 import getEpicMiddleware from '../middleware/epic';
 import catchMiddleware from '../middleware/catch';
 
+declare var document: Object;  // ignore 'potentially null' document.body
 
 const noopMiddleware = store => next => action => next(action);
 
@@ -17,10 +19,12 @@ export const clickTrackEnhancer = createStore => (reducer, initialState, enhance
 	return store;
 };
 
-export const getInitialState = APP_RUNTIME => {
-	// the initial state is delivered in the HTML from the server as a plain object
-	// containing the HTML-escaped JSON string in `window.INITIAL_STATE.escapedState`.
-	// unescape the text using native `textarea.textContent` unescaping
+/**
+ * the initial state is delivered in the HTML from the server as a plain object
+ * containing the HTML-escaped JSON string in `window.INITIAL_STATE.escapedState`.
+ * unescape the text using native `textarea.textContent` unescaping
+ */
+export const getInitialState = (APP_RUNTIME: { escapedState: string }): ?Object => {
 	if (!APP_RUNTIME) {
 		return;
 	}

--- a/src/util/createStoreBrowser.test.js
+++ b/src/util/createStoreBrowser.test.js
@@ -1,6 +1,7 @@
 import { createStore } from 'redux';
 import {
 	clickTrackEnhancer,
+	getInitialState,
 	getBrowserCreateStore,
 } from './createStoreBrowser';
 import {
@@ -33,5 +34,22 @@ describe('clickTrackEnhancer', () => {
 
 describe('getBrowserCreateStore', () => {
 	testCreateStore(getBrowserCreateStore(MOCK_ROUTES, []));
+});
+
+describe('getInitialState', () => {
+	const injectedState = { foo: 'bar' };
+	global.document.createElement = jest.fn(() => {
+		return {
+			set innerHTML(stateJSON) {
+				const state = JSON.parse(stateJSON);
+				this.textContent = JSON.stringify({ ...injectedState, ...state });
+			},
+		};
+	});
+	it('returns "unescaped" APP_RUNTIME.escapedState', () => {
+		const state = { baz: 'qux' };
+		const APP_RUNTIME = { escapedState: JSON.stringify(state) };
+		expect(getInitialState(APP_RUNTIME)).toEqual({ ...injectedState, ...state });
+	});
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3229,7 +3229,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.0.0, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@~15.5.7:
+prop-types@15.5.8, prop-types@^15.0.0, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@~15.5.7:
   version "15.5.8"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
   dependencies:


### PR DESCRIPTION
**Prelim until I flesh out docs and tests**

Instead of letting the platform call `ReactDOM.render`, it will be better to package up the browser rendering into a component that can be directly imported by consumer applications. This will allow consumer apps to further wrap the application if they so choose, e.g. for hot reloading.

cc @mikespencer I think you might appreciate this one