### PR TITLE
configure `supportedLocaleCodes` with consolidated CONFIGURE action

### DIFF
--- a/src/actions/configActionCreators.js
+++ b/src/actions/configActionCreators.js
@@ -1,15 +1,5 @@
 // @flow
-export const configure = (config: { [string]: mixed }) => ({
+export default (config: { [string]: mixed }) => ({
 	type: 'CONFIGURE',
 	payload: config,
 });
-export const configureSupportedLocaleCodes = (
-	supportedLocaleCodes: Array<string>
-) => configure({ supportedLocaleCodes });
-
-export const configureLocaleCode = (localeCode: string) =>
-	configure({ localeCode });
-
-export const configureApiUrl = (apiUrl: string) => configure({ apiUrl });
-
-export const configureBaseUrl = (baseUrl: string) => configure({ baseUrl });

--- a/src/actions/configActionCreators.js
+++ b/src/actions/configActionCreators.js
@@ -1,20 +1,15 @@
-export function configureLocaleCode(localeCode) {
-	return {
-		type: 'CONFIGURE_LOCALE_CODE',
-		payload: localeCode,
-	};
-}
+// @flow
+export const configure = (config: { [string]: mixed }) => ({
+	type: 'CONFIGURE',
+	payload: config,
+});
+export const configureSupportedLocaleCodes = (
+	supportedLocaleCodes: Array<string>
+) => configure({ supportedLocaleCodes });
 
-export function configureApiUrl(url) {
-	return {
-		type: 'CONFIGURE_API_URL',
-		payload: url,
-	};
-}
+export const configureLocaleCode = (localeCode: string) =>
+	configure({ localeCode });
 
-export function configureBaseUrl(url) {
-	return {
-		type: 'CONFIGURE_BASE_URL',
-		payload: url,
-	};
-}
+export const configureApiUrl = (apiUrl: string) => configure({ apiUrl });
+
+export const configureBaseUrl = (baseUrl: string) => configure({ baseUrl });

--- a/src/reducers/platform.js
+++ b/src/reducers/platform.js
@@ -133,16 +133,10 @@ export function clickTracking(state = DEFAULT_CLICK_TRACK, action) {
 }
 
 export function config(state = {}, action) {
-	switch (action.type) {
-		case 'CONFIGURE_API_URL':
-			return { ...state, apiUrl: action.payload };
-		case 'CONFIGURE_LOCALE_CODE':
-			return { ...state, localeCode: action.payload };
-		case 'CONFIGURE_BASE_URL':
-			return { ...state, baseUrl: action.payload };
-		default:
-			return state;
+	if (action.type === 'CONFIGURE') {
+		return { ...state, ...action.payload };
 	}
+	return state;
 }
 
 /**

--- a/src/renderers/server-render.jsx
+++ b/src/renderers/server-render.jsx
@@ -18,6 +18,7 @@ import {
 	configureApiUrl,
 	configureBaseUrl,
 	configureLocaleCode,
+	configureSupportedLocaleCodes,
 } from '../actions/configActionCreators';
 
 // Ensure global Intl for use with FormatJS
@@ -107,16 +108,14 @@ const getRouterRenderer = ({
 	};
 };
 
-const makeRenderer$ = (
-	renderConfig: {
-		routes: Array<Object>,
-		reducer: Reducer,
-		assetPublicPath: string,
-		middleware: Array<Function>,
-		baseUrl: string,
-		scripts: Array<string>,
-	}
-) =>
+const makeRenderer$ = (renderConfig: {
+	routes: Array<Object>,
+	reducer: Reducer,
+	assetPublicPath: string,
+	middleware: Array<Function>,
+	baseUrl: string,
+	scripts: Array<string>,
+}) =>
 	makeRenderer(
 		renderConfig.routes,
 		renderConfig.reducer,
@@ -157,7 +156,7 @@ const makeRenderer = (
 ) => (request: Object) => {
 	middleware = middleware || [];
 	const {
-		app: { localeCode },
+		app: { localeCode, supportedLocaleCodes },
 		connection,
 		headers,
 		info,
@@ -187,6 +186,7 @@ const makeRenderer = (
 	store.dispatch(configureApiUrl(apiUrl));
 	store.dispatch(configureBaseUrl(host));
 	store.dispatch(configureLocaleCode(localeCode));
+	store.dispatch(configureSupportedLocaleCodes(supportedLocaleCodes));
 
 	// render skeleton if requested - the store is ready
 	if ('skeleton' in request.query) {

--- a/src/renderers/server-render.jsx
+++ b/src/renderers/server-render.jsx
@@ -14,12 +14,7 @@ import PlatformApp from '../components/PlatformApp';
 
 import { getServerCreateStore } from '../util/createStoreServer';
 import { SERVER_RENDER } from '../actions/syncActionCreators';
-import {
-	configureApiUrl,
-	configureBaseUrl,
-	configureLocaleCode,
-	configureSupportedLocaleCodes,
-} from '../actions/configActionCreators';
+import configure from '../actions/configActionCreators';
 
 // Ensure global Intl for use with FormatJS
 Intl.NumberFormat = IntlPolyfill.NumberFormat;
@@ -183,11 +178,14 @@ const makeRenderer = (
 	const store = createStore(reducer, initialState);
 
 	// load initial config
-	store.dispatch(configureApiUrl(apiUrl));
-	store.dispatch(configureBaseUrl(host));
-	store.dispatch(configureLocaleCode(localeCode));
-	store.dispatch(configureSupportedLocaleCodes(supportedLocaleCodes));
-
+	store.dispatch(
+		configure({
+			apiUrl,
+			baseUrl: host,
+			localeCode,
+			supportedLocaleCodes,
+		})
+	);
 	// render skeleton if requested - the store is ready
 	if ('skeleton' in request.query) {
 		return Observable.of({

--- a/src/routes/appRouteHandler.js
+++ b/src/routes/appRouteHandler.js
@@ -13,6 +13,7 @@ export const getAppRouteHandler = renderRequestMap => (request, reply) => {
 		return redirect;
 	}
 	request.app.localeCode = requestLanguage;
+	request.app.supportedLocaleCodes = supportedLangs;
 	const renderRequest = renderRequestMap[requestLanguage];
 
 	return renderRequest(request)


### PR DESCRIPTION
The main change is adding `supportedLocaleCodes` to `state.config` using the same Redux action pattern we've used for passing other config/environment data from the server to the client app.

I've also refactored the config action creators as a single `CONFIGURE` action creator that produces a single immutable object update to `state.config` since everything in `state.config` is a simple string-value map.