### PR TITLE
WP 265 clear inflight refs

### DIFF
--- a/src/reducers/platform.js
+++ b/src/reducers/platform.js
@@ -27,6 +27,15 @@ type ApiState = {
 export const DEFAULT_API_STATE: ApiState = { inFlight: [] };
 export const DEFAULT_APP_STATE = {};
 
+type ObjectFilter = (Object, ...args?: Array<any>) => Object;
+const filterKeys: ObjectFilter = (obj: ApiState, keys: Array<string>) =>
+	Object.keys(obj).reduce((newObj: ApiState, key: string) => {
+		if (keys.includes(key)) {
+			newObj[key] = obj[key];
+		}
+		return newObj;
+	}, DEFAULT_API_STATE);
+
 export const responseToState = (
 	response: QueryResponse
 ): { [string]: QueryResponse } => ({ [response.ref]: response });
@@ -50,7 +59,13 @@ export function api(
 				return { ...DEFAULT_API_STATE, inFlight };
 			}
 
-			return { ...state, inFlight };
+			// remove any `ref`s that are being refreshed - eliminate stale data
+			const newState: ApiState = {
+				...filterKeys(state, requestRefs),
+				inFlight,
+			};
+
+			return newState;
 		}
 		case API_RESP_SUCCESS: // fall though
 		case API_RESP_ERROR:

--- a/src/reducers/platform.js
+++ b/src/reducers/platform.js
@@ -29,12 +29,15 @@ export const DEFAULT_APP_STATE = {};
 
 type ObjectFilter = (Object, ...args?: Array<any>) => Object;
 const filterKeys: ObjectFilter = (obj: ApiState, keys: Array<string>) =>
-	Object.keys(obj).reduce((newObj: ApiState, key: string) => {
-		if (keys.includes(key)) {
-			newObj[key] = obj[key];
-		}
-		return newObj;
-	}, DEFAULT_API_STATE);
+	Object.keys(obj).reduce(
+		(newObj: ApiState, key: string) => {
+			if (!keys.includes(key)) {
+				newObj[key] = obj[key];
+			}
+			return newObj;
+		},
+		{ ...DEFAULT_API_STATE }
+	);
 
 export const responseToState = (
 	response: QueryResponse

--- a/src/reducers/platform.js
+++ b/src/reducers/platform.js
@@ -63,7 +63,7 @@ export function api(
 			}
 
 			// remove any `ref`s that are being refreshed - eliminate stale data
-			const newState: ApiState = {
+			const newState = {
 				...filterKeys(state, requestRefs),
 				inFlight,
 			};

--- a/src/reducers/platform.test.js
+++ b/src/reducers/platform.test.js
@@ -18,7 +18,9 @@ describe('app reducer', () => {
 		expect(app(undefined, {})).toEqual(DEFAULT_APP_STATE);
 	});
 	it('re-sets app state on logout API_REQUEST', function() {
-		const logoutRequest = syncActionCreators.apiRequest([], { logout: true });
+		const logoutRequest = syncActionCreators.apiRequest([], {
+			logout: true,
+		});
 		expect(app(this.MOCK_STATE, logoutRequest)).toEqual(DEFAULT_APP_STATE);
 	});
 	it('assembles success responses into single state tree', () => {
@@ -50,9 +52,27 @@ describe('api reducer', () => {
 	});
 	it('re-sets api state on logout API_REQ, with inFlight query', function() {
 		const ref = 'foobar';
-		const logoutRequest = apiActions.requestAll([{ ref }], { logout: true });
+		const logoutRequest = apiActions.requestAll([{ ref }], {
+			logout: true,
+		});
 		expect(api({ ...DEFAULT_API_STATE }, logoutRequest)).toEqual({
 			...DEFAULT_API_STATE,
+			inFlight: [ref],
+		});
+	});
+	it('clears refs corresponding to new requests', function() {
+		const ref = 'foobar';
+		const populatedState = {
+			...DEFAULT_API_STATE,
+			bar: 'something unrelated',
+		};
+		const populatedStateWithRef = {
+			...populatedState,
+			[ref]: 'not empty',
+		};
+		const action = apiActions.requestAll([{ ref }]);
+		expect(api(populatedStateWithRef, action)).toEqual({
+			...populatedState,
 			inFlight: [ref],
 		});
 	});


### PR DESCRIPTION
This PR updates the platform reducer to clear out data old that is being refreshed by a new query.

This will prevent flashes of content from prior navigation on things like group or event pages when moving around the app. For repeated queries, the cache middleware will ensure that the UI get 'instant' updates of the cleared state.