### PR TITLE
Update docs and config management to default HTTPS

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -75,8 +75,9 @@ The secrets in this example are dummy values and won't work in an actual app.
 ### Running over HTTPS
 
 By default, the app server and asset server will run over HTTPS, but you must
-supply the cert files (`.key` and `.crt`). By default, the platform will look
-for these files in `~/.certs/` and warn you if they are not found.
+supply the cert files (`.key` and `.crt`). The platform will look for these
+files in `~/.certs/` and warn you if they are not found, although you can supply
+a custom file path if desired.
 
 To get the cert files, you can copy them from the chapstick repo at
 `/util/conf/localdev/ssl/`. You should copy the
@@ -87,6 +88,7 @@ your dev machine.
 checked into version control
 
 ```
+$ mkdir ~/.certs # if it doesn't exist
 $ scp www.dev.meetup.com:/usr/local/meetup/util/conf/localdev/ssl/star.dev.meetup.com.* ~/.certs/
 ```
 

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -51,16 +51,12 @@ The secrets in this example are dummy values and won't work in an actual app.
     "root_url": "https://www.api.dev.meetup.com"
   },
   "asset_server": {
-    "protocol": "http",
     "host": "beta2.dev.meetup.com",
-    "port": 0
   },
   "csrf_secret": "asdfasdfasdfasdfasdfasdfasdfasdf",
   "cookie_encrypt_secret": "asdfasdfasdfasdfasdfasdfasdfasdf",
   "app_server": {
-    "protocol": "http",
     "host": "beta2.dev.meetup.com",
-    "port": 0
   },
   "disable_hmr": false,
   "duotone_urls": [
@@ -78,42 +74,38 @@ The secrets in this example are dummy values and won't work in an actual app.
 
 ### Running over HTTPS
 
-You need to change change the `protocol` to `https`, and tell the server where
-to find the certificate and the private key (`crt_file` and `key_file`). You'll
-need to add these values to both the `asset_server` and the `app_server`.
+By default, the app server and asset server will run over HTTPS, but you must
+supply the cert files (`.key` and `.crt`). By default, the platform will look
+for these files in `~/.certs/` and warn you if they are not found.
+
+To get the cert files, you can copy them from the chapstick repo at
+`/util/conf/localdev/ssl/`. You should copy the
+`star.dev.meetup.com.crt` and `star.dev.meetup.com.key` files to `~/certs/` on
+your dev machine.
+
+**Important** DO NOT copy the files into the mup-web repo - they should not be
+checked into version control
+
+```
+$ scp www.dev.meetup.com:/usr/local/meetup/util/conf/localdev/ssl/star.dev.meetup.com.* ~/.certs/
+```
+
+If you want to keep the cert files elsewhere, you will need to create/update
+your `config.development.json` to tell the platform where to find them
 
 ```json
 {
-  "api": {
-    "protocol": "https",
-    "host": "www.api.dev.meetup.com",
-    "timeout": 10,
-    "root_url": "https://www.api.dev.meetup.com"
-  },
   "asset_server": {
-    "protocol": "https",
-    "host": "beta2.dev.meetup.com",
-    "port": 0,
     "crt_file":"/path/to/certificate.crt",
-    "key_file":"/path/to/certificate.key",
-
+    "key_file":"/path/to/certificate.key"
   },
-  "csrf_secret": "asdfasdfasdfasdfasdfasdfasdfasdf",
-  "cookie_encrypt_secret": "asdfasdfasdfasdfasdfasdfasdfasdf",
   "app_server": {
-    "protocol": "https",
-    "host": "beta2.dev.meetup.com",
-    "port": 0,
     "crt_file":"/path/to/certificate.crt",
-    "key_file":"/path/to/certificate.key",
-  },
-  "disable_hmr": false,
-  "photo_scaler_salt": "asdfasdfasdfasdfasdfasdfasdfasdf",
-  "oauth": {
-    "auth_url": "https://secure.dev.meetup.com/oauth2/authorize",
-    "access_url": "https://secure.dev.meetup.com/oauth2/access",
-    "key": "asdfasdfasdfasdfasdfasdfasdfasdf",
-    "secret": "asdfasdfasdfasdfasdfasdfasdfasdf"
+    "key_file":"/path/to/certificate.key"
   }
 }
 ```
+
+The current certs are valid until April 2019 and are issued by a Certificate
+Authority (GeoTrust), so you shouldn't have to ignore SSL warnings about self-
+signed certificates.

--- a/src/util/config/build.js
+++ b/src/util/config/build.js
@@ -30,7 +30,9 @@ export const schema = {
 		},
 		protocol: {
 			format: String,
-			default: 'https',
+			default: process.env.NODE_ENV === 'production'
+				? 'http' // SSL handled by load balancer
+				: 'https',
 			env: 'ASSET_SERVER_PROTOCOL',
 		},
 		key_file: {

--- a/src/util/config/index.js
+++ b/src/util/config/index.js
@@ -1,6 +1,9 @@
 import fs from 'fs';
-import convict from 'convict';
+import os from 'os';
 import path from 'path';
+
+import chalk from 'chalk';
+import convict from 'convict';
 
 import buildConfig, { schema as buildSchema } from './build';
 import { duotones, getDuotoneUrls } from '../duotone';
@@ -111,12 +114,12 @@ export const config = convict({
 		},
 		key_file: {
 			format: String,
-			default: '',
+			default: path.resolve(os.homedir(), '.certs', 'star.dev.meetup.com.key'),
 			env: 'APP_KEY_FILE',
 		},
 		crt_file: {
 			format: String,
-			default: '',
+			default: path.resolve(os.homedir(), '.certs', 'star.dev.meetup.com.crt'),
 			env: 'APP_CRT_FILE',
 		},
 	},
@@ -213,13 +216,24 @@ config.set(
 
 config.set('isProd', config.get('env') === 'production');
 config.set('isDev', config.get('env') === 'development');
-config.validate();
 const appConf = config.get('app_server');
 if (
 	appConf.protocol === 'https' &&
 	(!fs.existsSync(appConf.key_file) || !fs.existsSync(appConf.crt_file))
 ) {
-	throw new Error('Missing HTTPS cert or key!');
+	const message = 'Missing HTTPS cert or key for application server!';
+	if (config.isProd) {
+		throw new Error(message);
+	}
+	console.error(chalk.red(message));
+	console.warn(
+		chalk.yellow(
+			'Re-setting protocol to HTTP - some features may not work as expected'
+		)
+	);
+	console.warn(chalk.yellow('See MWP config docs to configure HTTPS'));
+	config.set('app_server.protocol', 'http');
 }
+config.validate();
 
 export default config.getProperties();

--- a/src/util/config/index.js
+++ b/src/util/config/index.js
@@ -102,7 +102,9 @@ export const config = convict({
 	app_server: {
 		protocol: {
 			format: validateProtocol,
-			default: 'http',
+			default: process.env.NODE_ENV === 'production'
+				? 'http' // SSL handled by load balancer
+				: 'https',
 			env: 'DEV_SERVER_PROTOCOL', // legacy naming
 		},
 		// host: '0.0.0.0', ALWAYS 0.0.0.0


### PR DESCRIPTION
A few updates, with docs.

I wanted to make it 'easy' to configure the platform to use the SSL certs, so I've updated the config files to

1. Default to HTTPS everywhere
2. assume that the cert files are located at `~/.certs/star.dev.meetup.com.{crt|key}`

The `scp` command for getting those files onto your dev machine is in the docs, so hopefully it's easy for people to do the Right Thing. It's also possible to put them somewhere custom and supply a path the certs in a config file, but hopefully most people won't need to do that.

In development, the config module will also automatically fall back to HTTP if things are not set up correctly, but it will print a warning. In prod, an invalid SSL config will throw an Error on startup.

I think this implementation will make it quick and easy for people to convert to SSL in dev.