### PR TITLE
WP 356 301 redirect

### DIFF
--- a/src/components/Redirect.jsx
+++ b/src/components/Redirect.jsx
@@ -50,6 +50,11 @@ type RedirectState = {
  * <Router to='http://example.com' />
  * // external URL, URL object
  * <Router to={new URL('http://example.com')} />
+
+ * // internal route, permanent redirect
+ * <Router to='http://example.com' permanent />
+ * // external URL, permanent redirect
+ * <Router to='http://example.com' permanent />
  * ```
  */
 class Redirect extends React.Component {

--- a/src/components/Redirect.jsx
+++ b/src/components/Redirect.jsx
@@ -52,7 +52,7 @@ type RedirectState = {
  * <Router to={new URL('http://example.com')} />
 
  * // internal route, permanent redirect
- * <Router to='http://example.com' permanent />
+ * <Router to='/foo/bar' permanent />
  * // external URL, permanent redirect
  * <Router to='http://example.com' permanent />
  * ```
@@ -65,7 +65,10 @@ class Redirect extends React.Component {
 			// this is an external URL, so let `withSideEffect` handlers do redirect
 			return null;
 		}
-		// internal route URL
+		// internal route URL - <Route> provides access to the static routing
+		// context on the server so we can populate the `permanent` value, and the
+		// `<Redirect>` will populate the context `url` value or trigger the
+		// `window.location` redirect in the browser
 		return (
 			<Route
 				render={({ staticContext }) => {

--- a/src/components/Redirect.jsx
+++ b/src/components/Redirect.jsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import withSideEffect from 'react-side-effect';
 import RouterRedirect from 'react-router-dom/Redirect';
+import Route from 'react-router-dom/Route';
 
 const testForExternal = (to: RouterTo): boolean => {
 	if (to instanceof URL) {
@@ -16,13 +17,19 @@ const testForExternal = (to: RouterTo): boolean => {
 type RouterTo = string | LocationShape | URL;
 type RedirectProps = {
 	to: RouterTo,
+	permanent?: boolean,
 	push?: boolean,
+};
+type RedirectState = {
+	url: string,
+	permanent?: boolean,
 };
 
 /*
  * A routing component that, when rendered, will redirect the application to
  * another internal route _or_ external URL. On the server, the redirect will
- * be handled with a 302 redirect HTTP response to the browser. On the client,
+ * be handled with a 301/302 redirect HTTP response to the browser - 301 when
+ * the `permanent` prop has been set, 302 otherwise. On the client,
  * `window.location.replace` will be used for external URLs, but React Router
  * will respect a `push: false` property to decide whether to push or replace
  * ``window.history` state.
@@ -48,25 +55,39 @@ type RedirectProps = {
 class Redirect extends React.Component {
 	props: RedirectProps;
 	render() {
-		const { to, push } = this.props;
+		const { to, push, permanent } = this.props;
 		if (to instanceof URL || testForExternal(to)) {
+			// this is an external URL, so let `withSideEffect` handlers do redirect
 			return null;
 		}
-		return <RouterRedirect to={to} push={push} />;
+		// internal route URL
+		return (
+			<Route
+				render={({ staticContext }) => {
+					if (staticContext) {
+						// populate static context for server-side redirect
+						staticContext.permanent = permanent;
+					}
+					return <RouterRedirect to={to} push={push} />;
+				}}
+			/>
+		);
 	}
 }
 
-const reducePropsToState = (propsList: Array<RedirectProps>): ?string => {
-	const { to } = propsList.pop();
+const reducePropsToState = (
+	propsList: Array<RedirectProps>
+): ?RedirectState => {
+	const { to, permanent } = propsList.pop();
 	if (to instanceof URL) {
 		// return the external URL as a string
-		return to.toString();
+		return { url: to.toString(), permanent };
 	}
 	if (!testForExternal(to) || typeof to !== 'string') {
 		// no external URL string
 		return undefined;
 	}
-	return to;
+	return { url: to, permanent };
 };
 
 const handleStateChangeOnClient = (to: RouterTo) => {

--- a/src/components/redirect.test.jsx
+++ b/src/components/redirect.test.jsx
@@ -3,12 +3,12 @@ import ReactDOMServer from 'react-dom/server';
 import StaticRouter from 'react-router-dom/StaticRouter';
 import Redirect from './Redirect';
 
-const renderToContext = to => {
+const renderToContext = (to, permanent) => {
 	const context = {};
 
 	ReactDOMServer.renderToString(
 		<StaticRouter location={new URL('http://example.com')} context={context}>
-			<Redirect to={to} />
+			<Redirect to={to} permanent={permanent} />
 		</StaticRouter>
 	);
 	return context;
@@ -18,32 +18,51 @@ describe('Server rendering', () => {
 	it('sets React Router context for "local" redirect, nothing from Redirect.rewind()', () => {
 		const internalTo = 'foo/bar';
 		const httpContext = renderToContext(internalTo);
-		expect(httpContext.url).toEqual(internalTo);
+		expect(httpContext).toMatchObject({ url: internalTo });
+		expect(httpContext.permanent).toBeUndefined();
 		expect(Redirect.rewind()).toBeUndefined();
 	});
 	it('provides external redirect URL from Redirect.rewind(), nothing from React Router context', () => {
-		let externalTo = 'http://foo.com';
+		let externalTo = 'http://foo.com'; // non-SSL
 		const httpContext = renderToContext(externalTo);
 		expect(httpContext.url).toBeUndefined();
-		expect(Redirect.rewind()).toEqual(externalTo);
+		const externalRedirect = Redirect.rewind();
+		expect(externalRedirect).toMatchObject({ url: externalTo });
+		expect(externalRedirect.permanent).toBeUndefined();
 
-		externalTo = 'https://foo.com';
+		externalTo = 'https://foo.com'; // SSL
 		const httpsContext = renderToContext(externalTo);
 		expect(httpsContext.url).toBeUndefined();
-		expect(Redirect.rewind()).toEqual(externalTo);
+		expect(Redirect.rewind()).toMatchObject({ url: externalTo });
 	});
 	it('handles location object "to" props', () => {
 		const externalTo = new URL('https://foo.com/foo');
 		const httpsContext = renderToContext(externalTo);
 		expect(httpsContext.url).toBeUndefined();
-		expect(Redirect.rewind()).toEqual(externalTo.href);
+		const externalRedirect = Redirect.rewind();
+		expect(externalRedirect).toMatchObject({ url: externalTo.href });
+		expect(externalRedirect.permanent).toBeUndefined();
 
 		const internalTo = { pathname: '/foo/bar', search: '?foo=bar' };
 		const httpContext = renderToContext(internalTo);
-		expect(httpContext.url).toEqual(
-			`${internalTo.pathname}${internalTo.search}`
-		);
+		expect(httpContext).toMatchObject({
+			url: `${internalTo.pathname}${internalTo.search}`,
+		});
+		expect(httpContext.permanent).toBeUndefined();
 		expect(Redirect.rewind()).toBeUndefined();
+	});
+	it('sets `permanent` on internal permanent redirect', () => {
+		const internalTo = 'foo/bar';
+		const permanent = true;
+		const httpContext = renderToContext(internalTo, permanent);
+		expect(httpContext).toMatchObject({ url: internalTo, permanent });
+	});
+	it('sets `permanent` on external permanent redirect', () => {
+		const externalTo = 'https://foo.com'; // SSL
+		const permanent = true;
+		const httpsContext = renderToContext(externalTo, permanent);
+		expect(httpsContext.url).toBeUndefined();
+		expect(Redirect.rewind()).toMatchObject({ url: externalTo, permanent });
 	});
 	it('returns undefined when no Redirect', () => {
 		ReactDOMServer.renderToString(<div />);

--- a/src/routes/appRouteHandler.js
+++ b/src/routes/appRouteHandler.js
@@ -21,7 +21,7 @@ export const getAppRouteHandler = renderRequestMap => (request, reply) => {
 		.subscribe(({ redirect, result, statusCode }) => {
 			// response is sent when this function returns (`nextTick`)
 			if (redirect) {
-				return reply.redirect(redirect);
+				return reply.redirect(redirect.url).permanent(redirect.permanent);
 			}
 			const response = reply(result).code(statusCode);
 

--- a/tests/integration/render.int.js
+++ b/tests/integration/render.int.js
@@ -174,4 +174,46 @@ describe('Full dummy app render', () => {
 					throw err;
 				});
 		}));
+	it('redirects permanently (301) to internal route for <Redirect to={internalPath} permanent />', () =>
+		start(getMockRenderRequestMap(), {}).then(server => {
+			const request = {
+				method: 'get',
+				url: '/redirect/internal/permanent',
+				credentials: 'whatever',
+			};
+			return server
+				.inject(request)
+				.then(response => {
+					expect(response.statusCode).toBe(301);
+					expect(response.headers.location).toBe(
+						INTERNAL_REDIRECT_PATH
+					);
+				})
+				.then(() => server.stop())
+				.catch(err => {
+					server.stop();
+					throw err;
+				});
+		}));
+	it('redirects permanently (301) to external route for <Redirect to={URL object} permanent />', () =>
+		start(getMockRenderRequestMap(), {}).then(server => {
+			const request = {
+				method: 'get',
+				url: '/redirect/external/permanent',
+				credentials: 'whatever',
+			};
+			return server
+				.inject(request)
+				.then(response => {
+					expect(response.statusCode).toBe(301);
+					expect(response.headers.location).toBe(
+						EXTERNAL_REDIRECT_URL
+					);
+				})
+				.then(() => server.stop())
+				.catch(err => {
+					server.stop();
+					throw err;
+				});
+		}));
 });

--- a/tests/mockApp.jsx
+++ b/tests/mockApp.jsx
@@ -16,7 +16,8 @@ const MockRedirect = props => {
 	const to = props.match.params.redirectType === 'internal'
 		? INTERNAL_REDIRECT_PATH
 		: new URL(EXTERNAL_REDIRECT_URL);
-	return <div><Redirect to={to} /></div>;
+	const permanent = Boolean(props.match.params.isPermanent);
+	return <div><Redirect to={to} permanent={permanent} /></div>;
 };
 
 export const routes = [
@@ -52,7 +53,7 @@ export const routes = [
 					import('./mockAsyncRoute').then(r => r.default),
 			},
 			{
-				path: '/redirect/:redirectType',
+				path: '/redirect/:redirectType?/:isPermanent?',
 				component: MockRedirect,
 			},
 			{


### PR DESCRIPTION
Follow-on from #289, which provided basic HTTP 302 redirect support. This adds support for 301 (Permanent) redirects using a new `permanent` prop on the `<Redirect />` component