### PR TITLE
flags are returned with ', ' delimiter

### DIFF
--- a/src/util/apiUtils.js
+++ b/src/util/apiUtils.js
@@ -96,7 +96,7 @@ export const parseMetaHeaders = headers => {
 	// special case handling for flags
 	if (meetupHeaders.flags) {
 		meetupHeaders.flags = querystring.parse(meetupHeaders.flags, {
-			delimiter: ',',
+			delimiter: ', ',
 			decoder: coerceBool,
 		});
 	}

--- a/src/util/apiUtils.test.js
+++ b/src/util/apiUtils.test.js
@@ -209,7 +209,7 @@ describe('parseApiResponse', () => {
 	};
 	it('returns the flags set in the X-Meetup-Flags header', () => {
 		const headers = {
-			'x-meetup-flags': 'foo=true,bar=false',
+			'x-meetup-flags': 'foo=true, bar=false',
 		};
 		const flaggedResponse = { ...MOCK_RESPONSE, headers };
 		expect(
@@ -278,7 +278,7 @@ describe('parseMetaHeaders', () => {
 	});
 	it('returns x-meetup-flags as flags object with real booleans', () => {
 		expect(
-			parseMetaHeaders({ 'x-meetup-flags': 'foo=true,bar=false' })
+			parseMetaHeaders({ 'x-meetup-flags': 'foo=true, bar=false' })
 		).toMatchObject({ flags: { foo: true, bar: false } });
 	});
 	it('parses specified x- headers', () => {


### PR DESCRIPTION
need to split the returned flags on `', '` not `','`. Go figure.

I'll SV this if no one picks it up.