### PR TITLE
add app-server host config

### DIFF
--- a/src/util/config/index.js
+++ b/src/util/config/index.js
@@ -107,7 +107,11 @@ export const config = convict({
 				: 'https',
 			env: 'DEV_SERVER_PROTOCOL', // legacy naming
 		},
-		// host: '0.0.0.0', ALWAYS 0.0.0.0
+		host: {
+			format: validateServerHost,
+			default: 'beta2.dev.meetup.com',
+			env: 'DEV_SERVER_HOST',
+		},
 		port: {
 			format: 'port',
 			default: 8000,

--- a/src/util/config/index.test.js
+++ b/src/util/config/index.test.js
@@ -70,6 +70,7 @@ describe('config', () => {
 		expect(config.cookie_encrypt_secret).toBeTruthy();
 		expect(config.csrf_secret).toBeTruthy();
 		expect(config.app_server).toBeTruthy();
+		expect(config.app_server.host).toBeTruthy();
 		expect(config.app_server.protocol).toBeTruthy();
 		expect(config.duotone_urls).toBeTruthy();
 		expect(config.isDev).toBeDefined();


### PR DESCRIPTION
Not exactly sure what the reasoning was with not having a `app_server.host` config, but this just adds it back in.

The start info script in `mup-web` expects a value. So we should either add is back in, or edit mup-web to remove or hardcode that line in the script.