### PR TITLE
WP 379 default SSL port 443 in dev

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -41,7 +41,7 @@ export default function start(
 
 	const connection = {
 		host: '0.0.0.0',
-		port: appConfig.app_server.port, // needed for custom port behind SSL proxy in prod
+		port: appConfig.app_server.port, // needed for custom port in prod
 		routes: {
 			plugins: {
 				'electrode-csrf-jwt': {

--- a/src/server.js
+++ b/src/server.js
@@ -41,7 +41,7 @@ export default function start(
 
 	const connection = {
 		host: '0.0.0.0',
-		port: appConfig.app_server.port,
+		port: appConfig.app_server.port, // needed for custom port behind SSL proxy in prod
 		routes: {
 			plugins: {
 				'electrode-csrf-jwt': {

--- a/src/util/config/index.js
+++ b/src/util/config/index.js
@@ -110,7 +110,7 @@ export const config = convict({
 		// host: '0.0.0.0', ALWAYS 0.0.0.0
 		port: {
 			format: 'port',
-			default: 443,
+			default: process.getuid() === 0 ? 443 : 8000, // default to standard SSL port when running with sudo
 			arg: 'app-port',
 			env: process.env.NODE_ENV !== 'test' && 'DEV_SERVER_PORT', // don't read env in tests
 		},

--- a/src/util/config/index.js
+++ b/src/util/config/index.js
@@ -110,7 +110,7 @@ export const config = convict({
 		// host: '0.0.0.0', ALWAYS 0.0.0.0
 		port: {
 			format: 'port',
-			default: 8000,
+			default: 443,
 			arg: 'app-port',
 			env: process.env.NODE_ENV !== 'test' && 'DEV_SERVER_PORT', // don't read env in tests
 		},


### PR DESCRIPTION
This is sort of a weird solution because of some OS-level limits on binding to ports < 1024.

In order to use port 443 and thereby be able to run the dev server at https://beta2.dev.meetup.com rather than https://beta2.dev.meetup.com:8000, the `node` command needs to be run with `sudo`, so I've made it an opt-in port assignment that will only be applied when the server is run with `sudo` - in consumer apps, you'll have to run something like

```sh
$ sudo yarn start
# or assign the current env vars to the `sudo` context with `-E`
$ sudo -E yarn start
```