### PR TITLE
don't sort lang list

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,11 @@
     "coveralls": "cat coverage/lcov.info | coveralls",
     "flow": "flow",
     "lint": "eslint . --ext .js,.jsx --fix",
+    "precommit": "lint-staged",
     "test": "yarn run flow && yarn run test:unit && yarn run test:integration -- --silent",
     "test:base": "jest --config jest.config.json",
     "test:integration": "NODE_ENV=test jest --config jest.int.config.json",
-    "test:unit": "NODE_ENV=test yarn test:base",
+    "test:unit": "NODE_ENV=test yarn test:base -- --silent --coverage",
     "test:watch": "yarn test:base -- --watch"
   },
   "repository": {
@@ -43,7 +44,7 @@
     "joi": "10.4.1",
     "js-cookie": "2.1.4",
     "node-fetch": "1.6.3",
-    "pino": "4.3.0",
+    "pino": "4.5.0",
     "prop-types": "15.5.8",
     "qs": "6.4.0",
     "react-dom": "15.5.4",
@@ -74,14 +75,18 @@
     "babel-preset-stage-2": "6.24.1",
     "coveralls": "2.13.0",
     "eslint": "3.19.0",
+    "eslint-config-prettier": "1.7.0",
     "eslint-plugin-flowtype": "2.32.1",
     "eslint-plugin-react": "6.10.3",
     "flow-bin": "0.44.2",
+    "husky": "0.13.3",
     "intl-messageformat": "1.3.0",
     "intl-relativeformat": "1.3.0",
     "iron": "4.0.4",
     "jest-cli": "19.0.2",
+    "lint-staged": "3.4.1",
     "meetup-web-mocks": "1.0.183",
+    "prettier": "1.2.2",
     "react": "15.5.4",
     "react-addons-test-utils": "15.5.1",
     "react-helmet": "5.0.3",
@@ -91,5 +96,12 @@
     "redux": "3.6.0",
     "rxjs": "5.3.0",
     "tough-cookie": "2.3.2"
+  },
+  "lint-staged": {
+    "*.{js,jsx}": [
+      "prettier --write --single-quote --use-tabs --trailing-comma es5",
+      "eslint",
+      "git add"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "yarn run flow && yarn run test:unit && yarn run test:integration -- --silent",
     "test:base": "jest --config jest.config.json",
     "test:integration": "NODE_ENV=test jest --config jest.int.config.json",
-    "test:unit": "NODE_ENV=test yarn test:base -- --silent --coverage",
+    "test:unit": "NODE_ENV=test yarn test:base",
     "test:watch": "yarn test:base -- --watch"
   },
   "repository": {

--- a/src/util/languageUtils.js
+++ b/src/util/languageUtils.js
@@ -39,9 +39,9 @@ export const getLanguage = (
 	supportedLangs,
 	defaultLang = LANG_DEFAULT
 ) => {
+	// places defaultLang at top of list
+	supportedLangs.sort(l => l === defaultLang ? -1 : 1);
 	// return the first language hit in the order of preference
-	// TODO - better comment
-	supportedLangs.unshift(defaultLang);
 	return (
 		getCookieLang(request, supportedLangs) ||
 		getUrlLang(request, supportedLangs) ||

--- a/src/util/languageUtils.js
+++ b/src/util/languageUtils.js
@@ -38,16 +38,10 @@ export const getLanguage = (
 	request,
 	supportedLangs,
 	defaultLang = LANG_DEFAULT
-) => {
-	// return the first language hit in the order of preference
-	supportedLangs.sort(l => l !== defaultLang);
-	return (
-		getCookieLang(request, supportedLangs) ||
+) => getCookieLang(request, supportedLangs) ||
 		getUrlLang(request, supportedLangs) ||
 		getBrowserLang(request, supportedLangs) ||
-		defaultLang
-	);
-};
+		defaultLang;
 
 const makeRedirect = (reply, originalUrl) => redirectPathname =>
 	reply.redirect(url.format({ ...originalUrl, pathname: redirectPathname }));

--- a/src/util/languageUtils.js
+++ b/src/util/languageUtils.js
@@ -38,10 +38,17 @@ export const getLanguage = (
 	request,
 	supportedLangs,
 	defaultLang = LANG_DEFAULT
-) => getCookieLang(request, supportedLangs) ||
+) => {
+	// return the first language hit in the order of preference
+	// TODO - better comment
+	supportedLangs.unshift(defaultLang);
+	return (
+		getCookieLang(request, supportedLangs) ||
 		getUrlLang(request, supportedLangs) ||
 		getBrowserLang(request, supportedLangs) ||
-		defaultLang;
+		defaultLang
+	);
+};
 
 const makeRedirect = (reply, originalUrl) => redirectPathname =>
 	reply.redirect(url.format({ ...originalUrl, pathname: redirectPathname }));

--- a/src/util/languageUtils.test.js
+++ b/src/util/languageUtils.test.js
@@ -25,8 +25,8 @@ const altLang = 'fr-FR';
 const altLang2 = 'de-DE';
 const altLang3 = 'es-ES';
 const supportedLangs = [
-	defaultLang,
 	similarToDefault,
+	defaultLang,
 	altLang,
 	altLang2,
 	altLang3,

--- a/src/util/languageUtils.test.js
+++ b/src/util/languageUtils.test.js
@@ -25,8 +25,8 @@ const altLang = 'fr-FR';
 const altLang2 = 'de-DE';
 const altLang3 = 'es-ES';
 const supportedLangs = [
-	similarToDefault,
 	defaultLang,
+	similarToDefault,
 	altLang,
 	altLang2,
 	altLang3,


### PR DESCRIPTION
this started with a failing integration test in mup-web after adding a couple of languages -

```
 FAIL  tests/integration/routing.int.js
  ● Startup and render - using current /build/ files › returns a 404 for invalid route

    expect(received).toBe(expected)

    Expected value to be (using ===):
      404
    Received:
      302

      at responseTest (tests/integration/routing.int.js:40:33)
      at process._tickCallback (internal/process/next_tick.js:109:7)

  ● Startup and render - using current /build/ files › renders the group home page

    expect(received).toBe(expected)

    Expected value to be (using ===):
      200
    Received:
      302

      at responseTest (tests/integration/routing.int.js:49:33)
      at process._tickCallback (internal/process/next_tick.js:109:7)

  Startup and render - using current /build/ files
    ✕ returns a 404 for invalid route (100ms)
    ✕ renders the group home page (31ms)

Test Suites: 1 failed, 1 total
Tests:       2 failed, 2 total
```

for some reason `it-IT` is being selected as the language which i suspect is causing the redirect.

it looks like this is related to language sorting. i'm not sure why this is being done or what the desired effect is but its getting in the way of adding new languages. it appears that, by chance, with the lang list currently in master `en-US` sorts to the top and tests pass. if i add a couple (2) more languages to the list then `it-IT` is at the top of the list. 

Perhaps the solution is to document the language list and make clear the implications of language order.

before adding more languages -

lang list - 
```
    [ 'en-US',
      'en-AU',
      'de-DE',
      'fr-FR',
      'ja-JP',
      'it-IT',
      'pt-BR',
      'es-ES',
      'es' ]
```
sorted lang list - 
```
    [ 'en-US',
      'es',
      'es-ES',
      'pt-BR',
      'it-IT',
      'ja-JP',
      'fr-FR',
      'de-DE',
      'en-AU' ]
```
After adding new languages - 


lang list -
```
    [ 'en-US',
      'en-AU',
      'de-DE',
      'fr-FR',
      'ja-JP',
      'it-IT',
      'pt-BR',
      'es-ES',
      'es',
      'ko-KR',
      'tr-TR' ]
```

sorted lang list - 
```
[ 'it-IT',
      'en-US',
      'tr-TR',
      'ko-KR',
      'es',
      'es-ES',
      'pt-BR',
      'en-AU',
      'ja-JP',
      'fr-FR',
      'de-DE' ]
```
