### PR TITLE
convert MEETUP_LANGUAGE to accept-language header

### DIFF
--- a/src/util/apiUtils.js
+++ b/src/util/apiUtils.js
@@ -320,11 +320,22 @@ export function getAuthHeaders(request) {
 	};
 }
 
+export function getLanguageHeader(request) {
+	const cookieLang = getCookieLang(request);
+	const headerLang = request.headers['accept-language'];
+	const acceptLang = cookieLang ?
+		`${cookieLang},${headerLang}` :
+		headerLang;
+	return {
+		'accept-language': acceptLang,
+	};
+}
+
 export function parseRequestHeaders(request) {
 	const externalRequestHeaders = {
 		...request.headers,
 		...getAuthHeaders(request),
-		'accept-language': getCookieLang(request) || request.headers['accept-language'],
+		'accept-language': getCookieLang(request),
 	};
 
 	delete externalRequestHeaders['host'];  // let app server set 'host'

--- a/src/util/apiUtils.js
+++ b/src/util/apiUtils.js
@@ -335,7 +335,7 @@ export function parseRequestHeaders(request) {
 	const externalRequestHeaders = {
 		...request.headers,
 		...getAuthHeaders(request),
-		'accept-language': getCookieLang(request),
+		'accept-language': getLanguageHeader(request),
 	};
 
 	delete externalRequestHeaders['host'];  // let app server set 'host'

--- a/src/util/apiUtils.js
+++ b/src/util/apiUtils.js
@@ -323,9 +323,9 @@ export function getAuthHeaders(request) {
 export function getLanguageHeader(request) {
 	const cookieLang = getCookieLang(request);
 	const headerLang = request.headers['accept-language'];
-	const acceptLang = cookieLang ?
+	const acceptLang = cookieLang && headerLang ?
 		`${cookieLang},${headerLang}` :
-		headerLang;
+		(cookieLang || headerLang);
 	return {
 		'accept-language': acceptLang,
 	};

--- a/src/util/apiUtils.js
+++ b/src/util/apiUtils.js
@@ -326,9 +326,7 @@ export function getLanguageHeader(request) {
 	const acceptLang = cookieLang && headerLang ?
 		`${cookieLang},${headerLang}` :
 		(cookieLang || headerLang);
-	return {
-		'accept-language': acceptLang,
-	};
+	return acceptLang;
 }
 
 export function parseRequestHeaders(request) {

--- a/src/util/apiUtils.js
+++ b/src/util/apiUtils.js
@@ -20,6 +20,9 @@ import {
 	removeAuthState,
 } from './authUtils';
 import {
+	getCookieLang
+} from './languageUtils';
+import {
 	coerceBool,
 	toCamelCase,
 } from './stringUtils';
@@ -321,6 +324,7 @@ export function parseRequestHeaders(request) {
 	const externalRequestHeaders = {
 		...request.headers,
 		...getAuthHeaders(request),
+		'accept-language': getCookieLang(request) || request.headers['accept-language'],
 	};
 
 	delete externalRequestHeaders['host'];  // let app server set 'host'

--- a/src/util/apiUtils.test.js
+++ b/src/util/apiUtils.test.js
@@ -18,6 +18,9 @@ import {
 } from 'meetup-web-mocks/lib/api';
 
 import * as authUtils from '../util/authUtils';
+import {
+	LANGUAGE_COOKIE
+} from './cookieUtils';
 
 import {
 	apiResponseToQueryResponse,
@@ -25,6 +28,7 @@ import {
 	buildRequestArgs,
 	errorResponse$,
 	getAuthHeaders,
+	getLanguageHeader,
 	injectResponseCookies,
 	logApiResponse,
 	parseRequest,
@@ -78,6 +82,32 @@ describe('getAuthHeaders', () => {
 		expect(cookies['MEETUP_CSRF']).not.toBeUndefined();
 		expect(cookies['MEETUP_CSRF_DEV']).not.toBeUndefined();
 		expect(authHeaders['csrf-token']).toEqual(cookies['MEETUP_CSRF']);
+	});
+});
+
+describe('getLanguageHeader', () => {
+	it('returns accept-language containing parsed MEMBER_LANGUAGE cookie', () => {
+		const request = {
+			headers: {},
+			state: { [LANGUAGE_COOKIE]: 'language=fr&country=FR' },
+		};
+		expect(getLanguageHeader(request)).toEqual({ 'accept-language': 'fr-FR' });
+	});
+	it('prepends parsed MEMBER_LANGUAGE cookie on existing accepts-langauge', () => {
+		const headerLang = 'foo';
+		const request = {
+			headers: { 'accept-language': headerLang },
+			state: { [LANGUAGE_COOKIE]: 'language=fr&country=FR' },
+		};
+		expect(getLanguageHeader(request)).toEqual({ 'accept-language': `fr-FR,${headerLang}` });
+	});
+	it('returns existing accepts-langauge unmodified when no language cookie', () => {
+		const headerLang = 'foo';
+		const request = {
+			headers: { 'accept-language': headerLang },
+			state: {},
+		};
+		expect(getLanguageHeader(request)).toEqual({ 'accept-language': headerLang });
 	});
 });
 

--- a/src/util/apiUtils.test.js
+++ b/src/util/apiUtils.test.js
@@ -91,7 +91,7 @@ describe('getLanguageHeader', () => {
 			headers: {},
 			state: { [LANGUAGE_COOKIE]: 'language=fr&country=FR' },
 		};
-		expect(getLanguageHeader(request)).toEqual({ 'accept-language': 'fr-FR' });
+		expect(getLanguageHeader(request)).toEqual('fr-FR');
 	});
 	it('prepends parsed MEMBER_LANGUAGE cookie on existing accepts-langauge', () => {
 		const headerLang = 'foo';
@@ -99,7 +99,7 @@ describe('getLanguageHeader', () => {
 			headers: { 'accept-language': headerLang },
 			state: { [LANGUAGE_COOKIE]: 'language=fr&country=FR' },
 		};
-		expect(getLanguageHeader(request)).toEqual({ 'accept-language': `fr-FR,${headerLang}` });
+		expect(getLanguageHeader(request)).toEqual(`fr-FR,${headerLang}`);
 	});
 	it('returns existing accepts-langauge unmodified when no language cookie', () => {
 		const headerLang = 'foo';
@@ -107,7 +107,7 @@ describe('getLanguageHeader', () => {
 			headers: { 'accept-language': headerLang },
 			state: {},
 		};
-		expect(getLanguageHeader(request)).toEqual({ 'accept-language': headerLang });
+		expect(getLanguageHeader(request)).toEqual(headerLang);
 	});
 });
 

--- a/src/util/cookieUtils.js
+++ b/src/util/cookieUtils.js
@@ -2,6 +2,7 @@ import querystring from 'qs';
 
 const isProd = process.env.NODE_ENV === 'production';
 export const MEMBER_COOKIE = isProd ? 'MEETUP_MEMBER' : 'MEETUP_MEMBER_DEV';
+export const LANGUAGE_COOKIE = isProd ? 'MEETUP_LANGUAGE' : 'MEETUP_LANGUAGE_DEV';
 
 export const parseMemberCookie = state => {
 	if (!state[MEMBER_COOKIE]) {

--- a/src/util/languageUtils.js
+++ b/src/util/languageUtils.js
@@ -2,10 +2,14 @@ import querystring from 'qs';
 import url from 'url';
 import Accepts from 'accepts';
 
+import {
+	LANGUAGE_COOKIE
+} from './cookieUtils';
+
 export const LANG_DEFAULT = 'en-US';
 
 export const getCookieLang = (request, supportedLangs) => {
-	const cookie = request.state.MEETUP_LANGUAGE;
+	const cookie = request.state[LANGUAGE_COOKIE];
 	if (!cookie) {
 		return;
 	}

--- a/src/util/languageUtils.js
+++ b/src/util/languageUtils.js
@@ -14,7 +14,10 @@ export const getCookieLang = (request, supportedLangs) => {
 		country,
 	} = querystring.parse(cookie);
 	const cookieLang = `${language}-${country}`;
-	return supportedLangs.includes(cookieLang) && cookieLang;
+	if (supportedLangs) {
+		return supportedLangs.includes(cookieLang) && cookieLang;
+	}
+	return cookieLang;
 };
 
 export const getUrlLang = (request, supportedLangs) => {

--- a/src/util/languageUtils.test.js
+++ b/src/util/languageUtils.test.js
@@ -1,6 +1,9 @@
 import querystring from 'qs';
 import url from 'url';
 import {
+	LANGUAGE_COOKIE
+} from './cookieUtils';
+import {
 	getCookieLang,
 	getUrlLang,
 	getBrowserLang,
@@ -35,7 +38,7 @@ describe('getCookieLang', () => {
 			country: 'FR',
 			language: 'fr',
 		});
-		const request = { ...MOCK_HAPI_REQUEST, state: { MEETUP_LANGUAGE } };
+		const request = { ...MOCK_HAPI_REQUEST, state: { [LANGUAGE_COOKIE]: MEETUP_LANGUAGE } };
 		const lang = getCookieLang(request, supportedLangs);
 		expect(lang).toEqual(altLang);
 	});


### PR DESCRIPTION
https://meetup.atlassian.net/browse/WP-310

apparently the API doesn't read the MEETUP_LANGUAGE cookie to set the language of its response - it respect `Accept-Language` only

This PR forces the `Accept-Language` header to be the cookie language.