### PR TITLE
WP-439 do not re-fetch on hash change

### DIFF
--- a/src/components/SyncContainer.jsx
+++ b/src/components/SyncContainer.jsx
@@ -19,12 +19,19 @@ export class SyncContainer extends React.Component {
 	 * This container connects route changes to Redux actions. When the router
 	 * inject new props, the container determines whether or not to dispatch a
 	 * 'locationChange' action
+	 * 
+	 * In order to prevent data fetches when the hash changes, we only compare
+	 * the new pathname and querystring with the current pathname and querystring
+	 * 
 	 * @return {undefined} side effect only - dispatch
 	 */
-	componentWillReceiveProps(nextProps) {
-		if (nextProps.location !== this.props.location) {
-			this.props.dispatchLocationChange(nextProps.location);
-			if (nextProps.history.action === 'PUSH') {
+	componentWillReceiveProps({ location, history }) {
+		if (
+			location.pathname !== this.props.pathname ||
+			location.search !== this.props.search
+		) {
+			this.props.dispatchLocationChange(location);
+			if (history.action === 'PUSH') {
 				// new navigation - scroll to top
 				window.scrollTo(0, 0);
 			}

--- a/src/components/SyncContainer.jsx
+++ b/src/components/SyncContainer.jsx
@@ -27,8 +27,8 @@ export class SyncContainer extends React.Component {
 	 */
 	componentWillReceiveProps({ location, history }) {
 		if (
-			location.pathname !== this.props.pathname ||
-			location.search !== this.props.search
+			location.pathname !== this.props.location.pathname ||
+			location.search !== this.props.location.search
 		) {
 			this.props.dispatchLocationChange(location);
 			if (history.action === 'PUSH') {


### PR DESCRIPTION
**`Prelim` while I test locally**

The SyncContainer was looking for _any_ location change when determining whether or not to trigger a REST API re-fetch. Instead, it should only check the pathname and querystring, which are the only location properties that indicate that a 'new page' has been requested.