### PR TITLE
`large` and `small` duotoned image urls for group object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [5.1]
+
+- **Change** (could be considered breaking, but it's specifically for a
+  requested update to GroupCard in mup-web): `group.duotoneUrl` is now an object
+  with `small` and `large` properties - `small` has a resolution of 300x400, and
+  `large` has a resolution of 1100x800.
+
 ## [5.0]
 
 ### BREAKING CHANGE

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CI_BUILD_NUMBER ?= $(USER)-snapshot
-VERSION ?= 5.0.$(CI_BUILD_NUMBER)
+VERSION ?= 5.1.$(CI_BUILD_NUMBER)
 
 version:
 	@echo $(VERSION)

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "iron": "4.0.5",
     "jest": "20.0.4",
     "lint-staged": "4.0.1",
-    "meetup-web-mocks": "1.0.194",
+    "meetup-web-mocks": "1.0.203",
     "mwp-cli": "1.0.101",
     "prettier": "1.5.2",
     "react": "15.6.1",

--- a/src/util/apiUtils.js
+++ b/src/util/apiUtils.js
@@ -451,7 +451,10 @@ export const groupDuotoneSetter = duotoneUrls => group => {
 		);
 	const duotoneUrlRoot = duotoneKey && duotoneUrls[duotoneKey];
 	if (duotoneUrlRoot && photo.id) {
-		group.duotoneUrl = `${duotoneUrlRoot}/${photo.id}.jpeg`;
+		group.duotoneUrl = {
+			small: `${duotoneUrlRoot.small}/${photo.id}.jpeg`,
+			large: `${duotoneUrlRoot.large}/${photo.id}.jpeg`,
+		};
 	}
 	return group;
 };

--- a/src/util/apiUtils.test.js
+++ b/src/util/apiUtils.test.js
@@ -412,7 +412,8 @@ describe('groupDuotoneSetter', () => {
 		const modifiedGroup = groupDuotoneSetter(MOCK_DUOTONE_URLS)(group);
 		const { duotoneUrl } = modifiedGroup;
 		const expectedUrl = MOCK_DUOTONE_URLS.dtaxb;
-		expect(duotoneUrl.startsWith(expectedUrl)).toBe(true);
+		expect(duotoneUrl.small.startsWith(expectedUrl.small)).toBe(true);
+		expect(duotoneUrl.large.startsWith(expectedUrl.large)).toBe(true);
 	});
 });
 
@@ -431,7 +432,8 @@ describe('apiResponseDuotoneSetter', () => {
 		);
 		const { duotoneUrl } = modifiedResponse.value;
 		const expectedUrl = MOCK_DUOTONE_URLS.dtaxb;
-		expect(duotoneUrl.startsWith(expectedUrl)).toBe(true);
+		expect(duotoneUrl.small.startsWith(expectedUrl.small)).toBe(true);
+		expect(duotoneUrl.large.startsWith(expectedUrl.large)).toBe(true);
 	});
 	it('adds duotone url to type: "home" api response', () => {
 		// this is an awkward test because we have to mock the deeply-nested
@@ -456,8 +458,8 @@ describe('apiResponseDuotoneSetter', () => {
 		};
 		// run the function - rely on side effect in group
 		apiResponseDuotoneSetter(MOCK_DUOTONE_URLS)(homeApiResponse);
-		const expectedUrl = MOCK_DUOTONE_URLS.dtaxb;
-		expect(group.duotoneUrl.startsWith(expectedUrl)).toBe(true);
+		const expectedUrl = MOCK_DUOTONE_URLS.dtaxb.small;
+		expect(group.duotoneUrl.small.startsWith(expectedUrl)).toBe(true);
 	});
 	it("returns object unmodified when it doesn't need duotones", () => {
 		const member = { ...MOCK_MEMBER };

--- a/src/util/duotone.js
+++ b/src/util/duotone.js
@@ -70,6 +70,16 @@ export const duotones = [
  * @module duotoneServer
  */
 
+export const makeSign = (salt, ref) => rx => {
+	const spec = `event/${rx}/${ref}`;
+	const signature = crypto
+		.createHash('sha1')
+		.update(`${spec}${salt}`)
+		.digest('hex')
+		.substring(0, 10);
+	return `https://a248.e.akamai.net/secure.meetupstatic.com/photo_api/${spec}/sg${signature}`;
+};
+
 /**
  * Using a passed in *SECRET* salt, generate the photo scaler URL templates
  * in the format described by the sign/photo_transform API. Return the values
@@ -84,14 +94,12 @@ export const duotones = [
  */
 export function generateSignedDuotoneUrl(salt, [light, dark]) {
 	const ref = duotoneRef(light, dark);
-	const spec = `event/rx300x400/${ref}`;
-	const signature = crypto
-		.createHash('sha1')
-		.update(`${spec}${salt}`)
-		.digest('hex')
-		.substring(0, 10);
+	const sign = makeSign(salt, ref);
 	return {
-		[ref]: `https://a248.e.akamai.net/secure.meetupstatic.com/photo_api/${spec}/sg${signature}`,
+		[ref]: {
+			small: sign('rx300x400'),
+			large: sign('rx1100x800'),
+		},
 	};
 }
 

--- a/src/util/duotone.test.js
+++ b/src/util/duotone.test.js
@@ -1,5 +1,6 @@
 import {
 	duotoneRef,
+	makeSign,
 	getDuotoneUrls,
 	generateSignedDuotoneUrl,
 } from './duotone';
@@ -7,17 +8,26 @@ import {
 const MOCK_SALT = 'abcd';
 const MOCK_DUOTONE = ['123456', '234567'];
 const MOCK_DUOTONE_2 = ['345678', '456789'];
+describe('makeSign', () => {
+	it('creates a function that returns a URL with the ref', () => {
+		const ref = duotoneRef(...MOCK_DUOTONE);
+		const sign = makeSign(MOCK_SALT, ref);
+		expect(sign).toEqual(expect.any(Function));
+		const signed = sign('rx100x100');
+		expect(signed.startsWith('http')).toBe(true);
+		expect(signed.indexOf(ref)).toBeGreaterThan(-1);
+	});
+});
 describe('generateSignedDuotoneUrl', () => {
 	const signedUrlMap = generateSignedDuotoneUrl(MOCK_SALT, MOCK_DUOTONE);
 	const ref = duotoneRef(...MOCK_DUOTONE);
 	it('maps a duotone ref to a string', () => {
 		expect(signedUrlMap).toEqual({
-			[ref]: jasmine.any(String),
+			[ref]: {
+				small: expect.any(String),
+				large: expect.any(String),
+			},
 		});
-	});
-	it('writes a url containing the ref', () => {
-		expect(signedUrlMap[ref].startsWith('http')).toBe(true);
-		expect(signedUrlMap[ref].indexOf(ref)).toBeGreaterThan(-1);
 	});
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4624,9 +4624,9 @@ media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
 
-meetup-web-mocks@1.0.194:
-  version "1.0.194"
-  resolved "https://registry.yarnpkg.com/meetup-web-mocks/-/meetup-web-mocks-1.0.194.tgz#0f0a4526a739a0dcebacbc12c9adf4ab16fe38e0"
+meetup-web-mocks@1.0.203:
+  version "1.0.203"
+  resolved "https://registry.yarnpkg.com/meetup-web-mocks/-/meetup-web-mocks-1.0.203.tgz#6bb222fad96ff5680dc257c86c8b6f4623d9bad5"
   dependencies:
     rxjs "5.4.2"
 


### PR DESCRIPTION
`group.duotoneUrl` is now an object instead of a string, and has a `large` and `small` photo URL

This is for Foundation, who would like a higher-resolution duotoned image for the group context header/hero. The `GroupCard` will need to be updated to point to the `small` URL in mup-web.