### PR TITLE
do not allow undefined params in encoded queries

### DIFF
--- a/flow-typed/platform.js
+++ b/flow-typed/platform.js
@@ -1,7 +1,7 @@
 // @flow
 declare var Intl: Object;
 
-declare type Params = { [string]: string };
+declare type Params = { [string]: string | number };
 
 declare type FluxStandardAction = {
 	type: string,

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "react-intl": "2.3.0",
     "react-redux": "5.0.5",
     "react-router-dom": "4.1.1",
+    "react-test-renderer": "15.5.4",
     "redux": "3.6.0",
     "rxjs": "5.4.0",
     "tough-cookie": "2.3.2"

--- a/src/components/BrowserApp.test.jsx
+++ b/src/components/BrowserApp.test.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import TestUtils from 'react-dom/test-utils';
+import ShallowRenderer from 'react-test-renderer/shallow';
 import BrowserApp from './BrowserApp';
 
-const renderer = TestUtils.createRenderer();
+const renderer = new ShallowRenderer();
 
 describe('BrowserApp', function() {
 	const routes = [];

--- a/src/util/routeUtils.js
+++ b/src/util/routeUtils.js
@@ -18,9 +18,12 @@ const _routeMatchOptions = (
 	exact: route.exact,
 });
 
-export const decodeParams = (params: Params) =>
+export const decodeParams = (params: { [string]: any }): Params =>
 	Object.keys(params).reduce((decodedParams, key) => {
-		decodedParams[key] = params[key] && decodeURI(params[key]);
+		if (typeof params[key] !== 'undefined') {
+			// skip 'undefined' values that cannot be encoded (null is okay)
+			decodedParams[key] = params[key] && decodeURI(params[key]);
+		}
 		return decodedParams;
 	}, {});
 

--- a/src/util/routeUtils.test.js
+++ b/src/util/routeUtils.test.js
@@ -94,9 +94,9 @@ describe('decodeParams', () => {
 		});
 	});
 	it('skips keys with undefined values', () => {
-		const params = { foo: undefined, bar: 'baz' };
+		const params = { foo: undefined, bar: 'baz', qux: null };
 		const decoded = decodeParams(params);
-		expect(decoded).toEqual({ bar: 'baz' });
+		expect(decoded).toEqual({ bar: 'baz', qux: null });
 	});
 	it('returns empty object unchanged', () => {
 		const object = {};

--- a/src/util/routeUtils.test.js
+++ b/src/util/routeUtils.test.js
@@ -77,7 +77,7 @@ describe('activeRouteQueries', () => {
 });
 
 describe('decodeParams', () => {
-	it('url-decodes all values of object', () => {
+	it('url-decodes all defined values of object', () => {
 		const rawValues = ['&asdfkj%20sfd', 'asdfs', '%dsjdasdf///', '驚くばかり'];
 		const encodedValues = rawValues.map(encodeURI);
 		const params = encodedValues.reduce(
@@ -92,6 +92,11 @@ describe('decodeParams', () => {
 		Object.keys(decoded).forEach(k => {
 			expect(decoded[k]).toEqual(rawValues[k]);
 		});
+	});
+	it('skips keys with undefined values', () => {
+		const params = { foo: undefined, bar: 'baz' };
+		const decoded = decodeParams(params);
+		expect(decoded).toEqual({ bar: 'baz' });
 	});
 	it('returns empty object unchanged', () => {
 		const object = {};
@@ -210,7 +215,10 @@ describe('getMatchedQueries', () => {
 			match: { params },
 		};
 		getMatchedQueries(location)([matchedRoute]);
-		expect(matchedRoute.route.query).toHaveBeenCalledWith({ location, params });
+		expect(matchedRoute.route.query).toHaveBeenCalledWith({
+			location,
+			params,
+		});
 	});
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3746,6 +3746,13 @@ react-side-effect@1.1.3, react-side-effect@^1.1.0:
     exenv "^1.2.1"
     shallowequal "^1.0.1"
 
+react-test-renderer@15.5.4:
+  version "15.5.4"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-15.5.4.tgz#d4ebb23f613d685ea8f5390109c2d20fbf7c83bc"
+  dependencies:
+    fbjs "^0.8.9"
+    object-assign "^4.1.0"
+
 react@15.5.4:
   version "15.5.4"
   resolved "https://registry.yarnpkg.com/react/-/react-15.5.4.tgz#fa83eb01506ab237cdc1c8c3b1cea8de012bf047"


### PR DESCRIPTION
This will permanently fix a bug encountered here https://github.com/meetup/mup-web/pull/1122. When queries are url-encoded, we need to make sure that there aren't any keys with `undefined` values because our URL-encoding package (rison) will throw an error.

This PR allows `null` values to get through, but skips `undefined` values