### PR TITLE
WP 344 render error

### DIFF
--- a/src/apiProxy/apiProxyHandler.js
+++ b/src/apiProxy/apiProxyHandler.js
@@ -1,5 +1,3 @@
-import Boom from 'boom';
-
 import 'rxjs/add/operator/catch';
 
 const handleQueryResponses = (request, reply) => queryResponses =>
@@ -12,8 +10,6 @@ const handleQueryResponses = (request, reply) => queryResponses =>
 export const getApiProxyRouteHandler = proxyApiRequest$ => (request, reply) => {
 	proxyApiRequest$(request).subscribe(
 		handleQueryResponses(request, reply),
-		err => {
-			reply(Boom.badImplementation(err.message));
-		}
+		err => reply(err) // 500 error - will only be thrown on bad implementation
 	);
 };

--- a/src/routes/appRouteHandler.js
+++ b/src/routes/appRouteHandler.js
@@ -18,13 +18,16 @@ export const getAppRouteHandler = renderRequestMap => (request, reply) => {
 
 	return renderRequest(request)
 		.do(() => request.server.app.logger.debug('HTML response ready'))
-		.subscribe(({ redirect, result, statusCode }) => {
-			// response is sent when this function returns (`nextTick`)
-			if (redirect) {
-				return reply.redirect(redirect.url).permanent(redirect.permanent);
-			}
-			const response = reply(result).code(statusCode);
+		.subscribe(
+			({ redirect, result, statusCode }) => {
+				// response is sent when this function returns (`nextTick`)
+				if (redirect) {
+					return reply.redirect(redirect.url).permanent(redirect.permanent);
+				}
+				const response = reply(result).code(statusCode);
 
-			request.trackSession(response);
-		});
+				request.trackSession(response);
+			},
+			err => reply(err) // 500 error - will only be thrown on bad implementation
+		);
 };

--- a/tests/integration/render.int.js
+++ b/tests/integration/render.int.js
@@ -143,9 +143,7 @@ describe('Full dummy app render', () => {
 				.inject(request)
 				.then(response => {
 					expect(response.statusCode).toBe(302);
-					expect(response.headers.location).toBe(
-						INTERNAL_REDIRECT_PATH
-					);
+					expect(response.headers.location).toBe(INTERNAL_REDIRECT_PATH);
 				})
 				.then(() => server.stop())
 				.catch(err => {
@@ -164,9 +162,7 @@ describe('Full dummy app render', () => {
 				.inject(request)
 				.then(response => {
 					expect(response.statusCode).toBe(302);
-					expect(response.headers.location).toBe(
-						EXTERNAL_REDIRECT_URL
-					);
+					expect(response.headers.location).toBe(EXTERNAL_REDIRECT_URL);
 				})
 				.then(() => server.stop())
 				.catch(err => {
@@ -185,9 +181,7 @@ describe('Full dummy app render', () => {
 				.inject(request)
 				.then(response => {
 					expect(response.statusCode).toBe(301);
-					expect(response.headers.location).toBe(
-						INTERNAL_REDIRECT_PATH
-					);
+					expect(response.headers.location).toBe(INTERNAL_REDIRECT_PATH);
 				})
 				.then(() => server.stop())
 				.catch(err => {
@@ -206,10 +200,24 @@ describe('Full dummy app render', () => {
 				.inject(request)
 				.then(response => {
 					expect(response.statusCode).toBe(301);
-					expect(response.headers.location).toBe(
-						EXTERNAL_REDIRECT_URL
-					);
+					expect(response.headers.location).toBe(EXTERNAL_REDIRECT_URL);
 				})
+				.then(() => server.stop())
+				.catch(err => {
+					server.stop();
+					throw err;
+				});
+		}));
+	it('returns 500 error for React rendering errors - developer error', () =>
+		start(getMockRenderRequestMap(), {}).then(server => {
+			const request = {
+				method: 'get',
+				url: '/badImplementation',
+				credentials: 'whatever',
+			};
+			return server
+				.inject(request)
+				.then(response => expect(response.statusCode).toBe(500))
 				.then(() => server.stop())
 				.catch(err => {
 					server.stop();

--- a/tests/mockApp.jsx
+++ b/tests/mockApp.jsx
@@ -39,13 +39,6 @@ export const routes = [
 		},
 		routes: [
 			{
-				path: '/badImplementation',
-				component: () => {
-					throw new Error('your implementation is bad and you should feel bad');
-					return <div />; // eslint-disable-line no-unreachable
-				},
-			},
-			{
 				path: '/foo',
 				component: 'div',
 				indexRoute: {
@@ -57,6 +50,13 @@ export const routes = [
 					}),
 				},
 				getNestedRoutes: () => import('./mockAsyncRoute').then(r => r.default),
+			},
+			{
+				path: '/badImplementation',
+				component: () => {
+					throw new Error('your implementation is bad and you should feel bad');
+					return <div />; // eslint-disable-line no-unreachable
+				},
 			},
 			{
 				path: '/redirect/:redirectType?/:isPermanent?',

--- a/tests/mockApp.jsx
+++ b/tests/mockApp.jsx
@@ -39,6 +39,13 @@ export const routes = [
 		},
 		routes: [
 			{
+				path: '/badImplementation',
+				component: () => {
+					throw new Error('your implementation is bad and you should feel bad');
+					return <div />; // eslint-disable-line no-unreachable
+				},
+			},
+			{
 				path: '/foo',
 				component: 'div',
 				indexRoute: {
@@ -49,8 +56,7 @@ export const routes = [
 						params: {},
 					}),
 				},
-				getNestedRoutes: () =>
-					import('./mockAsyncRoute').then(r => r.default),
+				getNestedRoutes: () => import('./mockAsyncRoute').then(r => r.default),
 			},
 			{
 				path: '/redirect/:redirectType?/:isPermanent?',


### PR DESCRIPTION
Errors during render were timing out in tests rather than returning a 500 error as expected. This should fix some dev annoyances. Integration test included