### PR TITLE
Route post/delete middleware functionality through apiActionCreators/sync middleware

### DIFF
--- a/src/actions/apiActionCreators.js
+++ b/src/actions/apiActionCreators.js
@@ -21,12 +21,12 @@ export function requestAll(queries, meta) {
 	};
 }
 
-export const _applyMethod = method => query => {
+export const _applyMethod = method => (query, meta) => {
 	query.meta = {
 		...(query.meta || {}),
 		method,
 	};
-	return requestAll([query]);
+	return requestAll([query], meta);
 };
 
 export const get = _applyMethod('get');

--- a/src/actions/apiActionCreators.js
+++ b/src/actions/apiActionCreators.js
@@ -21,7 +21,7 @@ export function requestAll(queries, meta) {
 	};
 }
 
-export const _applyMethod = method => (query, meta) => {
+const _applyMethod = method => (query, meta) => {
 	query.meta = {
 		...(query.meta || {}),
 		method,

--- a/src/epics/mutate.js
+++ b/src/epics/mutate.js
@@ -1,15 +1,7 @@
-import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/observable/of';
-import 'rxjs/add/observable/from';
-import 'rxjs/add/observable/fromPromise';
-import 'rxjs/add/operator/catch';
+import * as api from '../actions/apiActionCreators';
 import 'rxjs/add/operator/do';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/filter';
-import 'rxjs/add/operator/mergeMap';
-import { apiSuccess, apiError } from '../actions/syncActionCreators';
-import * as api from '../actions/apiActionCreators';
-import { getDeprecatedSuccessPayload } from '../util/fetchUtils';
 
 /**
  * Mutate epic  provides a generic interface for triggering POST and DELETE requests
@@ -37,65 +29,16 @@ import { getDeprecatedSuccessPayload } from '../util/fetchUtils';
  * @module MutateEpic
  */
 
-/**
- * get a function that receives a mutation-specific action and returns the
- * corresponding fetch Promise
- *
- * The wrapping function needs current app state in order to apply correct
- * config
- *
- * @param {String} method the desirect HTTP method ('post', 'delete', 'patch')
- * @param {Object} { apiUrl } from state.config
- * @param {Object} postAction, providing query, onSuccess, and onError
- * @return {Promise} results of the fetch, either onSuccess or onError
- */
-const getMethodQueryFetch = (method, fetchQueries, store) => query => {
-	// force presence of meta.method
-	query.meta = { ...(query.meta || {}), method };
-	const { config: { apiUrl } } = store.getState();
-	return fetchQueries(apiUrl)([query]);
-};
-
-/**
- * Make the mutation call to the API and send the responses to the appropriate
- * places
- *
- * 1. Always send successful mutation responses to API_SUCCESS action
- * 2. If mutation action has an 'onSuccess' action creators, send successful
- *    responses there as well
- * 3. Failed mutation responses will be sent to the mutation action's `onError`
- */
-const doFetch$ = fetchQuery => ({ query, onSuccess, onError }) =>
-	Observable.fromPromise(fetchQuery(query)) // make the fetch call
-		.mergeMap(({ successes, errors }) => {
-			const responses = getDeprecatedSuccessPayload(successes, errors);
-			const actions = [
-				...successes.map(api.success), // send the successes to success
-				...errors.map(api.error), // send errors to error
-				apiSuccess(responses),
-			];
-			if (onSuccess) {
-				actions.push(onSuccess(responses));
-			}
-			return Observable.from(actions);
-		})
-		.catch(err => {
-			const actions = [api.fail(err), apiError(err)];
-			if (onError) {
-				actions.push(onError(err));
-			}
-			return Observable.from(actions);
-		});
-
-const getMethodEpic = method => fetchQueries => (action$, store) =>
+const getMethodEpic = method => action$ =>
 	action$
 		.filter(
 			({ type }) =>
 				type.endsWith(`_${method.toUpperCase()}`) ||
 				type.startsWith(`${method.toUpperCase()}_`)
 		)
-		.do(({ type, payload: { query: { endpoint } } }) => {
-			if (endpoint.indexOf('.dev.') > -1) {
+		.do(({ type }) => {
+			// Webpack will make sure process.env.NODE_ENV is populated on client
+			if (process.env.NODE_ENV !== 'production') {
 				// using a dev endpoint, render a deprecation warning
 				console.warn(
 					`This application is using Post/Delete middleware through ${type}.
@@ -104,8 +47,14 @@ https://github.com/meetup/meetup-web-platform/blob/master/docs/Queries.md#recipe
 				);
 			}
 		})
-		.map(({ payload }) => payload)
-		.mergeMap(doFetch$(getMethodQueryFetch(method, fetchQueries, store)));
+		.map(({ payload: { query, onSuccess, onError } }) => ({
+			query,
+			meta: { onSuccess, onError },
+		}))
+		.map(({ query, meta }) => {
+			const actionCreator = method === 'delete' ? 'del' : method;
+			return api[actionCreator](query, meta);
+		});
 
-export const getPostEpic = getMethodEpic('post');
-export const getDeleteEpic = getMethodEpic('delete');
+export const postEpic = getMethodEpic('post');
+export const deleteEpic = getMethodEpic('delete');

--- a/src/epics/mutate.js
+++ b/src/epics/mutate.js
@@ -29,7 +29,13 @@ import 'rxjs/add/operator/filter';
  * @module MutateEpic
  */
 
-const getMethodEpic = method => action$ =>
+/*
+ * Delegate method-specific request actions (e.g. 'POST_MY_FORM') to the sync
+ * middleware by modifying the request actions' query payloads to include
+ * request method properties
+ * @deprecated
+ */
+const _getMethodEpic = method => action$ =>
 	action$
 		.filter(
 			({ type }) =>
@@ -56,5 +62,5 @@ https://github.com/meetup/meetup-web-platform/blob/master/docs/Queries.md#recipe
 			return api[actionCreator](query, meta);
 		});
 
-export const postEpic = getMethodEpic('post');
-export const deleteEpic = getMethodEpic('delete');
+export const postEpic = _getMethodEpic('post');
+export const deleteEpic = _getMethodEpic('delete');

--- a/src/epics/mutate.test.js
+++ b/src/epics/mutate.test.js
@@ -1,218 +1,35 @@
 import { ActionsObservable } from 'redux-observable';
+import 'rxjs/add/observable/of';
 import 'rxjs/add/operator/toArray';
 import 'rxjs/add/operator/toPromise';
 
-import { getDeprecatedSuccessPayload } from '../util/fetchUtils';
+import { MOCK_POST_ACTION, MOCK_DELETE_ACTION } from 'meetup-web-mocks/lib/app';
 
-import {
-	MOCK_POST_ACTION,
-	MOCK_DELETE_ACTION,
-	MOCK_APP_STATE,
-} from 'meetup-web-mocks/lib/app';
+import { epicIgnoreAction } from '../util/testUtils';
 
-import { createFakeStore, epicIgnoreAction } from '../util/testUtils';
+import { postEpic, deleteEpic } from './mutate';
+import * as api from '../actions/apiActionCreators';
 
-import { getPostEpic, getDeleteEpic } from './mutate';
-import * as fetchUtils from '../util/fetchUtils'; // used for mocking
-import * as syncActionCreators from '../actions/syncActionCreators';
-
-MOCK_APP_STATE.config = {
-	apiUrl: 'http://fake.api.meetup.com',
-};
-const store = createFakeStore(MOCK_APP_STATE);
-describe('getPostEpic', () => {
-	it(
-		'does not pass through arbitrary actions',
-		epicIgnoreAction(getPostEpic(fetchUtils.fetchQueries))
-	);
-	it('sets query.meta.method = "post"', function() {
-		const innerFetchQueries = jest.fn();
-		fetchUtils.fetchQueries = jest.fn(() => innerFetchQueries);
+describe('postEpic', () => {
+	it('does not pass through arbitrary actions', epicIgnoreAction(postEpic));
+	it('returns an api.post(query) action', () => {
 		const action$ = ActionsObservable.of(MOCK_POST_ACTION);
-		return getPostEpic(fetchUtils.fetchQueries)(action$, store)
-			.do(() => {
-				const fetchedQueries = innerFetchQueries.mock.calls[0][0];
-				expect(fetchedQueries[0].meta).toEqual(
-					expect.objectContaining({ method: 'post' })
-				);
-			})
-			.toPromise();
-	});
-
-	it('Returns response from fetchqueries as argument to API_SUCCESS', function() {
-		const response = {
-			successes: [{ query: {}, response: { ref: 'asdf', foo: 'bar' } }],
-			errors: [],
-		};
-		const deprecatedResponse = getDeprecatedSuccessPayload(
-			response.successes,
-			response.errors
-		);
-		fetchUtils.fetchQueries = jest.fn(() => () => Promise.resolve(response));
-		const noSuccessPayload = { ...MOCK_POST_ACTION.payload };
-		delete noSuccessPayload.onSuccess;
-		const postWithoutOnSuccess = {
-			...MOCK_POST_ACTION,
-			payload: noSuccessPayload,
-		};
-		spyOn(syncActionCreators, 'apiSuccess');
-		const action$ = ActionsObservable.of(postWithoutOnSuccess);
-		return getPostEpic(fetchUtils.fetchQueries)(action$, store)
-			.toArray()
-			.toPromise()
-			.then(actions => {
-				expect(syncActionCreators.apiSuccess).toHaveBeenCalledWith(
-					deprecatedResponse
-				);
-			});
-	});
-	it('Returns error from fetchQueries as argument to API_ERROR', function() {
-		const err = new Error('boo');
-		spyOn(fetchUtils, 'fetchQueries').and.callFake(() => () =>
-			Promise.reject(err));
-		spyOn(syncActionCreators, 'apiError');
-		// The promises resolve async, but resolution is not accessible to test, so
-		// we use a setTimeout to make sure execution has completed
-		const action$ = ActionsObservable.of(MOCK_POST_ACTION);
-		return getPostEpic(fetchUtils.fetchQueries)(action$, store)
-			.do(() => expect(syncActionCreators.apiError).toHaveBeenCalledWith(err))
-			.toPromise();
-	});
-	it("Returns response from fetchqueries as argument to API_SUCCESS and action's onSuccess", function() {
-		const response = {
-			successes: [{ query: {}, response: { ref: 'asdf', foo: 'bar' } }],
-			errors: [],
-		};
-		const deprecatedResponse = getDeprecatedSuccessPayload(
-			response.successes,
-			response.errors
-		);
-		fetchUtils.fetchQueries = jest.fn(() => () => Promise.resolve(response));
-		spyOn(MOCK_POST_ACTION.payload, 'onSuccess');
-		spyOn(syncActionCreators, 'apiSuccess');
-		const action$ = ActionsObservable.of(MOCK_POST_ACTION);
-		return getPostEpic(fetchUtils.fetchQueries)(action$, store)
-			.toPromise()
-			.then(() => {
-				expect(syncActionCreators.apiSuccess).toHaveBeenCalledWith(
-					deprecatedResponse
-				);
-				expect(syncActionCreators.apiSuccess).toHaveBeenCalledWith(
-					deprecatedResponse
-				);
-				expect(MOCK_POST_ACTION.payload.onSuccess).toHaveBeenCalledWith(
-					deprecatedResponse
-				);
-			});
-	});
-	it("Returns error from fetchQueries as argument to action's onError", function() {
-		const err = new Error('boo');
-		spyOn(fetchUtils, 'fetchQueries').and.callFake(() => () =>
-			Promise.reject(err));
-		spyOn(MOCK_POST_ACTION.payload, 'onError');
-		// The promises resolve async, but resolution is not accessible to test, so
-		// we use a setTimeout to make sure execution has completed
-		const action$ = ActionsObservable.of(MOCK_POST_ACTION);
-		return getPostEpic(fetchUtils.fetchQueries)(action$, store)
-			.do(() =>
-				expect(MOCK_POST_ACTION.payload.onError).toHaveBeenCalledWith(err)
-			)
-			.toPromise();
+		return postEpic(action$).toPromise().then(action => {
+			const { query, onSuccess, onError } = MOCK_POST_ACTION.payload;
+			const expectedAction = api.del(query, { onSuccess, onError });
+			expect(action).toMatchObject(expectedAction);
+		});
 	});
 });
 
-describe('getDeleteEpic', () => {
-	it(
-		'does not pass through arbitrary actions',
-		epicIgnoreAction(getDeleteEpic(fetchUtils.fetchQueries))
-	);
-	it('sets query.meta.method = "delete"', function() {
-		const innerFetchQueries = jest.fn();
-		fetchUtils.fetchQueries = jest.fn(() => innerFetchQueries);
+describe('deleteEpic', () => {
+	it('does not pass through arbitrary actions', epicIgnoreAction(deleteEpic));
+	it('returns an api.del(query) action', () => {
 		const action$ = ActionsObservable.of(MOCK_DELETE_ACTION);
-		return getDeleteEpic(fetchUtils.fetchQueries)(action$, store)
-			.do(() => {
-				const fetchedQueries = innerFetchQueries.mock.calls[0][0];
-				expect(fetchedQueries[0].meta).toEqual(
-					expect.objectContaining({ method: 'delete' })
-				);
-			})
-			.toPromise();
-	});
-	it('Returns response from fetchqueries as argument to API_SUCCESS', function() {
-		const response = {
-			successes: [{ query: {}, response: { ref: 'asdf', foo: 'bar' } }],
-			errors: [],
-		};
-		const deprecatedResponse = getDeprecatedSuccessPayload(
-			response.successes,
-			response.errors
-		);
-		fetchUtils.fetchQueries = jest.fn(() => () => Promise.resolve(response));
-		const noSuccessPayload = { ...MOCK_DELETE_ACTION.payload };
-		delete noSuccessPayload.onSuccess;
-		const postWithoutOnSuccess = {
-			...MOCK_DELETE_ACTION,
-			payload: noSuccessPayload,
-		};
-		spyOn(syncActionCreators, 'apiSuccess');
-		const action$ = ActionsObservable.of(postWithoutOnSuccess);
-		return getDeleteEpic(fetchUtils.fetchQueries)(action$, store)
-			.toPromise()
-			.then(() => {
-				expect(syncActionCreators.apiSuccess).toHaveBeenCalledWith(
-					deprecatedResponse
-				);
-			});
-	});
-	it('Returns error from fetchQueries as argument to API_ERROR', function() {
-		const err = new Error('boo');
-		spyOn(fetchUtils, 'fetchQueries').and.callFake(() => () =>
-			Promise.reject(err));
-		spyOn(syncActionCreators, 'apiError');
-		// The promises resolve async, but resolution is not accessible to test, so
-		// we use a setTimeout to make sure execution has completed
-		const action$ = ActionsObservable.of(MOCK_DELETE_ACTION);
-		return getDeleteEpic(fetchUtils.fetchQueries)(action$, store)
-			.do(() => expect(syncActionCreators.apiError).toHaveBeenCalledWith(err))
-			.toPromise();
-	});
-	it("Returns response from fetchqueries as argument to API_SUCCESS and action's onSuccess", function() {
-		const response = {
-			successes: [{ query: {}, response: { ref: 'asdf', foo: 'bar' } }],
-			errors: [],
-		};
-		const deprecatedResponse = getDeprecatedSuccessPayload(
-			response.successes,
-			response.errors
-		);
-		fetchUtils.fetchQueries = jest.fn(() => () => Promise.resolve(response));
-		spyOn(MOCK_DELETE_ACTION.payload, 'onSuccess');
-		spyOn(syncActionCreators, 'apiSuccess');
-		const action$ = ActionsObservable.of(MOCK_DELETE_ACTION);
-		return getDeleteEpic(fetchUtils.fetchQueries)(action$, store)
-			.toPromise()
-			.then(() => {
-				expect(syncActionCreators.apiSuccess).toHaveBeenCalledWith(
-					deprecatedResponse
-				);
-				expect(MOCK_DELETE_ACTION.payload.onSuccess).toHaveBeenCalledWith(
-					deprecatedResponse
-				);
-			});
-	});
-	it("Returns error from fetchQueries as argument to action's onError", function() {
-		const err = new Error('boo');
-		spyOn(fetchUtils, 'fetchQueries').and.callFake(() => () =>
-			Promise.reject(err));
-		spyOn(MOCK_DELETE_ACTION.payload, 'onError');
-		// The promises resolve async, but resolution is not accessible to test, so
-		// we use a setTimeout to make sure execution has completed
-		const action$ = ActionsObservable.of(MOCK_DELETE_ACTION);
-		return getDeleteEpic(fetchUtils.fetchQueries)(action$, store)
-			.do(() =>
-				expect(MOCK_DELETE_ACTION.payload.onError).toHaveBeenCalledWith(err)
-			)
-			.toPromise();
+		return deleteEpic(action$).toPromise().then(action => {
+			const { query, onSuccess, onError } = MOCK_DELETE_ACTION.payload;
+			const expectedAction = api.del(query, { onSuccess, onError });
+			expect(action).toMatchObject(expectedAction);
+		});
 	});
 });

--- a/src/epics/sync.js
+++ b/src/epics/sync.js
@@ -116,21 +116,33 @@ export const getFetchQueriesEpic = fetchQueriesFn => (action$, store) =>
 		return Observable.fromPromise(fetchQueries(queries, meta)) // call fetch
 			.takeUntil(action$.ofType(LOCATION_CHANGE)) // cancel this fetch when nav happens
 			.mergeMap(({ successes = [], errors = [] }) => {
+				const deprecatedSuccessPayload = getDeprecatedSuccessPayload(
+					successes,
+					errors
+				);
+				const deprecatedActions = [apiSuccess(deprecatedSuccessPayload)];
+				if (meta && meta.onSuccess) {
+					deprecatedActions.push(meta.onSuccess(deprecatedSuccessPayload));
+				}
 				const actions = [
 					...successes.map(api.success), // send the successes to success
 					...errors.map(api.error), // send errors to error
-					apiSuccess(getDeprecatedSuccessPayload(successes, errors)), // DEPRECATED - necessary to continue populating old state
+					...deprecatedActions,
 					api.complete(queries),
 				];
 				return Observable.of(...actions);
 			})
-			.catch(err =>
-				Observable.of(
+			.catch(err => {
+				const deprecatedActions = [apiError(err)];
+				if (meta && meta.onError) {
+					deprecatedActions.push(meta.onError(err));
+				}
+				return Observable.of(
 					api.fail(err),
-					apiError(err), // DEPRECATED
+					...deprecatedActions,
 					api.complete(queries)
-				)
-			);
+				);
+			});
 	});
 
 export default function getSyncEpic(routes, fetchQueries, baseUrl) {

--- a/src/middleware/epic.js
+++ b/src/middleware/epic.js
@@ -2,7 +2,7 @@ import { combineEpics, createEpicMiddleware } from 'redux-observable';
 
 import getSyncEpic from '../epics/sync';
 import getCacheEpic from '../epics/cache';
-import { getPostEpic, getDeleteEpic } from '../epics/mutate'; // DEPRECATED
+import { postEpic, deleteEpic } from '../epics/mutate'; // DEPRECATED
 
 /**
  * The middleware is exported as a getter because it needs the application's
@@ -18,8 +18,8 @@ const getPlatformMiddleware = (routes, fetchQueries, baseUrl) =>
 		combineEpics(
 			getSyncEpic(routes, fetchQueries, baseUrl),
 			getCacheEpic(),
-			getPostEpic(fetchQueries), // DEPRECATED
-			getDeleteEpic(fetchQueries) // DEPRECATED
+			postEpic, // DEPRECATED
+			deleteEpic // DEPRECATED
 		)
 	);
 

--- a/src/util/fetchUtils.js
+++ b/src/util/fetchUtils.js
@@ -91,7 +91,13 @@ export const getFetchArgs = (apiUrl, queries, meta) => {
 	fetchUrl.searchParams.append('queries', rison.encode_array(queries));
 
 	if (meta) {
-		const { clickTracking, logout, ...metadata } = meta;
+		const {
+			clickTracking,
+			logout,
+			onSuccess, // eslint-disable-line no-unused-vars
+			onError, // eslint-disable-line no-unused-vars
+			...metadata
+		} = meta;
 
 		if (clickTracking) {
 			BrowserCookies.set('click-track', JSON.stringify(clickTracking), {
@@ -107,9 +113,10 @@ export const getFetchArgs = (apiUrl, queries, meta) => {
 		}
 
 		// send other metadata in searchParams
-		if (Object.keys(metadata).length) {
+		const encodedMetadata = metadata && rison.encode_object(metadata);
+		if (encodedMetadata) {
 			// send other metadata in searchParams
-			fetchUrl.searchParams.append('metadata', rison.encode_object(metadata));
+			fetchUrl.searchParams.append('metadata', encodedMetadata);
 		}
 	}
 
@@ -157,7 +164,8 @@ export const getFetchArgs = (apiUrl, queries, meta) => {
  */
 export const fetchQueries = apiUrl => (queries, meta) => {
 	if (
-		typeof window === 'undefined' && typeof test === 'undefined' // not in browser // not in testing env (global set by Jest)
+		typeof window === 'undefined' &&
+		typeof test === 'undefined' // not in browser // not in testing env (global set by Jest)
 	) {
 		throw new Error('fetchQueries was called on server - cannot continue');
 	}


### PR DESCRIPTION
This PR helps bridge the gap between post/delete middleware and the new apiActionCreators/sync system, and _greatly_ simplifies the post/delete middleware, removing their dependency on fetchUtils.

The only thing that post/delete did that wasn't supported by sync middleware was having custom `onSuccess` and `onError` handlers, but this PR allows those handlers to be passed as an additional `meta` argument to method-specific apiActionCreators (`meta` was already supported by the root `api.requestAll` action creator - this PR just surfaces that option to method-specific action creators).