### PR TITLE
WP 415 selector helpers moved from mup-web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [5.2]
+
+- **Feature** `src/reducers/selectors.js` selectors that can be composed to
+  process state provided by the platform reducer. These were ported from mup-web
+  and retain most of the same interface definition, although there are two minor
+  changes:
+
+  1. `testUtils:generateMockState` takes a `{ ref, value?, meta? }` object arg
+     instead of mup-web's `(ref, value?)` signature - note the newly available
+     `meta` property override.
+  2. `EMPTY_AR` is now `EMPTY_ARR`.
+
 ## [5.1]
 
 - **Change** (could be considered breaking, but it's specifically for a

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CI_BUILD_NUMBER ?= $(USER)-snapshot
-VERSION ?= 5.1.$(CI_BUILD_NUMBER)
+VERSION ?= 5.2.$(CI_BUILD_NUMBER)
 
 version:
 	@echo $(VERSION)

--- a/flow-typed/platform.js
+++ b/flow-typed/platform.js
@@ -1,6 +1,7 @@
 // @flow
 declare var Intl: Object;
 
+declare type NonNull = string | number | boolean | {} | [];
 declare type Params = { [string]: string | number };
 
 declare type FluxStandardAction = {
@@ -11,6 +12,8 @@ declare type FluxStandardAction = {
 };
 
 declare type Reducer = (state: ?Object, action: FluxStandardAction) => Object;
+// Selector is paramaterized by its output type
+declare type Selector<T> = (state: ?Object) => T;
 
 // API query structure
 declare type Query = {
@@ -24,9 +27,10 @@ declare type Query = {
 	},
 };
 
+declare type QueryResponseValue = Object | Array<Object>;
 declare type QueryResponse = {
 	ref: string,
-	value: Object | Array<Object>,
+	value: QueryResponseValue,
 	type?: string,
 	flags?: Array<string>,
 	meta?: Object,
@@ -62,29 +66,32 @@ declare type Match = {
 
 declare type MatchedRoute = { route: PlatformRoute, match: Match };
 declare type MatchPathOptions = {
-  path: string,
-  exact?: boolean,
-  strict?: boolean,
-}
+	path: string,
+	exact?: boolean,
+	strict?: boolean,
+};
 
 declare module 'react-router-dom/matchPath' {
-	declare function matchPath(pathname: string, options: MatchPathOptions): null | Match;
+	declare function matchPath(
+		pathname: string,
+		options: MatchPathOptions
+	): null | Match;
 	declare module.exports: typeof matchPath;
 }
 
 declare type LocationShape = {
-  pathname?: string,
-  search?: string,
-  hash?: string,
-  state?: any,
-}
+	pathname?: string,
+	search?: string,
+	hash?: string,
+	state?: any,
+};
 
 declare class RouterRedirect extends React$Component {
 	props: {
 		to: string | LocationShape,
 		push?: boolean,
-	}
+	},
 }
 declare module 'react-router-dom/Redirect' {
-	declare export default typeof RouterRedirect;
+	declare export default typeof RouterRedirect
 }

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "uuid": "3.1.0"
   },
   "peerDependencies": {
-    "mwp-cli": "^1.0.101"
+    "mwp-cli": "^1.0.101",
+    "reselect": "^3.0.1"
   },
   "devDependencies": {
     "babel-cli": "6.24.1",
@@ -98,6 +99,7 @@
     "react-router-dom": "4.1.1",
     "react-test-renderer": "15.6.1",
     "redux": "3.7.1",
+    "reselect": "3.0.1",
     "rxjs": "5.4.2",
     "tough-cookie": "2.3.2"
   },

--- a/src/reducers/selectors.js
+++ b/src/reducers/selectors.js
@@ -1,0 +1,124 @@
+// @flow
+
+import { createSelector } from 'reselect';
+
+export const EMPTY_OBJ = {};
+export const EMPTY_AR = [];
+
+/**
+ * Checks a response object for errors and returns them
+ * @param  {Object} responseValue Response value from Api
+ * @return {Object} an object containing errors parsed from the response
+ */
+export const processErrors = (responseValue: ?QueryResponse): Object => {
+	if (!responseValue || !responseValue.error) {
+		return {};
+	}
+	return responseValue;
+};
+
+export const processErrorsMaybe = (responseValue: ?QueryResponse) => {
+	const processed = processErrors(responseValue);
+	return Object.keys(processed).length ? processed : null;
+};
+
+// Checks if object is empty
+export const isEmpty: Selector<boolean> = state => {
+	if (!state) {
+		return true;
+	}
+	return Object.keys(state).length === 0;
+};
+
+// Checks if object is has errors
+export const hasErrors: Selector<boolean> = state =>
+	Object.keys(processErrors(state)).length > 0;
+
+// Combo check if the object is either empty or has errors
+export const hasValidValue: Selector<boolean> = state =>
+	!isEmpty(state) && !hasErrors(state);
+
+/*
+ * returns the QueryResponse.value, or an object containing a single `error`
+ * property. An empty response returns the defaultValue.
+ */
+export const getValue = (
+	resp: ?QueryResponse,
+	defaultValue: mixed = EMPTY_OBJ
+): mixed => {
+	if (!resp || isEmpty(resp)) {
+		return defaultValue;
+	}
+	if (hasErrors(resp)) {
+		return resp; // this is an object like { error, meta }
+	}
+	return resp.value; // the 'unwrapped' value
+};
+
+/**
+ * Returns a property from response.value in state. If response.error or
+ * response is empty, returns default value
+ */
+export const getProperty = (
+	resp: ?QueryResponse,
+	prop: string,
+	defaultValue: mixed = EMPTY_OBJ
+): mixed => {
+	const value = getValue(resp, defaultValue);
+
+	if (value === defaultValue || value.error) {
+		return value;
+	}
+	if (value instanceof Object && value[prop]) {
+		return value[prop];
+	}
+
+	return defaultValue;
+};
+
+/**
+ * Pulls the value out of the state object provided or if error returns default value
+ * @param  {Object}  defaultValue    fallback value if value is inValid
+ * @param  {Object}  selector    selector to be pulled off state object
+ * @return {Object}  returns selected value
+ */
+export const getSelectOrFallback = (
+	defaultValue: mixed,
+	selector: Selector<mixed> = s => s
+) => (state: ?Object) => {
+	if (isEmpty(state)) {
+		return defaultValue;
+	}
+	return selector(state);
+};
+
+// selects the inFlight part of state
+const getInFlightResp = state => state.api.inFlight;
+
+export const getInFlight = createSelector(
+	getInFlightResp,
+	getSelectOrFallback(EMPTY_AR, resp => resp)
+);
+
+// Reads response and builds error object based on response.error
+export const getResponse = (
+	resp: ?QueryResponse,
+	type: string,
+	defaultValue: mixed = EMPTY_OBJ
+) => {
+	// empty check
+	if (!resp || isEmpty(resp)) {
+		return defaultValue;
+	}
+	// error object
+	if (resp.error) {
+		return {
+			error: {
+				type,
+				message: resp.error,
+			},
+		};
+	}
+
+	return resp.value;
+};

--- a/src/reducers/selectors.js
+++ b/src/reducers/selectors.js
@@ -5,11 +5,7 @@ import { createSelector } from 'reselect';
 export const EMPTY_OBJ = {};
 export const EMPTY_AR = [];
 
-/**
- * Checks a response object for errors and returns them
- * @param  {Object} responseValue Response value from Api
- * @return {Object} an object containing errors parsed from the response
- */
+// Checks a response object for errors and returns them
 export const processErrors = (responseValue: ?QueryResponse): Object => {
 	if (!responseValue || !responseValue.error) {
 		return {};
@@ -55,7 +51,7 @@ export const getValue = (
 	return resp.value; // the 'unwrapped' value
 };
 
-/**
+/*
  * Returns a property from response.value in state. If response.error or
  * response is empty, returns default value
  */
@@ -76,11 +72,9 @@ export const getProperty = (
 	return defaultValue;
 };
 
-/**
- * Pulls the value out of the state object provided or if error returns default value
- * @param  {Object}  defaultValue    fallback value if value is inValid
- * @param  {Object}  selector    selector to be pulled off state object
- * @return {Object}  returns selected value
+/*
+ * reads the value out of the state object provided using an optional selector,
+ * or, if response is empty, returns the provided default value
  */
 export const getSelectOrFallback = (
 	defaultValue: mixed,
@@ -106,17 +100,13 @@ export const getResponse = (
 	type: string,
 	defaultValue: mixed = EMPTY_OBJ
 ) => {
-	// empty check
 	if (!resp || isEmpty(resp)) {
 		return defaultValue;
 	}
-	// error object
+
 	if (resp.error) {
 		return {
-			error: {
-				type,
-				message: resp.error,
-			},
+			error: { type, message: resp.error },
 		};
 	}
 

--- a/src/reducers/selectors.test.js
+++ b/src/reducers/selectors.test.js
@@ -2,7 +2,7 @@ import { generateMockState } from '../util/testUtils';
 import { MOCK_EVENT } from 'meetup-web-mocks/lib/api';
 import {
 	EMPTY_OBJ,
-	EMPTY_AR,
+	EMPTY_ARR,
 	isEmpty,
 	hasErrors,
 	hasValidValue,
@@ -130,7 +130,7 @@ describe('Selector Helpers', () => {
 		});
 		it('should return default value of error response', () => {
 			const newState = getInFlight({ api: {} });
-			expect(newState).toBe(EMPTY_AR);
+			expect(newState).toBe(EMPTY_ARR);
 		});
 	});
 	describe('getResponse', () => {

--- a/src/reducers/selectors.test.js
+++ b/src/reducers/selectors.test.js
@@ -1,0 +1,165 @@
+import { generateMockState } from '../util/testUtils';
+import { MOCK_EVENT } from 'meetup-web-mocks/lib/api';
+import {
+	EMPTY_OBJ,
+	EMPTY_AR,
+	isEmpty,
+	hasErrors,
+	hasValidValue,
+	getValue,
+	getProperty,
+	getSelectOrFallback,
+	getInFlight,
+	getResponse,
+} from './selectors';
+
+describe('Selector Helpers', () => {
+	describe('isEmpty', () => {
+		it('should be `false` if valid object provided', () => {
+			const processed = isEmpty({ value: '222' });
+			expect(processed).toBe(false);
+		});
+		it('should be `false` if error object provided', () => {
+			const processed = isEmpty({ error: 'Bad' });
+			expect(processed).toBe(false);
+		});
+		it('should be `true` if empty object provided', () => {
+			const processed = isEmpty({});
+			expect(processed).toBe(true);
+		});
+		it('should be `true` if nothing provided', () => {
+			const processed = isEmpty();
+			expect(processed).toBe(true);
+		});
+	});
+	describe('hasErrors', () => {
+		it('should be `false` if valid object provided', () => {
+			const processed = hasErrors({ value: '222' });
+			expect(processed).toBe(false);
+		});
+		it('should be `false` if empty object provided', () => {
+			const processed = hasErrors({});
+			expect(processed).toBe(false);
+		});
+		it('should be `false` if nothing provided', () => {
+			const processed = hasErrors();
+			expect(processed).toBe(false);
+		});
+		it('should be `true` if error object provided', () => {
+			const processed = hasErrors({ error: 'Bad' });
+			expect(processed).toBe(true);
+		});
+	});
+	describe('hasValidValue', () => {
+		it('should be `false` if empty object provided', () => {
+			const processed = hasValidValue({});
+			expect(processed).toBe(false);
+		});
+		it('should be `false` if nothing provided', () => {
+			const processed = hasValidValue();
+			expect(processed).toBe(false);
+		});
+		it('should be `false` if error object provided', () => {
+			const processed = hasValidValue({ error: 'Bad' });
+			expect(processed).toBe(false);
+		});
+		it('should be `true` if valid object provided', () => {
+			const processed = hasValidValue({ value: '222' });
+			expect(processed).toBe(true);
+		});
+	});
+	describe('getValue', () => {
+		it('should return default object if invalid value', () => {
+			const processed = getValue({});
+			expect(processed).toBe(EMPTY_OBJ);
+		});
+		it('should return default object if invalid value', () => {
+			const processed = getValue();
+			expect(processed).toBe(EMPTY_OBJ);
+		});
+		it('should return error object if invalid value', () => {
+			const error = { error: 'Bad' };
+			const processed = getValue(error);
+			expect(processed).toMatchObject(error);
+		});
+		it('should return value object if valid object', () => {
+			const processed = getValue({ value: '222' });
+			expect(processed).toBe('222');
+		});
+	});
+	describe('getProperty', () => {
+		it('should return default object if invalid value', () => {
+			const processed = getProperty({});
+			expect(processed).toBe(EMPTY_OBJ);
+		});
+		it('should return default object if invalid prop', () => {
+			const processed = getProperty({}, 'id', '');
+			expect(processed).toBe('');
+		});
+		it('should return error object if invalid value', () => {
+			const error = { error: 'Bad' };
+			const processed = getProperty(error, 'id', '');
+			expect(processed).toMatchObject(error);
+		});
+		it('should return value object if valid object', () => {
+			const id = '222';
+			const processed = getProperty({ value: { id } }, 'id', '');
+			expect(processed).toBe(id);
+		});
+	});
+	describe('getSelectOrFallback', () => {
+		const fallback = '111';
+		it('should return default object if invalid value', () => {
+			const processed = getSelectOrFallback(fallback, () => {})({});
+			expect(processed).toBe(fallback);
+		});
+		it('should return default object if invalid value', () => {
+			const value = '222';
+			const state = { value };
+			const processed = getSelectOrFallback(fallback, state => state.value)(
+				state
+			);
+			expect(processed).toBe(value);
+		});
+	});
+	describe('getInFlight', () => {
+		it('should return inFlight from state object', () => {
+			const mock_state = generateMockState('inFlight');
+			const newState = getInFlight(mock_state);
+			expect(newState).toMatchObject(mock_state.api.inFlight);
+		});
+		it('should return default value of error response', () => {
+			const newState = getInFlight({ api: {} });
+			expect(newState).toBe(EMPTY_AR);
+		});
+	});
+	describe('getResponse', () => {
+		it('should return empty object if event is empty', () => {
+			const proccessedObj = getResponse();
+			expect(proccessedObj).toEqual(EMPTY_OBJ);
+		});
+		it('should return default object if event is empty', () => {
+			const proccessedObj = getResponse({}, null, 'default');
+			expect(proccessedObj).toEqual('default');
+		});
+		it('should return error object if resp has error', () => {
+			const type = 'ACTION';
+			const message = { error: 'Bad Response 🎃' };
+			const proccessedObj = getResponse(message, type);
+			const expected = {
+				error: {
+					type,
+					message: message.error,
+				},
+			};
+			expect(proccessedObj).toEqual(expected);
+		});
+		it('should return resp.value if resp is valid', () => {
+			const resp = {
+				value: MOCK_EVENT,
+			};
+			const proccessedObj = getResponse(resp);
+			expect(proccessedObj).toEqual(MOCK_EVENT);
+		});
+	});
+});

--- a/src/util/testUtils.js
+++ b/src/util/testUtils.js
@@ -116,12 +116,16 @@ export function testCreateStore(createStoreFn) {
  * @param {Object} value value to use in object creation
  * @return {Object} mock object
  */
-export const generateMockState = (ref, value = { id: '🦄' }) => ({
+export const generateMockState = ({
+	ref,
+	value = { id: '🦄' },
+	meta = { statusCode: 204 },
+}) => ({
 	api: {
 		...MOCK_APP_STATE.api,
 		[ref]: {
-			ref: ref,
-			meta: { statusCode: 204 },
+			ref,
+			meta,
 			value,
 		},
 	},

--- a/src/util/testUtils.js
+++ b/src/util/testUtils.js
@@ -37,9 +37,10 @@ export const middlewareDispatcher = middleware => (storeData, action) => {
 };
 
 export const parseCookieHeader = cookieHeader => {
-	const cookies = cookieHeader instanceof Array
-		? cookieHeader.map(Cookie.parse)
-		: [Cookie.parse(cookieHeader)];
+	const cookies =
+		cookieHeader instanceof Array
+			? cookieHeader.map(Cookie.parse)
+			: [Cookie.parse(cookieHeader)];
 
 	return cookies.reduce(
 		(acc, cookie) => ({ ...acc, [cookie.key]: cookie.value }),
@@ -108,3 +109,20 @@ export function testCreateStore(createStoreFn) {
 		basicStore.dispatch({ type: 'dummy' });
 	});
 }
+
+/**
+ * Useful function when generating fake state objects
+ * @param {String} ref Reference to use in object creation
+ * @param {Object} value value to use in object creation
+ * @return {Object} mock object
+ */
+export const generateMockState = (ref, value = { id: '🦄' }) => ({
+	api: {
+		...MOCK_APP_STATE.api,
+		[ref]: {
+			ref: ref,
+			meta: { statusCode: 204 },
+			value,
+		},
+	},
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -6222,6 +6222,10 @@ requires-port@1.0.x, requires-port@1.x.x:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
 
+reselect@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-3.0.1.tgz#efdaa98ea7451324d092b2b2163a6a1d7a9a2147"
+
 resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"


### PR DESCRIPTION
No new code here, just some Flow types - feel free to review that, but everything else is verbatim from mup-web.

Once this merges, I'll set up a PR in mup-web to remove the existing selectorsHelper.js script and update the import paths for modules that currently rely on it.