### PR TITLE
always parse the response body even for non-2xx responses

### DIFF
--- a/src/util/apiUtils.js
+++ b/src/util/apiUtils.js
@@ -146,9 +146,9 @@ export const parseMetaHeaders = headers => {
  * @param {Error} err the error to populate
  * @return {Object} { value, error? }
  */
-function formatApiError(err) {
+function formatApiError(err, value = null) {
 	return {
-		value: null,
+		value,
 		error: err.message,
 	};
 }
@@ -161,27 +161,45 @@ export const errorResponse$ = requestUrl => err =>
 		},
 	});
 
+const parseBody = body => {
+	if (!body) {
+		return null;
+	}
+	// Some newline literals will not work in JS string literals - they must be
+	// converted to an escaped newline character that will work end to end ('\n')
+	// treat non-success HTTP code as an error
+	const safeBody = body.replace(ESCAPED_UNICODE_NEWLINES, '\\n');
+	return JSON.parse(safeBody);
+};
+
 /**
+ * The externalRequest callback provides a `response` object and a `body` string
+ * that need to be parsed in order to determine the appropriate 'value'.
+ * 
+ * This function determines the { value, error } based on the status code and
+ * body of the response - it will always set an 'error' value when a non-2xx
+ * response is received, but it may provide additional error details that are
+ * included in the 'body' of the response - body error details will usually
+ * be JSON parsed into `value.errors`, but that is determined by the JSON
+ * returned by the REST API.
+ * 
  * @return {Object} { value, error? }
  */
 export const parseApiValue = ([response, body]) => {
-	// treat non-success HTTP code as an error
-	if (response.statusCode < 200 || response.statusCode > 299) {
-		return formatApiError(new Error(response.statusMessage));
+	if (response.statusCode === 204) {
+		// NoContent response type
+		return { value: null };
 	}
-	try {
-		if (response.statusCode === 204) {
-			// NoContent response type
-			return { value: null };
-		}
 
-		// Some newline literals will not work in JS string literals - they must be
-		// converted to an escaped newline character that will work end to end ('\n')
-		const safeBody = body.replace(ESCAPED_UNICODE_NEWLINES, '\\n');
-		const value = JSON.parse(safeBody);
+	try {
+		const value = parseBody(body);
+		if (response.statusCode < 200 || response.statusCode > 299) {
+			return formatApiError(new Error(response.statusMessage), value);
+		}
 		if (value && value.problem) {
 			return formatApiError(
-				new Error(`API problem: ${value.problem}: ${value.details}`)
+				new Error(`API problem: ${value.problem}: ${value.details}`),
+				value
 			);
 		}
 		return { value };

--- a/src/util/apiUtils.test.js
+++ b/src/util/apiUtils.test.js
@@ -161,12 +161,36 @@ describe('parseApiValue', () => {
 		headers: {},
 		statusCode: 200,
 	};
-	it('converts valid JSON into an equivalent object', () => {
+	const RESPONSE_400 = {
+		...MOCK_RESPONSE,
+		statusCode: 400,
+		statusMessage: 'Bad Request',
+	};
+	const RESPONSE_500 = {
+		...MOCK_RESPONSE,
+		statusCode: 500,
+		statusMessage: 'Internal Server Error',
+	};
+	it('converts valid JSON into an equivalent object for 200 OK response', () => {
 		const validJSON = JSON.stringify(MOCK_GROUP);
 		expect(parseApiValue([MOCK_RESPONSE, validJSON])).toEqual(
 			jasmine.any(Object)
 		);
 		expect(parseApiValue([MOCK_RESPONSE, validJSON])).toEqual({
+			value: MOCK_GROUP,
+		});
+	});
+	it('converts valid JSON into an equivalent object for 400 Bad Request response', () => {
+		const validJSON = JSON.stringify(MOCK_GROUP);
+		expect(parseApiValue([RESPONSE_400, validJSON])).toEqual({
+			error: expect.any(String),
+			value: MOCK_GROUP,
+		});
+	});
+	it('converts valid JSON into an equivalent object for 500 error response', () => {
+		const validJSON = JSON.stringify(MOCK_GROUP);
+		expect(parseApiValue([RESPONSE_500, validJSON])).toEqual({
+			error: expect.any(String),
 			value: MOCK_GROUP,
 		});
 	});
@@ -182,7 +206,7 @@ describe('parseApiValue', () => {
 			jasmine.any(String)
 		);
 	});
-	it('returns an object with a string "error" value for a not-ok response', () => {
+	it('returns an object with a null value for a 204 No Content response', () => {
 		const noContentStatus = {
 			statusCode: 204,
 			statusMessage: 'No Content',


### PR DESCRIPTION
This will allow error data from the body of REST API responses to appear in the Redux `API_RESP_ERROR` action and be used to provide more fine-grained error feedback.

see https://meetup.atlassian.net/browse/MW-1693