### PR TITLE
use correct state change arg type

### DIFF
--- a/src/components/Redirect.jsx
+++ b/src/components/Redirect.jsx
@@ -98,12 +98,12 @@ const reducePropsToState = (
 	return { url: to, permanent };
 };
 
-const handleStateChangeOnClient = (to: RouterTo) => {
-	if (!testForExternal(to)) {
+export const handleStateChangeOnClient = (redirect: RedirectState) => {
+	if (!testForExternal(redirect.url)) {
 		// 'internal' links will be handled by React Router
 		return;
 	}
-	window.location.replace(to);
+	window.location.replace(redirect.url);
 };
 
 export default withSideEffect(reducePropsToState, handleStateChangeOnClient)(

--- a/src/components/redirect.test.jsx
+++ b/src/components/redirect.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 import StaticRouter from 'react-router-dom/StaticRouter';
-import Redirect from './Redirect';
+import Redirect, { handleStateChangeOnClient } from './Redirect';
 
 const renderToContext = (to, permanent) => {
 	const context = {};
@@ -67,5 +67,20 @@ describe('Server rendering', () => {
 	it('returns undefined when no Redirect', () => {
 		ReactDOMServer.renderToString(<div />);
 		expect(Redirect.rewind()).toBeUndefined();
+	});
+});
+describe('Client behavior', () => {
+	global.window = { location: { replace: jest.fn() } };
+	it('calls window.location.replace for external URLs', () => {
+		window.location.replace.mockClear();
+		const url = 'https://google.com';
+		handleStateChangeOnClient({ url });
+		expect(window.location.replace).toHaveBeenCalledWith(url);
+	});
+	it('does not call window.location.replace for internal URLs', () => {
+		window.location.replace.mockClear();
+		const url = '/foo/bar';
+		handleStateChangeOnClient({ url });
+		expect(window.location.replace).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
Client-side redirects weren't working with the platform `<Redirect />` component - wasn't actually a problem because it wasn't being used anywhere, but I'm using it for Login/Logout redirect tickets