### PR TITLE
call console.error manually for request-error events

### DIFF
--- a/src/plugins.js
+++ b/src/plugins.js
@@ -94,8 +94,9 @@ export function getLogger(
 	};
 	const register = (server, options, next) => {
 		server.on('request-error', onRequestError);
-		return HapiPino(server, options, next);
+		return HapiPino.register(server, options, next);
 	};
+	register.attributes = HapiPino.register.attributes;
 
 	options.instance = logger;
 	return {


### PR DESCRIPTION
Our logging library, Pino, doesn't log to stderr [for performance reasons](https://github.com/pinojs/pino#transports), so its default handling of `request-error` (500 Internal server error) responses doesn't highlight errors in Stackdriver the way we would like.

This PR takes logging control away from Hapi-Pino for `request-error` events, and manually adds an event listener that replicates what a Hapi-Pino log would look like, only this time passed directly to `console.error`. Performance is not a concern - this is not intended to be a hot code path.