### PR TITLE
explicit fallback to first 'supportedLang' + test for unsupported accept-language

### DIFF
--- a/src/util/languageUtils.js
+++ b/src/util/languageUtils.js
@@ -28,16 +28,16 @@ export const getUrlLang = (request, supportedLangs) => {
  *   preferred languages first
  * @return {String|Boolean} language code
  */
-export const getBrowserLang = (request, supportedLangs) => {
-	return Accepts(request).language(supportedLangs);
-};
+export const getBrowserLang = (request, supportedLangs) =>
+	Accepts(request).language(supportedLangs);
 
 export const getLanguage = (request, supportedLangs) => {
 	// return the first language hit in the order of preference
 	return (
 		getCookieLang(request, supportedLangs) ||
 		getUrlLang(request, supportedLangs) ||
-		getBrowserLang(request, supportedLangs)
+		getBrowserLang(request, supportedLangs) ||
+		supportedLangs[0]
 	);
 };
 

--- a/src/util/languageUtils.test.js
+++ b/src/util/languageUtils.test.js
@@ -10,10 +10,13 @@ import {
 } from './languageUtils';
 
 const rootUrl = 'http://example.com/';
+const unsupportedLang = 'xx-XX';
 const MOCK_HAPI_REQUEST = {
 	log() {},
 	url: url.parse(rootUrl),
-	headers: {},
+	headers: {
+		'accept-language': unsupportedLang, // must test unsupported lang by default
+	},
 	state: {},
 };
 const MOCK_HAPI_REPLY = {


### PR DESCRIPTION
The unit test for `getLanguage` was insufficient because it didn't account for a request with an `accept-language` header that contained only an unsupported locale code - an empty/missing 'accept-language' header was handled correctly, but unsupported values would return `false` instead of the default lang.