### PR TITLE
Dedicated caching docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ In general, application-specific code will live outside of this package.
 - ['Query': structuring data dependencies](docs/Queries.md)
 - [Rendering in consumer applications](docs/Rendering.md)
 - [Routing configuration](docs/Routing.md)
+- [Caching - API and static assets](docs/Caching.md)
 
 # Releases
 
@@ -156,30 +157,7 @@ to log in repeatedly without waiting for previous login requests to be processed
 
 #### Cache `epics/cache.js`
 
-The cache epic provides optimistic `state` updates for any data specified
-by active route queries, similar to the SyncEpic, but using locally
-cached data rather than an API. It is client-side only, and it *does not suppress*
-data fetched from the server - it simply pre-empts it before the API response
-returns and overwrites everything with the latest server data.
-
-**on `API_REQUEST`**, which provides `queries` for the requested route
-
-1. For each query, use the JSON-encoded query as a key into the cache
-2. Format responses from the cache to look like API responses
-3. Trigger `CACHE_SUCCESS` containing the cache hits
-
-**on `API_SUCCESS`**,  which provides fresh info from the server
-
-- make an entry in the cache with `key` as the JSON-encoded `query` and
-	the `value` as the corresponding `response`
-
-The cache is stored locally in the user's browser using IndexedDB so that it
-will survive multiple sessions. All API queries are stored, and the data is
-refreshed each time the query is re-requested.
-
-In dev, be aware that the cache may be masking failed API requests - keep your
-network dev tools open and watch the server logs to make sure you haven't broken
-anything. We will add tooling to make such cases more obvious in the future.
+See [the Caching docs](./docs/Caching.md#cache-middleware)
 
 ##### Disable cache
 

--- a/docs/Caching.md
+++ b/docs/Caching.md
@@ -8,7 +8,7 @@ responsiveness. There are two primary types of content that are cached:
 
 ## Overview
 
-![Cache diagram](https://user-images.githubusercontent.com/1885153/27892985-d75546fe-6256-11e7-8272-66252caa5c85.png)
+![Cache diagram](https://user-images.githubusercontent.com/1885153/28044152-c9f076ce-6629-11e7-9c6b-1bdf31fb6b50.png)
 
 ([from web platform diagrams](https://docs.google.com/presentation/d/1c8jf8UtGa81Ay4oqlbHfoP4Ile2VkiRVrCMVag6cRBQ/#slide=id.g1f921bb8da_0_0))
 

--- a/docs/Caching.md
+++ b/docs/Caching.md
@@ -1,6 +1,6 @@
 # Caching
 
-Web platform apps cache data at a few different levels in order to improve UI
+Network data is cached at a few different levels in order to improve UI
 responsiveness. There are two primary types of content that are cached:
 
 1. REST API responses
@@ -32,12 +32,6 @@ discussion](#future) for potential changes to the behavior.
 
 ### Browser
 
-The browser uses
-[IndexedDB](https://developer.mozilla.org/en/docs/Web/API/IndexedDB_API) for
-local storage of API response data - it caches the JSON response rather than the
-full HTTP response in order to avoid complexity arising from the batched API
-request/response routine.
-
 #### Service Worker
 
 The service worker does not cache API requests/responses (and probably
@@ -52,84 +46,44 @@ locally cached data rather than an HTTP response. It is client-side only, and it
 the API response returns and overwrites everything with the latest server data.
 [See the 'Future' discussion](#future) for potential changes to this behavior.
 
+The cache middleware implementation uses
+[IndexedDB](https://developer.mozilla.org/en/docs/Web/API/IndexedDB_API) for
+local storage of API response data - it caches the JSON response rather than the
+full HTTP response in order to avoid complexity arising from the batched API
+request/response routine.
+
 ##### Cache lifecycle
-
-**on `API_REQ`**, which provides `queries` to be sent to the API:
-
-1. For each query, use the JSON-encoded query as a key into the cache
-2. Format responses from the cache to look like API responses
-3. Trigger `CACHE_SUCCESS` containing the cache hits
-
-**on `API_SUCCESS`**,  which provides fresh info from the server
-
-- make an entry in the cache with `key` as the JSON-encoded `query` and
-	the `value` as the corresponding `response`
 
 The cache is stored locally in the user's browser using IndexedDB so that it
 will survive multiple sessions. All API queries are stored, and the data is
-refreshed each time the query is re-requested.
+refreshed each time the query is re-requested. Cached data survives as long as
+the browser allows the `IndexedDB` table to grow - it is theoretically
+unbounded.
+
+- **on `API_REQ`**, which provides `queries` to be sent to the API:
+
+    1. For each query, use the JSON-encoded query as a key into the cache
+    2. Format responses from the cache to look like API responses
+    3. Trigger `CACHE_SUCCESS` containing the cache hits
+
+- **on `API_SUCCESS`**,  which provides fresh info from the server
+
+    - make an entry in the cache with `key` as the JSON-encoded `query` and
+      the `value` as the corresponding `response`
+
+- **on `CACHE_CLEAR`** (e.g. when navigating to /logout)
+    
+    - clear all data from cache
+
+To manually clear the cache, go to the 'Application' tab in Chrome Dev Tools
+while viewing meetup.com. 'IndexedDB' will appear in the left sidebar containing
+a 'keyval-store' table - click on that and then click on 'Delete database' in
+order to clear the cache. The database will be re-created next time you open a
+web platform-based page.
 
 In dev, be aware that the cache may be masking failed API requests - keep your
 network dev tools open and watch the server logs to make sure you haven't broken
 anything.
-
-### Future
-
-The core engineering team is working on improving cache handling at the REST API
-layer, which should eventually include `Cache-Control` headers in API responses.
-For real-time data, this cache would be short-lived, but for something like a
-past event, the cache time could be very long.
-
-Because the web platform batches API requests and responses, it will have to
-carefully handle these cache rules at both the app server and browser app
-levels.
-
-1. **App server** - cache REST API responses
-
-    At a minimum, the Node app server could maintain a lightweight (Redis?) local
-cache of API responses with the correct cache control rules applied. This would
-still require the browser application to make an HTTP API request for each
-active query, but the response would be delivered faster in some cases because
-the app server would not have to generate a corresponding HTTP request to the
-REST API server.
-
-2. **CDN** - cache batched API responses from app server
-
-    The next level of caching could appear between the CDN and the browser
-application. If the app server sent batched responses with a `Cache-Control`
-header that matched the _minimum cache time_ of the individual API responses,
-the CDN could be configured to cache those batched responses. For example, if
-a request was made for a group event, the batched response would contain
-responses from the _group endpoint_ and the _event endpoint_. The app server
-could apply a `Cache-Control` header that matched the shortest cache
-time-to-live of those two responses, and the CDN could cache that combined
-response and deliver it to _every user who subsequently made the same batched
-request_. This cache behavior would not be useful if every batched request
-included an un-cacheable response (e.g. a private/logged-in response, like 
-`/members/self`), so it would have to be developed after the app was updated to
-cache individual API responses and only request stale data, as described below.
-
-3. **Redux middleware** - cache parsed API responses and filter `fetch`
-
-    The next level of caching would require changes to the query-based API proxy
-routine. Each individual query response would need to contain the cache control
-rules of the corresponding REST API response so that the browser could
-appropriately cache the responses _and avoid making the same query request_
-while the browser-cached response was available. A complintary caching stategy
-could be applied at the CDN layer - if the CDN was configured to cache responses
-from the `/mu_api` endpoint based on
-
-    Although a service worker might be able to provide a 'transparent' caching
-solution, the batched requests and responses would be awkward to parse in order
-to correctly refine them to include only stale data.
-
-    Instead, cache control rules should probably be handled by a more sophisticated 
-interaction between the Sync epic (middleware) and the Cache epic
-to allow `fetch` requests to be modified (or cancelled) when cached data was
-available for the requested queries. We would probably still want to use the
-Cache epic to cache everything so that the UI was responsive even when 'fresh'
-data was being fetched, but the cache control rules would allow the `fetch` to
-be fine-tuned to include only the data that was known to _require_ an update.
 
 ## 2. Static assets
 
@@ -139,20 +93,34 @@ infinite cache lifetime.
 
 ### CDN
 
-(CDN cache invalidation policy?)
+All static assets are delivered to the browser with a `Cache-Control` header
+with a a 10 year expiration.
 
 ### Browser
 
-All static assets are delivered to the browser with a `Cache-Control` header
-with a a 10 year expiration. For
-[browsers that do not support Service Workers](https://jakearchibald.github.io/isserviceworkerready/),
-normal browser cache rules apply - static assets will be cached as they are
-requested by the app, but not before. For browsers that _do_ support service
-workers, the platform service worker will 'pre-cache' all bundled assets
-asynchronously after the in-page assets load, and serve those assets from the
-browser cache for all future requests.
+#### Service Worker pre-cache
+
+For browsers that support service workers, the platform service worker will 
+'pre-cache' all bundled assets asynchronously after the in-page assets load, and
+serve those assets from the browser cache for all future requests.
+
+**Timeline**
+
+1. First webpage request
+2. rendered page HTML downloads
+3. current static assets download (CSS, JS)
+4. JS executes, registers service worker
+5. Service worker immediately fetches other static assets that are used
+   elsewhere on the site, e.g. async routes and static images/icons.
 
 When new assets are generated, a new service worker is generated. When a client
 loads the site, the new service worker will replace any existing service workers
 and immediately start downloading new static assets. Any un-changed static
 assets (hashed filename unchanged) will not be re-downloaded.
+
+#### No Service Worker support
+
+For
+[browsers that do not support Service Workers](https://jakearchibald.github.io/isserviceworkerready/),
+normal browser cache rules apply - static assets will be cached as they are
+requested by the app, but not before. 

--- a/docs/Caching.md
+++ b/docs/Caching.md
@@ -24,20 +24,20 @@ data.
 
 ### CDN
 
-The CDN does not currently cache any API responses. [See the 'Future'
-discussion](#future) for potential changes to the behavior.
+The CDN does not currently cache any API responses. See the 'Future'
+discussion #322 for potential changes to the behavior.
 
 ### App server
 
-The app server does not currently cache any API responses. [See the 'Future' 
-discussion](#future) for potential changes to the behavior.
+The app server does not currently cache any API responses. See the 'Future' 
+discussion #322 for potential changes to the behavior.
 
 ### Browser
 
 #### Service Worker
 
 The service worker does not cache API requests/responses (and probably
-shouldn't - [see the 'Future' discussion](#future)).
+shouldn't - see the 'Future' discussion #322).
 
 #### Cache middleware
 
@@ -46,7 +46,7 @@ specified by dispatched `GET` queries, similar to the Sync epic, but uses
 locally cached data rather than an HTTP response. It is client-side only, and it
 *does not suppress* data fetched from the server - it simply pre-empts it before
 the API response returns and overwrites everything with the latest server data.
-[See the 'Future' discussion](#future) for potential changes to this behavior.
+See the 'Future' discussion #322 for potential changes to this behavior.
 
 The cache middleware implementation uses
 [IndexedDB](https://developer.mozilla.org/en/docs/Web/API/IndexedDB_API) for

--- a/docs/Caching.md
+++ b/docs/Caching.md
@@ -1,0 +1,158 @@
+# Caching
+
+Web platform apps cache data at a few different levels in order to improve UI
+responsiveness. There are two primary types of content that are cached:
+
+1. REST API responses
+2. Static assets (files)
+
+## Overview
+
+![Cache diagram](https://user-images.githubusercontent.com/1885153/27892985-d75546fe-6256-11e7-8272-66252caa5c85.png)
+
+([from web platform diagrams](https://docs.google.com/presentation/d/1c8jf8UtGa81Ay4oqlbHfoP4Ile2VkiRVrCMVag6cRBQ/#slide=id.g1f921bb8da_0_0))
+
+## 1. API responses
+
+Currently the Meetup REST API does not provide a
+[`Cache-Control` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control)
+(e.g. `max-age`), so the 'raw' API responses cannot be directly cached at the
+app server or browser level - the app must re-fetch every API request from the 
+browser to ensure that it delivers the requested data.
+
+### CDN
+
+The CDN does not currently cache any API responses. [See the 'Future'
+discussion](#future) for potential changes to the behavior.
+
+### App server
+
+The app server does not currently cache any API responses. [See the 'Future' 
+discussion](#future) for potential changes to the behavior.
+
+### Browser
+
+The browser uses
+[IndexedDB](https://developer.mozilla.org/en/docs/Web/API/IndexedDB_API) for
+local storage of API response data - it caches the JSON response rather than the
+full HTTP response in order to avoid complexity arising from the batched API
+request/response routine.
+
+#### Service Worker
+
+The service worker does not cache API requests/responses (and probably
+shouldn't - [see the 'Future' discussion](#future)).
+
+#### Cache middleware
+
+The cache epic (middleware) provides optimistic `state` updates for any data
+specified by dispatched `GET` queries, similar to the Sync epic, but uses
+locally cached data rather than an HTTP response. It is client-side only, and it
+*does not suppress* data fetched from the server - it simply pre-empts it before
+the API response returns and overwrites everything with the latest server data.
+[See the 'Future' discussion](#future) for potential changes to this behavior.
+
+##### Cache lifecycle
+
+**on `API_REQ`**, which provides `queries` to be sent to the API:
+
+1. For each query, use the JSON-encoded query as a key into the cache
+2. Format responses from the cache to look like API responses
+3. Trigger `CACHE_SUCCESS` containing the cache hits
+
+**on `API_SUCCESS`**,  which provides fresh info from the server
+
+- make an entry in the cache with `key` as the JSON-encoded `query` and
+	the `value` as the corresponding `response`
+
+The cache is stored locally in the user's browser using IndexedDB so that it
+will survive multiple sessions. All API queries are stored, and the data is
+refreshed each time the query is re-requested.
+
+In dev, be aware that the cache may be masking failed API requests - keep your
+network dev tools open and watch the server logs to make sure you haven't broken
+anything.
+
+### Future
+
+The core engineering team is working on improving cache handling at the REST API
+layer, which should eventually include `Cache-Control` headers in API responses.
+For real-time data, this cache would be short-lived, but for something like a
+past event, the cache time could be very long.
+
+Because the web platform batches API requests and responses, it will have to
+carefully handle these cache rules at both the app server and browser app
+levels.
+
+1. **App server** - cache REST API responses
+
+    At a minimum, the Node app server could maintain a lightweight (Redis?) local
+cache of API responses with the correct cache control rules applied. This would
+still require the browser application to make an HTTP API request for each
+active query, but the response would be delivered faster in some cases because
+the app server would not have to generate a corresponding HTTP request to the
+REST API server.
+
+2. **CDN** - cache batched API responses from app server
+
+    The next level of caching could appear between the CDN and the browser
+application. If the app server sent batched responses with a `Cache-Control`
+header that matched the _minimum cache time_ of the individual API responses,
+the CDN could be configured to cache those batched responses. For example, if
+a request was made for a group event, the batched response would contain
+responses from the _group endpoint_ and the _event endpoint_. The app server
+could apply a `Cache-Control` header that matched the shortest cache
+time-to-live of those two responses, and the CDN could cache that combined
+response and deliver it to _every user who subsequently made the same batched
+request_. This cache behavior would not be useful if every batched request
+included an un-cacheable response (e.g. a private/logged-in response, like 
+`/members/self`), so it would have to be developed after the app was updated to
+cache individual API responses and only request stale data, as described below.
+
+3. **Redux middleware** - cache parsed API responses and filter `fetch`
+
+    The next level of caching would require changes to the query-based API proxy
+routine. Each individual query response would need to contain the cache control
+rules of the corresponding REST API response so that the browser could
+appropriately cache the responses _and avoid making the same query request_
+while the browser-cached response was available. A complintary caching stategy
+could be applied at the CDN layer - if the CDN was configured to cache responses
+from the `/mu_api` endpoint based on
+
+    Although a service worker might be able to provide a 'transparent' caching
+solution, the batched requests and responses would be awkward to parse in order
+to correctly refine them to include only stale data.
+
+    Instead, cache control rules should probably be handled by a more sophisticated 
+interaction between the Sync epic (middleware) and the Cache epic
+to allow `fetch` requests to be modified (or cancelled) when cached data was
+available for the requested queries. We would probably still want to use the
+Cache epic to cache everything so that the UI was responsive even when 'fresh'
+data was being fetched, but the cache control rules would allow the `fetch` to
+be fine-tuned to include only the data that was known to _require_ an update.
+
+## 2. Static assets
+
+Static assets generated by the build are cached in our CDN and in the browser.
+Because each filename includes a hash of the file contents, the file can have an
+infinite cache lifetime.
+
+### CDN
+
+(CDN cache invalidation policy?)
+
+### Browser
+
+All static assets are delivered to the browser with a `Cache-Control` header
+with a a 10 year expiration. For
+[browsers that do not support Service Workers](https://jakearchibald.github.io/isserviceworkerready/),
+normal browser cache rules apply - static assets will be cached as they are
+requested by the app, but not before. For browsers that _do_ support service
+workers, the platform service worker will 'pre-cache' all bundled assets
+asynchronously after the in-page assets load, and serve those assets from the
+browser cache for all future requests.
+
+When new assets are generated, a new service worker is generated. When a client
+loads the site, the new service worker will replace any existing service workers
+and immediately start downloading new static assets. Any un-changed static
+assets (hashed filename unchanged) will not be re-downloaded.

--- a/docs/Caching.md
+++ b/docs/Caching.md
@@ -16,9 +16,11 @@ responsiveness. There are two primary types of content that are cached:
 
 Currently the Meetup REST API does not provide a
 [`Cache-Control` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control)
-(e.g. `max-age`), so the 'raw' API responses cannot be directly cached at the
-app server or browser level - the app must re-fetch every API request from the 
-browser to ensure that it delivers the requested data.
+(e.g. `max-age`), so the web application doesn't have any upstream indication of
+how long the data should be considered valid for. The platform therefore does
+not cache 'raw' API responses at the app server or browser level - the app
+re-fetches every API request from the  browser to ensure that it delivers valid
+data.
 
 ### CDN
 


### PR DESCRIPTION
Probably best to view [the formatted doc](https://github.com/meetup/meetup-web-platform/blob/4765e4c9a60b5705f698151f9c64c7e5b28a135f/docs/Caching.md) rather than the raw markup. This document provides an overview of current platform caching tools and discusses future possibilities once we have `Cache-Control` headers available from REST API responses. We can start to get very sophisticated with our caching once that happens, but for now we're in a world full of HTTP requests.