### PR TITLE
WP 271 tracking log referrer bug

### DIFF
--- a/src/apiProxy/api-proxy.js
+++ b/src/apiProxy/api-proxy.js
@@ -1,3 +1,4 @@
+// Implicit dependency: tracking plugin providing request.trackApi method
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/observable/zip';
 
@@ -54,8 +55,10 @@ const apiProxy$ = (request, queries) => {
 		.map((opts, i) => [opts, queries[i]]) // zip the query back into the opts
 		.map(makeApiRequest$(request));
 
-	// 4. zip them together to send them parallel and return responses in order
-	return Observable.zip(...apiRequests$);
+	// 4. zip them together to make requests in parallel and return responses in order
+	return Observable.zip(...apiRequests$).do(responses =>
+		request.trackApi({ request }, responses)
+	);
 };
 
 export default apiProxy$;

--- a/src/apiProxy/api-proxy.test.js
+++ b/src/apiProxy/api-proxy.test.js
@@ -20,6 +20,7 @@ describe('apiProxy$', () => {
 			},
 			server: getServer(),
 			log: () => {},
+			trackApi: () => {},
 		};
 		const requestResult = {
 			type: 'fake',

--- a/src/apiProxy/apiProxyHandler.js
+++ b/src/apiProxy/apiProxyHandler.js
@@ -1,6 +1,4 @@
-import url from 'url';
 import Boom from 'boom';
-import rison from 'rison';
 
 import 'rxjs/add/operator/catch';
 
@@ -11,15 +9,7 @@ const handleQueryResponses = (request, reply) => queryResponses => {
 		})
 	).type('application/json');
 
-	const payload = request.method === 'post' ? request.payload : request.query;
-
-	const metadataRison = payload.metadata || rison.encode_object({});
-	const metadata = rison.decode_object(metadataRison);
-	const originUrl = response.request.info.referrer;
-	metadata.url = url.parse(originUrl).pathname;
-	metadata.method = response.request.method;
-
-	reply.trackApi(response, queryResponses, metadata);
+	request.trackApi(response, queryResponses);
 };
 
 export const getApiProxyRouteHandler = proxyApiRequest$ => (request, reply) => {

--- a/src/apiProxy/apiProxyHandler.js
+++ b/src/apiProxy/apiProxyHandler.js
@@ -2,15 +2,12 @@ import Boom from 'boom';
 
 import 'rxjs/add/operator/catch';
 
-const handleQueryResponses = (request, reply) => queryResponses => {
-	const response = reply(
+const handleQueryResponses = (request, reply) => queryResponses =>
+	reply(
 		JSON.stringify({
 			responses: queryResponses,
 		})
 	).type('application/json');
-
-	request.trackApi(response, queryResponses);
-};
 
 export const getApiProxyRouteHandler = proxyApiRequest$ => (request, reply) => {
 	proxyApiRequest$(request).subscribe(

--- a/src/epics/sync.js
+++ b/src/epics/sync.js
@@ -51,7 +51,7 @@ export const getNavEpic = (routes, baseUrl) => {
 			.ofType(LOCATION_CHANGE, SERVER_RENDER)
 			.mergeMap(({ payload: location }) => {
 				// note that this function executes _downstream_ of reducers, so the
-				// new location has already been incorporated into `state`
+				// new `routing` data has already been populated in `state`
 				const state = store.getState();
 				// inject request metadata from context, including `store.getState()`
 				const requestMetadata = {

--- a/src/epics/sync.js
+++ b/src/epics/sync.js
@@ -46,19 +46,19 @@ const logoutQueryMatch = /[?&]logout(?:[=&]|$)/;
  */
 export const getNavEpic = (routes, baseUrl) => {
 	const resolveRoutes = getRouteResolver(routes, baseUrl);
-	let currentLocation = {}; // keep track of current route so that apiRequest can get 'referrer'
 	return (action$, store) =>
 		action$
 			.ofType(LOCATION_CHANGE, SERVER_RENDER)
 			.mergeMap(({ payload: location }) => {
+				// note that this function executes _downstream_ of reducers, so the
+				// new location has already been incorporated into `state`
+				const state = store.getState();
 				// inject request metadata from context, including `store.getState()`
 				const requestMetadata = {
-					referrer: currentLocation.pathname || '',
+					referrer: (state.routing.referrer || {}).pathname || '',
 					logout: logoutQueryMatch.test(location.search),
-					clickTracking: store.getState().clickTracking,
+					clickTracking: state.clickTracking,
 				};
-				// now that referrer has been recorded, set new currentLocation
-				currentLocation = location;
 
 				const cacheAction$ = requestMetadata.logout
 					? Observable.of({ type: 'CACHE_CLEAR' })

--- a/src/epics/sync.test.js
+++ b/src/epics/sync.test.js
@@ -40,7 +40,7 @@ describe('Sync epic', () => {
 			payload: MOCK_RENDERPROPS.location,
 		};
 
-		const fakeStore = createFakeStore({});
+		const fakeStore = createFakeStore({ routing: {} });
 		const action$ = ActionsObservable.of(locationChange, serverRender);
 		return getSyncEpic(MOCK_ROUTES)(action$, fakeStore)
 			.toArray()
@@ -61,7 +61,7 @@ describe('Sync epic', () => {
 			payload: logoutLocation,
 		};
 
-		const fakeStore = createFakeStore({});
+		const fakeStore = createFakeStore({ routing: {} });
 		const action$ = ActionsObservable.of(locationChange);
 		return getSyncEpic(MOCK_ROUTES)(action$, fakeStore)
 			.toArray()

--- a/src/plugins/tracking/_activityTrackers.js
+++ b/src/plugins/tracking/_activityTrackers.js
@@ -107,9 +107,9 @@ export const getTrackApi: TrackGetter = (trackOpts: TrackOpts) => (
 
 	const metadataRison = payload.metadata || rison.encode_object({});
 	const metadata = rison.decode_object(metadataRison);
-	const originUrl = response.request.info.referrer;
+	const originUrl = request.info.referrer;
 	metadata.url = parseUrl(originUrl).pathname;
-	metadata.method = response.request.method;
+	metadata.method = request.method;
 
 	const { url, referrer, method } = metadata;
 	if (method === 'get') {

--- a/src/plugins/tracking/activity.js
+++ b/src/plugins/tracking/activity.js
@@ -3,7 +3,7 @@ import avro from './util/avro';
 import { getTrackApi, getTrackSession } from './_activityTrackers';
 
 /*
- * This plugin provides `reply.track...` methods that track events related to
+ * This plugin provides `request.track...` methods that track events related to
  * particular server responses, e.g. new sesssions and navigation activity.
  *
  * Available trackers:
@@ -39,7 +39,7 @@ export const getLogger: string => (Object, Object) => mixed = (
  * Each tracking function is a composition of a logging function and data about
  * the `response` object. This function computes some configuration information
  * to create the tracking functions, and returns each of them in a map keyed by
- * the target `reply` method name
+ * the target `request` method name
  */
 export function getTrackers(options: {
 	platform_agent: string,
@@ -63,7 +63,7 @@ export function getTrackers(options: {
 		sessionIdCookieName,
 		cookieOpts,
 	};
-	// These are the tracking methods that will be set on the `reply` interface
+	// These are the tracking methods that will be set on the `request` interface
 	const trackers: { [string]: Tracker } = {
 		trackApi: getTrackApi(trackOpts),
 		trackSession: getTrackSession(trackOpts),
@@ -72,7 +72,7 @@ export function getTrackers(options: {
 }
 
 /*
- * The plugin register function that will 'decorate' the `reply` interface with
+ * The plugin register function that will 'decorate' the `request` interface with
  * all tracking functions returned from `getTrackers`
  */
 export default function register(
@@ -83,7 +83,7 @@ export default function register(
 	const trackers: { [string]: Tracker } = getTrackers(options);
 
 	Object.keys(trackers).forEach((trackType: string) => {
-		server.decorate('reply', trackType, trackers[trackType]);
+		server.decorate('request', trackType, trackers[trackType]);
 	});
 
 	next();

--- a/src/reducers/platform.js
+++ b/src/reducers/platform.js
@@ -16,6 +16,7 @@ import {
 	API_RESP_FAIL,
 	API_RESP_COMPLETE,
 } from '../actions/apiActionCreators';
+import { LOCATION_CHANGE, SERVER_RENDER } from '../actions/syncActionCreators';
 import { CACHE_SUCCESS } from '../actions/cacheActionCreators';
 
 type ApiState = {
@@ -151,12 +152,27 @@ export function preRenderChecklist([apiDataLoaded] = [false], action) {
 	return [apiDataLoaded || action.type === API_RESP_COMPLETE];
 }
 
+/*
+ * Store routing state to allow middleware to report record more accurate
+ * tracking info
+ */
+export function routing(state = {}, action) {
+	if (action.type === LOCATION_CHANGE || action.type === SERVER_RENDER) {
+		return {
+			referrer: state.location || {},
+			location: action.payload,
+		};
+	}
+	return state;
+}
+
 const platformReducers = {
 	api,
 	app,
 	clickTracking,
 	config,
 	preRenderChecklist,
+	routing,
 };
 
 /**

--- a/src/reducers/platform.js
+++ b/src/reducers/platform.js
@@ -153,7 +153,7 @@ export function preRenderChecklist([apiDataLoaded] = [false], action) {
 }
 
 /*
- * Store routing state to allow middleware to report record more accurate
+ * Store routing state to allow middleware to record more accurate
  * tracking info
  */
 export function routing(state = {}, action) {

--- a/src/routes/appRouteHandler.js
+++ b/src/routes/appRouteHandler.js
@@ -22,6 +22,6 @@ export const getAppRouteHandler = renderRequestMap => (request, reply) => {
 			// response is sent when this function returns (`nextTick`)
 			const response = reply(result).code(statusCode);
 
-			reply.trackSession(response);
+			request.trackSession(response);
 		});
 };

--- a/src/util/createStoreServer.js
+++ b/src/util/createStoreServer.js
@@ -15,7 +15,6 @@ import 'rxjs/add/operator/toPromise';
  */
 export const serverFetchQueries = request => () => queries =>
 	apiProxy$(request, queries)
-		.do(responses => request.trackApi({ request }, responses)) // move this into apiProxy$ to consolidate
 		.map(responses => ({ responses })) // package the responses in object like the API proxy endpoint does
 		.toPromise()
 		.then(parseQueryResponse(queries));

--- a/src/util/createStoreServer.js
+++ b/src/util/createStoreServer.js
@@ -15,6 +15,7 @@ import 'rxjs/add/operator/toPromise';
  */
 export const serverFetchQueries = request => () => queries =>
 	apiProxy$(request, queries)
+		.do(responses => request.trackApi({ request }, responses)) // move this into apiProxy$ to consolidate
 		.map(responses => ({ responses })) // package the responses in object like the API proxy endpoint does
 		.toPromise()
 		.then(parseQueryResponse(queries));

--- a/src/util/createStoreServer.test.js
+++ b/src/util/createStoreServer.test.js
@@ -26,7 +26,7 @@ describe('serverFetchQueries', () => {
 	// 	.toPromise()
 	// 	.then(parseQueryResponse(queries));
 	it('calls apiProxy$ with request and queries, passes ', () => {
-		const request = {};
+		const request = { trackApi: jest.fn() };
 		const queries = [];
 		const expectedParsedResponse = 'foo';
 		spyOn(fetchUtils, 'parseQueryResponse').and.callFake(() => () =>

--- a/src/util/testUtils.js
+++ b/src/util/testUtils.js
@@ -62,8 +62,8 @@ export const getServer = () => {
 		request => () => Observable.of(request),
 		{ apply: true }
 	);
-	server.decorate('reply', 'trackApi', () => ({}));
-	server.decorate('reply', 'trackSession', () => ({}));
+	server.decorate('request', 'trackApi', () => ({}));
+	server.decorate('request', 'trackSession', () => ({}));
 	server.logger = () => MOCK_LOGGER;
 	return server;
 };


### PR DESCRIPTION
2 related fixes here

1. Ensure that the first navigation action in the browser populates a valid `referrer` property to the `API_REQ`. In the current codebase, `referrer` only appears on the _second_ navigation action. Sadface for tracking.

2. Make sure that the tracking log is generated for the initial server-side request as well as subsequent AJAX requests. The current code only calls `trackApi` for AJAX requests. Sadface for tracking