### PR TITLE
Update yarn test scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,11 +13,10 @@
     "flow": "flow",
     "lint": "eslint . --ext .js,.jsx --fix",
     "precommit": "lint-staged",
-    "test": "yarn run flow && yarn run test:unit && yarn run test:integration -- --silent",
-    "test:base": "jest --config jest.config.json",
+    "test": "yarn run flow && yarn run test:unit -- --silent --coverage && yarn run test:integration -- --silent",
     "test:integration": "NODE_ENV=test jest --config jest.int.config.json",
-    "test:unit": "NODE_ENV=test yarn test:base -- --silent --coverage",
-    "test:watch": "yarn test:base -- --watch"
+    "test:unit": "NODE_ENV=test jest --config jest.config.json",
+    "test:watch": "yarn test:unit -- --watch"
   },
   "repository": {
     "type": "git",

--- a/src/util/logger.js
+++ b/src/util/logger.js
@@ -1,7 +1,7 @@
 import pino from 'pino';
 
 const prettyPrint = process.env.NODE_ENV !== 'production';
-const enabled = !process.argv.includes('--silent');
+const enabled = process.env.NODE_ENV !== 'test'; // don't print when running tests
 
 const reqSerializerDev = req => `${req.method.toUpperCase()} ${req.url.href}`;
 const resSerializerDev = res => res.statusCode;
@@ -10,7 +10,9 @@ const pretty = pino.pretty({
 	forceColor: true,
 	messageKey: 'message', // Stackdriver uses this key for log summary
 });
+
 pretty.pipe(process.stdout);
+
 const logger = pino(
 	{
 		timestamp: prettyPrint, // prod logs provide their own timestamp


### PR DESCRIPTION
As part of the node-convict branch, I noticed that the yarn test scripts weren't really doing what I would want them to do, and I would often have to run either a subset command or pass in a `-- --verbose` argument that would end up with a command like `NODE_ENV=test yarn test:base -- silent -- coverage --verbose`, which works but supplies both silent and verbose.

What I propose here is that `test:unit` and `test:integration` don't supply any arguments to jest, and all `-- silent` and `-- coverage` flags are passed from either the `yarn run test` script or via the command line. By doing this we don't need a `test:base` script either.

Thoughts?

Also, pino INFO logs are making the integration tests hard to read. For example:

```
RUNS  src/util/apiUtils.test.js
 RUNS  src/plugins/requestAuthPlugin.test.js
 RUNS  src/routes.test.js

Test Suites: 1 passed, 1 of 32 total
Tests:       8 passed, 8 total
Snapshots:   0 total
Time:        5s, estimated 6s
                                        [2017-05-03T14:56:44.193Z] INFO (92835 on Sadafs-MacBook-Pro.local): Outgoing request GET http://example.com/auth_fakeout
    type: "request"
    direction: "out"
    info: {
      "url": "http://example.com/auth_fakeout",
      "method": "get"
    }
[2017-05-03T14:56:44.202Z] INFO (92835 on Sadafs-MacBook-Pro.local): Incoming response GET http://example.com/auth_fakeout
    type: "response"
    direction: "in"
    info: {
      "url": "http://example.com/auth_fakeout",
      "method": "get",
      "responseTime": 5
    }
[2017-05-03T14:56:44.206Z] INFO (92835 on Sadafs-MacBook-Pro.local): Outgoing request GET http://example.com/auth_fakeout
    type: "request"
    direction: "out"
    info: {
      "url": "http://example.com/auth_fakeout",
      "method": "get"
    }
[2017-05-03T14:56:44.208Z] INFO (92835 on Sadafs-MacBook-Pro.local): Incoming response GET http://example.com/auth_fakeout
    type: "response"
    direction: "in"
    info: {
      "url": "http://example.com/auth_fakeout",
      "method": "get",
      "responseTime": 2
    }
[2017-05-03T14:56:44.214Z] INFO (92835 on Sadafs-MacBook-Pro.local): Outgoing request GET http://example.com/access_fakeout?anonymous_code
    type: "request"
    direction: "out"
    info: {
      "url": "http://example.com/access_fakeout",
      "method": "get"
    }
[2017-05-03T14:56:44.216Z] INFO (92835 on Sadafs-MacBook-Pro.local): Incoming response GET http://example.com/access_fakeout?anonymous_code
    type: "response"
    direction: "in"
    info: {
      "url": "http://example.com/access_fakeout",
      "method": "get",
      "responseTime": 1
    }
[2017-05-03T14:56:44.219Z] INFO (92835 on Sadafs-MacBook-Pro.local): Outgoing request GET http://example.com/access_fakeout?anonymous_code
    type: "request"
    direction: "out"
    info: {
      "url": "http://example.com/access_fakeout",
      "method": "get"
    }
[2017-05-03T14:56:44.221Z] INFO (92835 on Sadafs-MacBook-Pro.local): Incoming response GET http://example.com/access_fakeout?anonymous_code
    type: "response"
    direction: "in"
    info: {
      "url": "http://example.com/access_fakeout",
      "method": "get",
      "responseTime": 1
    }
[2017-05-03T14:56:44.223Z] INFO (92835 on Sadafs-MacBook-Pro.local): Outgoing request GET http://example.com/auth_fakeout
    type: "request"
    direction: "out"
    info: {
      "url": "http://example.com/auth_fakeout",
      "method": "get"
    }
[2017-05-03T14:56:44.224Z] INFO (92835 on Sadafs-MacBook-Pro.local): Incoming response GET http://example.com/auth_fakeout
    type: "response"
    direction: "in"
    info: {
      "url": "http://example.com/auth_fakeout",
      "method": "get",
      "responseTime": 1
    }
[2017-05-03T14:56:44.225Z] INFO (92835 on Sadafs-MacBook-Pro.local): Outgoing request GET http://example.com/access_fakeout?anonymous_code
    type: "request"
    direction: "out"
    info: {
      "url": "http://example.com/access_fakeout",
      "method": "get"
    }
[2017-05-03T14:56:44.226Z] INFO (92835 on Sadafs-MacBook-Pro.local): Incoming response GET http://example.com/access_fakeout?anonymous_code
    type: "response"
    direction: "in"
    info: {
      "url": "http://example.com/access_fakeout",
      "method": "get",
      "responseTime": 1
    }
[2017-05-03T14:56:44.235Z] INFO (92835 on Sadafs-MacBook-Pro.local): Outgoing request GET http://example.com/auth_fakeout
    type: "request"
    direction: "out"
    info: {
      "url": "http://example.com/auth_fakeout",
      "method": "get"
    }
[2017-05-03T14:56:44.236Z] INFO (92835 on Sadafs-MacBook-Pro.local): Incoming response GET http://example.com/auth_fakeout
    type: "response"
    direction: "in"
    info: {
      "url": "http://example.com/auth_fakeout",
      "method": "get",
      "responseTime": 1
    }
[2017-05-03T14:56:44.237Z] INFO (92835 on Sadafs-MacBook-Pro.local): Outgoing request GET http://example.com/access_fakeout?anonymous_code
    type: "request"
    direction: "out"
    info: {
      "url": "http://example.com/access_fakeout",
      "method": "get"
 PASS  src/plugins/requestAuthPlugin.test.js
 PASS  src/util/apiUtils.test.js
```

`-- --silent` doesn't suppress them, and I think they should be as part of the tests. Should we fix this as well?