### PR TITLE
call trackSession with request, not response

### DIFF
--- a/flow-typed/activityPlugin.js
+++ b/flow-typed/activityPlugin.js
@@ -1,9 +1,10 @@
 // @flow
 declare type Logger = (Object, Object) => mixed;
-declare type Tracker = (response: Object, ...args: Array<any>) => mixed;
+declare type Tracker = (...args: Array<any>) => mixed;
 declare type TrackOpts = {
 	log: Logger,
 	trackIdCookieName: string,
 	sessionIdCookieName: string,
 };
-declare type TrackGetter = TrackOpts => Tracker;
+type Request = Object;
+declare type TrackGetter = TrackOpts => Request => Tracker;

--- a/src/apiProxy/api-proxy.js
+++ b/src/apiProxy/api-proxy.js
@@ -57,7 +57,7 @@ const apiProxy$ = (request, queries) => {
 
 	// 4. zip them together to make requests in parallel and return responses in order
 	return Observable.zip(...apiRequests$).do(responses =>
-		request.trackApi(request, responses)
+		request.trackApi(responses)
 	);
 };
 

--- a/src/plugins/tracking/activity.js
+++ b/src/plugins/tracking/activity.js
@@ -1,6 +1,12 @@
 // @flow
 import avro from './util/avro';
-import { getTrackApi, getTrackSession } from './_activityTrackers';
+import {
+	getTrackApi,
+	getTrackSession,
+	getTrackLogin,
+	getTrackLogout,
+	getTrackApiResponses,
+} from './_activityTrackers';
 
 const YEAR_IN_MS: number = 1000 * 60 * 60 * 24 * 365;
 export const ACTIVITY_PLUGIN_NAME = 'tracking';
@@ -61,6 +67,9 @@ export function getTrackers(options: {
 	const trackers: { [string]: Tracker } = {
 		trackApi: getTrackApi(trackOpts),
 		trackSession: getTrackSession(trackOpts),
+		trackLogin: getTrackLogin(trackOpts),
+		trackLogout: getTrackLogout(trackOpts),
+		trackApiResponses: getTrackApiResponses(trackOpts),
 	};
 	return trackers;
 }
@@ -121,7 +130,9 @@ export default function register(
 	});
 
 	Object.keys(trackers).forEach((trackType: string) => {
-		server.decorate('request', trackType, trackers[trackType]);
+		server.decorate('request', trackType, trackers[trackType], {
+			apply: true, // make the `request` available to tracker
+		});
 	});
 
 	server.ext('onRequest', onRequest);

--- a/src/plugins/tracking/activity.test.js
+++ b/src/plugins/tracking/activity.test.js
@@ -88,7 +88,7 @@ describe('tracking loggers', () => {
 			trackIdCookieName,
 			sessionIdCookieName,
 			cookieOpts,
-		})(request);
+		})(request)();
 		expect(spyable.log).toHaveBeenCalled();
 		const trackInfo = spyable.log.calls.mostRecent().args[1];
 		expect(spyable.log).toHaveBeenCalled();
@@ -119,7 +119,7 @@ describe('tracking loggers', () => {
 			trackIdCookieName,
 			sessionIdCookieName,
 			cookieOpts,
-		})(request, memberId);
+		})(request)(memberId);
 		expect(spyable.log).toHaveBeenCalled();
 		const trackInfo = spyable.log.calls.mostRecent().args[1];
 		expect(spyable.log).toHaveBeenCalled();
@@ -144,7 +144,7 @@ describe('tracking loggers', () => {
 				trackIdCookieName,
 				sessionIdCookieName,
 				cookieOpts,
-			})(getMockRequest(), [
+			})(getMockRequest())([
 				{ login: { type: 'login', value: { member: { id: 1234 } } } },
 			]);
 			expect(spyable.log).toHaveBeenCalled();
@@ -167,7 +167,7 @@ describe('tracking loggers', () => {
 				trackIdCookieName,
 				sessionIdCookieName,
 				cookieOpts,
-			})(request, [{}]);
+			})(request)([{}]);
 			expect(spyable.log).toHaveBeenCalled();
 			const trackInfo = spyable.log.calls.mostRecent().args[1];
 			expect(trackInfo.description).toEqual('logout');
@@ -187,7 +187,7 @@ describe('tracking loggers', () => {
 			trackIdCookieName,
 			sessionIdCookieName,
 			cookieOpts,
-		})(request);
+		})(request)();
 		expect(spyable.log).toHaveBeenCalled();
 		const trackInfo = spyable.log.calls.mostRecent().args[1];
 		expect(trackInfo.description).toEqual('session'); // this may change, but need to ensure tag is always correct
@@ -214,7 +214,7 @@ describe('tracking loggers', () => {
 			trackIdCookieName,
 			sessionIdCookieName,
 			cookieOpts,
-		})(request);
+		})(request)();
 		expect(spyable.log).not.toHaveBeenCalled();
 	});
 });

--- a/src/routes/appRouteHandler.js
+++ b/src/routes/appRouteHandler.js
@@ -24,9 +24,8 @@ export const getAppRouteHandler = renderRequestMap => (request, reply) => {
 				if (redirect) {
 					return reply.redirect(redirect.url).permanent(redirect.permanent);
 				}
-				const response = reply(result).code(statusCode);
-
-				request.trackSession(response.request);
+				request.trackSession();
+				return reply(result).code(statusCode);
 			},
 			err => reply(err) // 500 error - will only be thrown on bad implementation
 		);

--- a/src/routes/appRouteHandler.js
+++ b/src/routes/appRouteHandler.js
@@ -26,7 +26,7 @@ export const getAppRouteHandler = renderRequestMap => (request, reply) => {
 				}
 				const response = reply(result).code(statusCode);
 
-				request.trackSession(response);
+				request.trackSession(response.request);
 			},
 			err => reply(err) // 500 error - will only be thrown on bad implementation
 		);


### PR DESCRIPTION
`request.trackSession` was being called with the wrong argument. The simple fix would be to just change the argument, but Hapi has a better option for injecting the `request` object into methods that have been 'decorated' on the request, so this PR is a light refactor to change the function signature of the request `track___` methods - the `request` object is now injected as a curried argument. The overall structure change makes it easier to work with 'child tracking' methods like `trackLogin` and `trackApi` that are delegated to by `trackApi`, as well as making it much more difficult to accidentally refactor the trackers in such a way that the `request` object becomes inaccessible, which was the problem in the first place.