### PR TITLE
revert the catch-all unicode delete, convert all unicode newlines

### DIFF
--- a/src/components/dom.jsx
+++ b/src/components/dom.jsx
@@ -49,9 +49,7 @@ const DOM = props => {
 	// stringify the whole object so that it can be escaped in one pass
 	const initialStateJson = JSON.stringify(initialState);
 	// escape the string
-	const escapedState = escapeHtml(
-		initialStateJson.replace(/[^\u0000-\u007E]/g, '')
-	);
+	const escapedState = escapeHtml(initialStateJson);
 
 	// Extract the `<head>` information from any page-specific `<Helmet>` components
 	const head = Helmet.rewind();

--- a/src/util/apiUtils.test.js
+++ b/src/util/apiUtils.test.js
@@ -201,6 +201,12 @@ describe('parseApiValue', () => {
 			badStatus.statusMessage
 		);
 	});
+	it('returns a value without any JS-literal unfriendly newline characters', () => {
+		const fragileValue = 'foo \\u2028 \\u2029';
+		const fragileJSON = JSON.stringify({ foo: fragileValue });
+		const parsed = parseApiValue([MOCK_RESPONSE, fragileJSON]).value.foo;
+		expect(parsed).toEqual('foo \\n \\n');
+	});
 });
 describe('parseApiResponse', () => {
 	const MOCK_RESPONSE = {
@@ -292,7 +298,9 @@ describe('parseMetaHeaders', () => {
 
 		// both 'next' and 'prev'
 		expect(
-			parseMetaHeaders({ link: `<${next}>; rel="next", <${prev}>; rel="prev"` })
+			parseMetaHeaders({
+				link: `<${next}>; rel="next", <${prev}>; rel="prev"`,
+			})
 		).toMatchObject({ link: { next, prev } });
 		// just 'next'
 		expect(parseMetaHeaders({ link: `<${next}>; rel="next"` })).toMatchObject({


### PR DESCRIPTION
it's only those unicode newlines that are a problem. other unicode is (hopefully) safe. This PR catches the unicode newlines when they first appear in API responses.