### PR TITLE
WP-352 supply match object to query functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [3.3]
+
+- **New feature** API request actions now contain a reference to a Promise that
+  will resolve when the API request returns. [WP-334](https://meetup.atlassian.net/browse/WP-334)
+- **New feature** Supply `initialNow` to `state.config` to sync server and
+  browser time reference.
+- **New feature** 301/302 Redirects now supported for internal and external
+  routes. [WP-331](https://meetup.atlassian.net/browse/WP-331)
+- **New feature** Query creator functions assigned to routes will now receive
+  all React Router `match` properties in their argument. [WP-352](https://meetup.atlassian.net/browse/WP-352)
+
 ## [3.2]
 
 - **Deprecated** `~/.mupweb.config` has been deprecated - node convict now
@@ -72,32 +83,32 @@
      `apiActionCreators.requestAll` (or the method-specific equivalents
      [described in the Queries
      docs](https://github.com/meetup/meetup-web-platform/blob/30a220c9a5cb3b9339c4fbccd6e9ff1efbf5a49a/docs/Queries.md#action-creation)).
-  
+
   2. All reads from `state.app` should be converted to `state.api` - the child
      properties will be the same `ref`s used in `state.app`, except for
      `state.app.error` which is now `state.api.fail`.
-  
+
   3. Any reducers listening for `API_SUCCESS` (which has a `payload` containing
      an object with a `queries` array and corresponding `responses` array) must
      be refactored to listen for `API_RESP_SUCCESS` and `API_RESP_ERROR`
      actions, which will each contain a `{ query, response }` object
      corresponding to a single query and its response.
-     
+
      The shape of each `response` object has also changed - instead of a single
      root-level key corresponding to the original query's `ref`, the response
      is now a flat object with a `ref` property.
-     
+
      Instead of parsing the `API_SUCCESS` payload for errors, reducers will now
      be able to specifically identify responses that correspond to
      failed/invalid responses from the REST API by listening for
      `API_RESP_ERROR` - `API_RESP_SUCCESS` will always correspond to a valid
      REST API response.
-     
+
   4. Any reducers listening for `API_ERROR` must be refactored to listen for
      `API_RESP_FAIL`. Both actions have the same `Error` object payload
      corresponding to a general API request failure, unrelated to a specific
      query.
-  
+
   These changes must by made simultaneously, and this list assumes that the
   refactor described in the `v2.1` changelog has been completed first.
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 CI_BUILD_NUMBER ?= $(USER)-snapshot
-VERSION ?= 3.2.$(CI_BUILD_NUMBER)
+VERSION ?= 3.3.$(CI_BUILD_NUMBER)
 
 version:
 	@echo $(VERSION)
-

--- a/docs/Queries.md
+++ b/docs/Queries.md
@@ -329,7 +329,7 @@ the corresponding `ref` from `state.api.inFlight`.
 {
   [ref]: {
     ref,
-    type,
+    type?,
     value: {},
     meta?: {}
   },
@@ -344,7 +344,7 @@ the corresponding `ref` from `state.api.inFlight`.
   [ref]: {
     ref,
     type?,
-    error?: [],
+    error: error,
     meta?: {}
   },
   // ...
@@ -366,6 +366,11 @@ the failed call.
 
 ### Route query functions
 
+```js
+// see description for docs about object argument
+({ params, isExact, url, path, location }) => Query
+```
+
 One of the primary uses for queries is to load route-specific data from the
 API. The application will automatically generate these queries by calling
 particular 'query creator' functions that are assigned to application routes,
@@ -375,14 +380,17 @@ Route query creator functions have two requirements:
 
 1. They are assigned as _props_ of React Router `route`s .The `query` prop can
 be either a single query creator function or an array of functions
-2. They are pure functions that take the Router's `location` and `params`
-extracted from the URL), and deliver a query object for the associated route.
+2. They are pure functions that take a single object argument constructed from the
+[`match` object from React Router](https://reacttraining.com/react-router/web/api/match),
+which includes `params` extracted from the URL) with an additional `location`
+property corresponding to the current
+[React Router `location`](https://reacttraining.com/react-router/web/api/location).
 
 #### Example query function
 
 ```js
 export const GROUP_REF = 'group';
-function groupQuery({ location, params }) {
+function groupQuery({ params, location }) {
 	const { urlname } = params;
 
 	return {

--- a/src/util/routeUtils.js
+++ b/src/util/routeUtils.js
@@ -106,7 +106,7 @@ const _matchedRouteQueriesReducer = (location: URL) => (
 	// call the query functions with non-url-encoded params
 	const params = decodeParams(match.params);
 	const routeQueries = routeQueryFns
-		.map(queryFn => queryFn({ location, params }))
+		.map(queryFn => queryFn({ ...match, location, params }))
 		.filter(query => query);
 
 	return [...queries, ...routeQueries];

--- a/src/util/routeUtils.test.js
+++ b/src/util/routeUtils.test.js
@@ -206,18 +206,24 @@ describe('getMatchedQueries', () => {
 	});
 	it('calls query functions with params + location object', () => {
 		const location = new URL('http://foo.com/bar/baz');
-		const params = { foo: 'bar' };
+		const path = '/';
+		const match = {
+			isExact: false,
+			params: { foo: 'bar' },
+			path,
+			url: '/',
+		};
 		const matchedRoute = {
 			route: {
-				path: '/',
-				query: jest.fn(() => 'bar'),
+				path,
+				query: jest.fn(),
 			},
-			match: { params },
+			match,
 		};
 		getMatchedQueries(location)([matchedRoute]);
 		expect(matchedRoute.route.query).toHaveBeenCalledWith({
+			...match,
 			location,
-			params,
 		});
 	});
 });


### PR DESCRIPTION
The `match` object from React Router contains some useful info beyond the `location` and `params` that we've been supplying until now - we already have it available in the router, so might as well pass it along to query functions.

@eilinora had simulated this behaviorin one of her mup-web PRs, which was the motivation for the update - we shouldn't need to re-calculate the `match` inside a query function any more.