### PR TITLE
WP 324 separate buildtime config from runtime config

### DIFF
--- a/config.test.json
+++ b/config.test.json
@@ -1,22 +1,18 @@
 {
-  "buildtime": {
-    "asset_server": {
-      "port": 0
-    },
-    "app_server": {
-      "port": 0
-    }
+  "asset_server": {
+    "port": 0
   },
-  "runtime": {
-    "api": {
-      "timeout": 10
-    },
-    "csrf_secret": "asdfasdfasdfasdfasdfasdfasdfasdf",
-    "cookie_encrypt_secret": "asdfasdfasdfasdfasdfasdfasdfasdf",
-    "photo_scaler_salt": "asdfasdfasdfasdfasdfasdfasdfasdf",
-    "oauth": {
-      "key": "asdfasdfasdfasdfasdfasdfasdfasdf",
-      "secret": "asdfasdfasdfasdfasdfasdfasdfasdf"
-    }
+  "app_server": {
+    "port": 0
+  },
+  "api": {
+    "timeout": 10
+  },
+  "csrf_secret": "asdfasdfasdfasdfasdfasdfasdfasdf",
+  "cookie_encrypt_secret": "asdfasdfasdfasdfasdfasdfasdfasdf",
+  "photo_scaler_salt": "asdfasdfasdfasdfasdfasdfasdfasdf",
+  "oauth": {
+    "key": "asdfasdfasdfasdfasdfasdfasdfasdf",
+    "secret": "asdfasdfasdfasdfasdfasdfasdfasdf"
   }
 }

--- a/config.test.json
+++ b/config.test.json
@@ -1,28 +1,29 @@
 {
-  "api": {
-    "protocol": "https",
-    "host": "www.api.dev.meetup.com",
-    "timeout": 10,
-    "root_url": "https://www.api.dev.meetup.com"
+  "buildtime": {
+    "asset_server": {
+      "host": "beta2.dev.meetup.com",
+      "port": 0
+    },
+    "app_server": {
+      "host": "beta2.dev.meetup.com",
+      "port": 0
+    }
   },
-  "asset_server": {
-    "host": "beta2.dev.meetup.com",
-    "port": 0
-  },
-  "csrf_secret": "asdfasdfasdfasdfasdfasdfasdfasdf",
-  "cookie_encrypt_secret": "asdfasdfasdfasdfasdfasdfasdfasdf",
-  "app_server": {
-    "host": "beta2.dev.meetup.com",
-    "port": 0
-  },
-  "duotone_urls": [
-    "http://example.com/duotone.jpg"
-  ],
-  "photo_scaler_salt": "asdfasdfasdfasdfasdfasdfasdfasdf",
-  "oauth": {
-    "auth_url": "https://secure.dev.meetup.com/oauth2/authorize",
-    "access_url": "https://secure.dev.meetup.com/oauth2/access",
-    "key": "asdfasdfasdfasdfasdfasdfasdfasdf",
-    "secret": "asdfasdfasdfasdfasdfasdfasdfasdf"
+  "runtime": {
+    "api": {
+      "protocol": "https",
+      "host": "www.api.dev.meetup.com",
+      "timeout": 10,
+      "root_url": "https://www.api.dev.meetup.com"
+    },
+    "csrf_secret": "asdfasdfasdfasdfasdfasdfasdfasdf",
+    "cookie_encrypt_secret": "asdfasdfasdfasdfasdfasdfasdfasdf",
+    "photo_scaler_salt": "asdfasdfasdfasdfasdfasdfasdfasdf",
+    "oauth": {
+      "auth_url": "https://secure.dev.meetup.com/oauth2/authorize",
+      "access_url": "https://secure.dev.meetup.com/oauth2/access",
+      "key": "asdfasdfasdfasdfasdfasdfasdfasdf",
+      "secret": "asdfasdfasdfasdfasdfasdfasdfasdf"
+    }
   }
 }

--- a/config.test.json
+++ b/config.test.json
@@ -1,27 +1,20 @@
 {
   "buildtime": {
     "asset_server": {
-      "host": "beta2.dev.meetup.com",
       "port": 0
     },
     "app_server": {
-      "host": "beta2.dev.meetup.com",
       "port": 0
     }
   },
   "runtime": {
     "api": {
-      "protocol": "https",
-      "host": "www.api.dev.meetup.com",
-      "timeout": 10,
-      "root_url": "https://www.api.dev.meetup.com"
+      "timeout": 10
     },
     "csrf_secret": "asdfasdfasdfasdfasdfasdfasdfasdf",
     "cookie_encrypt_secret": "asdfasdfasdfasdfasdfasdfasdfasdf",
     "photo_scaler_salt": "asdfasdfasdfasdfasdfasdfasdfasdf",
     "oauth": {
-      "auth_url": "https://secure.dev.meetup.com/oauth2/authorize",
-      "access_url": "https://secure.dev.meetup.com/oauth2/access",
       "key": "asdfasdfasdfasdfasdfasdfasdfasdf",
       "secret": "asdfasdfasdfasdfasdfasdfasdfasdf"
     }

--- a/src/util/config/build.js
+++ b/src/util/config/build.js
@@ -1,0 +1,116 @@
+import fs from 'fs';
+import convict from 'convict';
+import path from 'path';
+
+/**
+ * This module provides a single source of truth for application configuration
+ * info. It uses node-convict to read configuration info from, in increasing
+ * order of precedence:
+ *
+ * 1. Default value
+ * 2. File (`config.loadFile()`) - app root `config.<NODE_ENV>.json`
+ * 3. Environment variables
+ * 4. Command line arguments
+ * 5. Set and load calls (config.set() and config.load())
+ *
+ * Note that environment variables have _higher_ precedence than values in
+ * config files, so the config files will only work if environment variables
+ * are cleared.
+ *
+ * The only values that _must_ be in environment variables are the secrets that
+ * are used to interact with external systems:
+ *
+ * - `MUPWEB_OAUTH_SECRET`
+ * - `MUPWEB_OAUTH_KEY`
+ * - `PHOTO_SCALER_SALT`
+ *
+ * @module config
+ */
+
+export const PROTOCOL_ERROR = 'Protocol must be http or https';
+
+export const validateProtocol = protocol => {
+	if (!['http', 'https'].includes(protocol)) {
+		throw new Error(PROTOCOL_ERROR);
+	}
+};
+
+export const schema = {
+	env: {
+		format: ['production', 'development', 'test'],
+		default: 'development',
+		env: 'NODE_ENV',
+	},
+	asset_server: {
+		host: {
+			format: String,
+			default: 'beta2.dev.meetup.com',
+			env: 'ASSET_SERVER_HOST',
+		},
+		path: {
+			format: String,
+			default: '/static',
+			env: 'ASSET_PATH',
+		},
+		port: {
+			format: 'port',
+			default: 8001,
+			arg: 'asset-port',
+			env: 'ASSET_SERVER_PORT',
+		},
+	},
+	app_server: {
+		protocol: {
+			format: validateProtocol,
+			default: 'http',
+			env: 'DEV_SERVER_PROTOCOL', // legacy naming
+		},
+		host: {
+			format: String,
+			default: 'beta2.dev.meetup.com',
+			env: 'DEV_SERVER_HOST', // legacy naming
+		},
+		port: {
+			format: 'port',
+			default: 8000,
+			arg: 'app-port',
+			env: process.env.NODE_ENV !== 'test' && 'DEV_SERVER_PORT', // don't read env in tests
+		},
+	},
+	disable_hmr: {
+		format: Boolean,
+		default: false,
+		env: 'DISABLE_HMR',
+	},
+	isDev: {
+		format: Boolean,
+		default: true,
+	},
+	isProd: {
+		format: Boolean,
+		default: false,
+	},
+};
+export const config = convict(schema);
+
+// Load environment dependent configuration
+const configPath = path.resolve(
+	process.cwd(),
+	`config.${config.get('env')}.json`
+);
+
+if (fs.existsSync(configPath)) {
+	const buildConfig = require(configPath).buildtime || {};
+	config.load(buildConfig);
+}
+
+config.set(
+	'api.root_url',
+	`${config.get('api.protocol')}://${config.get('api.host')}`
+);
+
+config.set('isProd', config.get('env') === 'production');
+config.set('isDev', config.get('env') === 'development');
+config.validate();
+
+export default config.getProperties();

--- a/src/util/config/build.js
+++ b/src/util/config/build.js
@@ -78,11 +78,13 @@ const configPath = path.resolve(
 	`config.${config.get('env')}.json`
 );
 
-export const localConfig = fs.existsSync(configPath) ? require(configPath) : {};
-
+export const { asset_server, app_server } = fs.existsSync(configPath)
+	? require(configPath)
+	: {};
+// only load buildtime vars - nothing else from config file
 config.load({
-	asset_server: localConfig.asset_server,
-	app_server: localConfig.app_server,
+	asset_server,
+	app_server,
 });
 
 config.set('isProd', config.get('env') === 'production');

--- a/src/util/config/build.js
+++ b/src/util/config/build.js
@@ -56,7 +56,7 @@ export const schema = {
 			format: 'port',
 			default: 8001,
 			arg: 'asset-port',
-			env: 'ASSET_SERVER_PORT',
+			env: process.env.NODE_ENV !== 'test' && 'ASSET_SERVER_PORT', // don't read env in tests
 		},
 	},
 	app_server: {
@@ -99,15 +99,11 @@ const configPath = path.resolve(
 	`config.${config.get('env')}.json`
 );
 
-if (fs.existsSync(configPath)) {
-	const buildConfig = require(configPath).buildtime || {};
-	config.load(buildConfig);
-}
+export const localBuildConfig = fs.existsSync(configPath)
+	? require(configPath).buildtime || {}
+	: {};
 
-config.set(
-	'api.root_url',
-	`${config.get('api.protocol')}://${config.get('api.host')}`
-);
+config.load(localBuildConfig);
 
 config.set('isProd', config.get('env') === 'production');
 config.set('isDev', config.get('env') === 'development');

--- a/src/util/config/build.js
+++ b/src/util/config/build.js
@@ -78,11 +78,12 @@ const configPath = path.resolve(
 	`config.${config.get('env')}.json`
 );
 
-export const localBuildConfig = fs.existsSync(configPath)
-	? require(configPath).buildtime || {}
-	: {};
+export const localConfig = fs.existsSync(configPath) ? require(configPath) : {};
 
-config.load(localBuildConfig);
+config.load({
+	asset_server: localConfig.asset_server,
+	app_server: localConfig.app_server,
+});
 
 config.set('isProd', config.get('env') === 'production');
 config.set('isDev', config.get('env') === 'development');

--- a/src/util/config/build.js
+++ b/src/util/config/build.js
@@ -3,28 +3,7 @@ import convict from 'convict';
 import path from 'path';
 
 /**
- * This module provides a single source of truth for application configuration
- * info. It uses node-convict to read configuration info from, in increasing
- * order of precedence:
- *
- * 1. Default value
- * 2. File (`config.loadFile()`) - app root `config.<NODE_ENV>.json`
- * 3. Environment variables
- * 4. Command line arguments
- * 5. Set and load calls (config.set() and config.load())
- *
- * Note that environment variables have _higher_ precedence than values in
- * config files, so the config files will only work if environment variables
- * are cleared.
- *
- * The only values that _must_ be in environment variables are the secrets that
- * are used to interact with external systems:
- *
- * - `MUPWEB_OAUTH_SECRET`
- * - `MUPWEB_OAUTH_KEY`
- * - `PHOTO_SCALER_SALT`
- *
- * @module config
+ * This module populates build time configuration data
  */
 
 export const PROTOCOL_ERROR = 'Protocol must be http or https';

--- a/src/util/config/build.test.js
+++ b/src/util/config/build.test.js
@@ -1,0 +1,12 @@
+import { PROTOCOL_ERROR, validateProtocol } from './build';
+
+describe('validateProtocol', () => {
+	it('does not error when protocol is `http` or `https`', () => {
+		expect(() => validateProtocol('http')).not.toThrow();
+		expect(() => validateProtocol('https')).not.toThrow();
+	});
+
+	it('throws error when the protocol is not `http` or `https`', () => {
+		expect(() => validateProtocol('ftp')).toThrowError(PROTOCOL_ERROR);
+	});
+});

--- a/src/util/config/index.js
+++ b/src/util/config/index.js
@@ -168,6 +168,5 @@ config.set(
 config.set('isProd', config.get('env') === 'production');
 config.set('isDev', config.get('env') === 'development');
 config.validate();
-// console.warn(config.getProperties());
 
 export default config.getProperties();

--- a/src/util/config/index.js
+++ b/src/util/config/index.js
@@ -149,11 +149,8 @@ const configPath = path.resolve(
 	`config.${config.get('env')}.json`
 );
 
-const localRunConfig = fs.existsSync(configPath)
-	? require(configPath) || {}
-	: {};
-
-config.load(localRunConfig);
+const localConfig = fs.existsSync(configPath) ? require(configPath) : {};
+config.load(localConfig);
 
 config.set(
 	'api.root_url',

--- a/src/util/config/index.js
+++ b/src/util/config/index.js
@@ -150,7 +150,7 @@ const configPath = path.resolve(
 );
 
 const localRunConfig = fs.existsSync(configPath)
-	? require(configPath).runtime || {}
+	? require(configPath) || {}
 	: {};
 
 config.load(localRunConfig);

--- a/src/util/config/index.js
+++ b/src/util/config/index.js
@@ -2,7 +2,8 @@ import fs from 'fs';
 import convict from 'convict';
 import path from 'path';
 
-import { duotones, getDuotoneUrls } from './duotone';
+import { schema as buildSchema, validateProtocol } from './build';
+import { duotones, getDuotoneUrls } from '../duotone';
 
 /**
  * This module provides a single source of truth for application configuration
@@ -31,19 +32,12 @@ import { duotones, getDuotoneUrls } from './duotone';
 
 const random32 = 'asdfasdfasdfasdfasdfasdfasdfasdf';
 
-export const PROTOCOL_ERROR = 'Protocol must be http or https';
 export const COOKIE_SECRET_ERROR =
 	'Cookie Encrypt Secret must be a random 32+ char string';
 export const CSRF_SECRET_ERROR = 'CSRF Secret must be a random 32+ char string';
 export const OAUTH_SECRET_ERROR = 'Invalid OAUTH Secret';
 export const OAUTH_KEY_ERROR = 'Invalid OAUTH Key';
 export const SALT_ERROR = 'Invalid Photo Scaler Salt';
-
-export const validateProtocol = protocol => {
-	if (!['http', 'https'].includes(protocol)) {
-		throw new Error(PROTOCOL_ERROR);
-	}
-};
 
 export const validateCookieSecret = secret => {
 	if (!secret || secret.toString().length < 32) {
@@ -75,12 +69,8 @@ export const validatePhotoScalerSalt = salt => {
 	}
 };
 
-let config = convict({
-	env: {
-		format: ['production', 'development', 'test'],
-		default: 'development',
-		env: 'NODE_ENV',
-	},
+export const config = convict({
+	...buildSchema,
 	api: {
 		protocol: {
 			format: validateProtocol,
@@ -102,68 +92,21 @@ let config = convict({
 			default: '',
 		},
 	},
-	asset_server: {
-		host: {
-			format: String,
-			default: 'beta2.dev.meetup.com',
-			env: 'ASSET_SERVER_HOST',
-		},
-		path: {
-			format: String,
-			default: '/static',
-			env: 'ASSET_PATH',
-		},
-		port: {
-			format: 'port',
-			default: 8001,
-			arg: 'asset-port',
-			env: 'ASSET_SERVER_PORT',
-		},
-	},
-	disable_hmr: {
-		format: Boolean,
-		default: false,
-		env: 'DISABLE_HMR',
-	},
-	cookie_encrypt_secret: {
-		format: validateCookieSecret,
-		default: process.env.NODE_ENV !== 'production' && random32,
-		env: 'COOKIE_ENCRYPT_SECRET',
-	},
-	csrf_secret: {
-		format: validateCsrfSecret,
-		default: process.env.NODE_ENV !== 'production' && random32,
-		env: 'CSRF_SECRET',
-	},
-	app_server: {
-		protocol: {
-			format: validateProtocol,
-			default: 'http',
-			env: 'DEV_SERVER_PROTOCOL', // legacy naming
-		},
-		host: {
-			format: String,
-			default: 'beta2.dev.meetup.com',
-			env: 'DEV_SERVER_HOST', // legacy naming
-		},
-		port: {
-			format: 'port',
-			default: 8000,
-			arg: 'app-port',
-			env: 'DEV_SERVER_PORT', // legacy naming
-		},
-	},
 	duotone_urls: {
 		format: Object,
 		default: {},
 	},
-	isDev: {
-		format: Boolean,
-		default: true,
+	cookie_encrypt_secret: {
+		format: validateCookieSecret,
+		default: (process.env.NODE_ENV !== 'production' && random32) || '',
+		env: 'COOKIE_ENCRYPT_SECRET',
+		sensitive: true,
 	},
-	isProd: {
-		format: Boolean,
-		default: false,
+	csrf_secret: {
+		format: validateCsrfSecret,
+		default: (process.env.NODE_ENV !== 'production' && random32) || '',
+		env: 'CSRF_SECRET',
+		sensitive: true,
 	},
 	oauth: {
 		auth_url: {
@@ -180,38 +123,37 @@ let config = convict({
 			format: validateOauthSecret,
 			default: null,
 			env: 'MUPWEB_OAUTH_SECRET',
+			sensitive: true,
 		},
 		key: {
 			format: validateOauthKey,
 			default: null,
 			env: 'MUPWEB_OAUTH_KEY',
+			sensitive: true,
 		},
 	},
 	photo_scaler_salt: {
 		format: validatePhotoScalerSalt,
 		default: null,
 		env: 'PHOTO_SCALER_SALT',
+		sensitive: true,
 	},
 });
 
 // Load environment dependent configuration
-const configFile = path.resolve(
+const configPath = path.resolve(
 	process.cwd(),
 	`config.${config.get('env')}.json`
 );
 
-if (fs.existsSync(configFile)) {
-	config.loadFile(configFile);
+if (fs.existsSync(configPath)) {
+	const runConfig = require(configPath).runtime || {};
+	config.load(runConfig);
 }
 
 config.set(
 	'duotone_urls',
 	getDuotoneUrls(duotones, config.get('photo_scaler_salt'))
-);
-
-config.set(
-	'api.root_url',
-	`${config.get('api.protocol')}://${config.get('api.host')}`
 );
 
 config.set('isProd', config.get('env') === 'production');

--- a/src/util/config/index.test.js
+++ b/src/util/config/index.test.js
@@ -1,17 +1,15 @@
 import config, {
-	PROTOCOL_ERROR,
 	COOKIE_SECRET_ERROR,
 	CSRF_SECRET_ERROR,
 	OAUTH_SECRET_ERROR,
 	OAUTH_KEY_ERROR,
 	SALT_ERROR,
-	validateProtocol,
 	validateCookieSecret,
 	validateCsrfSecret,
 	validateOauthSecret,
 	validateOauthKey,
 	validatePhotoScalerSalt,
-} from './config';
+} from './index';
 
 const string1 = '1';
 const string31 = 'asdfasdfasdfasdfasdfasdfasdfasd';
@@ -45,17 +43,6 @@ describe('config', () => {
 		expect(config.oauth.secret).toBeTruthy();
 		expect(config.oauth.key).toBeTruthy();
 		expect(config.photo_scaler_salt).toBeTruthy();
-	});
-});
-
-describe('validateProtocol', () => {
-	it('does not error when protocol is `http` or `https`', () => {
-		expect(() => validateProtocol('http')).not.toThrow();
-		expect(() => validateProtocol('https')).not.toThrow();
-	});
-
-	it('throws error when the protocol is not `http` or `https`', () => {
-		expect(() => validateProtocol('ftp')).toThrowError(PROTOCOL_ERROR);
 	});
 });
 

--- a/tests/integration/render.int.js
+++ b/tests/integration/render.int.js
@@ -1,5 +1,5 @@
 import { ROOT_INDEX_CONTENT, FOO_INDEX_CONTENT } from '../mockApp';
-import { getMockRenderRequestMap, mockConfig } from '../mocks';
+import { getMockRenderRequestMap } from '../mocks';
 import start from '../../src/server';
 import { fooPathContent } from '../MockContainer';
 
@@ -31,7 +31,7 @@ const fakeApiProxyResponse = 'value from api proxy';
 
 describe('Full dummy app render', () => {
 	it('renders the expected app content for nested path of mock app route config', () => {
-		return start(getMockRenderRequestMap(), {}, mockConfig).then(server => {
+		return start(getMockRenderRequestMap(), {}).then(server => {
 			const request = {
 				method: 'get',
 				url: '/foo/bar?heyhey=true',
@@ -57,7 +57,7 @@ describe('Full dummy app render', () => {
 		});
 	});
 	it('renders the expected root index route app content at `/`', () => {
-		return start(getMockRenderRequestMap(), {}, mockConfig).then(server => {
+		return start(getMockRenderRequestMap(), {}).then(server => {
 			const request = {
 				method: 'get',
 				url: '/',
@@ -77,7 +77,7 @@ describe('Full dummy app render', () => {
 		});
 	});
 	it('renders the expected child index route app content at `/foo`', () => {
-		return start(getMockRenderRequestMap(), {}, mockConfig).then(server => {
+		return start(getMockRenderRequestMap(), {}).then(server => {
 			const request = {
 				method: 'get',
 				url: '/foo',
@@ -97,8 +97,7 @@ describe('Full dummy app render', () => {
 		});
 	});
 	it('calls request with url-encoded params', () => {
-		require('request').mockReset();
-		return start(getMockRenderRequestMap(), {}, mockConfig).then(server => {
+		return start(getMockRenderRequestMap(), {}).then(server => {
 			const urlname = '驚くばかり';
 			const encodedUrlname = encodeURI(urlname);
 			const url = `/${urlname}`;


### PR DESCRIPTION
This PR separates out the buildtime config from the runtime config so that Travis can build the app in `NODE_ENV=production` but still run all 'simulated runtime' tests in `NODE_ENV=test`

In the mup-web Node Convict PR (https://github.com/meetup/mup-web/pull/999), we'll need to update the `config` imports in the build scripts so that they are importing from `meetup-web-platform/lib/util/config/build` instead of `meetup-web-platform/lib/util/config`. This should allow Webpack to correctly transpile the app.

The dummy testing runtime in Travis will be handled by `config.test.json`.

The prod runtime in GCP will be handled by env vars.