### PR TITLE
consolidate side-effect handling - ensure `.rewind()` is called on error

### DIFF
--- a/src/components/dom.jsx
+++ b/src/components/dom.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import Helmet from 'react-helmet';
 import escapeHtml from 'escape-html';
 
 function getInnerHTML(__html) {
@@ -35,6 +34,7 @@ const DOM = props => {
 		assetPublicPath,
 		baseUrl,
 		clientFilename,
+		head,
 		initialState = {},
 		scripts = [],
 	} = props;
@@ -50,9 +50,6 @@ const DOM = props => {
 	const initialStateJson = JSON.stringify(initialState);
 	// escape the string
 	const escapedState = escapeHtml(initialStateJson);
-
-	// Extract the `<head>` information from any page-specific `<Helmet>` components
-	const head = Helmet.rewind();
 
 	const APP_RUNTIME = {
 		baseUrl,
@@ -96,6 +93,13 @@ DOM.propTypes = {
 	assetPublicPath: PropTypes.string.isRequired,
 	baseUrl: PropTypes.string,
 	clientFilename: PropTypes.string,
+	head: PropTypes.shape({
+		// this is expected to come from Helmet.rewind()
+		title: PropTypes.shape({ toComponent: PropTypes.func }),
+		meta: PropTypes.shape({ toComponent: PropTypes.func }),
+		link: PropTypes.shape({ toComponent: PropTypes.func }),
+		script: PropTypes.shape({ toComponent: PropTypes.func }),
+	}),
 	initialState: PropTypes.object.isRequired,
 	scripts: PropTypes.array,
 };

--- a/src/renderers/server-render.jsx
+++ b/src/renderers/server-render.jsx
@@ -6,6 +6,7 @@ import 'rxjs/add/operator/first';
 import IntlPolyfill from 'intl';
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
+import Helmet from 'react-helmet';
 import StaticRouter from 'react-router-dom/StaticRouter';
 
 import Dom from '../components/dom';
@@ -48,6 +49,21 @@ function getRedirect(context) {
 	};
 }
 
+/*
+ * A helper to collect react-side-effect data from all components in the
+ * application that utilize side effects
+ *
+ * Any component class that uses react-side-effect should be 'rewound' in this
+ * function to prevent memory leaks and invalid state carrying over into other
+ * requests
+ */
+const resolveSideEffects = () => ({
+	head: Helmet.rewind(),
+	redirect: Redirect.rewind(),
+	forbidden: Forbidden.rewind(),
+	notFound: NotFound.rewind(),
+});
+
 /**
  * Using the current route information and Redux store, render the app to an
  * HTML string and server response code.
@@ -68,6 +84,7 @@ function getRedirect(context) {
 type RenderResult =
 	| { result: string, statusCode: number }
 	| { redirect: { url: string, permanent?: boolean } };
+
 const getRouterRenderer = ({
 	routes,
 	store,
@@ -87,18 +104,26 @@ const getRouterRenderer = ({
 	let appMarkup;
 	const staticContext: { url?: string, permanent?: boolean } = {};
 
-	appMarkup = ReactDOMServer.renderToString(
-		<StaticRouter
-			basename={baseUrl}
-			location={location}
-			context={staticContext}
-		>
-			<PlatformApp store={store} routes={routes} />
-		</StaticRouter>
-	);
+	try {
+		appMarkup = ReactDOMServer.renderToString(
+			<StaticRouter
+				basename={baseUrl}
+				location={location}
+				context={staticContext}
+			>
+				<PlatformApp store={store} routes={routes} />
+			</StaticRouter>
+		);
+	} catch (err) {
+		// cleanup all react-side-effect components to prevent error/memory leaks
+		resolveSideEffects();
+		// now we can re-throw and let the caller handle the error
+		throw err;
+	}
 
-	// must _always_ call Redirect.rewind() to avoid memory leak
-	const externalRedirect = getRedirect(Redirect.rewind());
+	const sideEffects = resolveSideEffects();
+
+	const externalRedirect = getRedirect(sideEffects.redirect);
 	const internalRedirect = getRedirect(staticContext);
 	const redirect = internalRedirect || externalRedirect;
 	if (redirect) {
@@ -112,6 +137,7 @@ const getRouterRenderer = ({
 			baseUrl={baseUrl}
 			assetPublicPath={assetPublicPath}
 			clientFilename={clientFilename}
+			head={sideEffects.head}
 			initialState={initialState}
 			appMarkup={appMarkup}
 			scripts={scripts}
@@ -119,7 +145,7 @@ const getRouterRenderer = ({
 	);
 
 	// prioritized status code fallbacks
-	const statusCode = Forbidden.rewind() || NotFound.rewind() || 200;
+	const statusCode = sideEffects.forbidden || sideEffects.notFound || 200;
 
 	return {
 		statusCode,
@@ -223,6 +249,7 @@ const makeRenderer = (
 					baseUrl={baseUrl}
 					assetPublicPath={assetPublicPath}
 					clientFilename={clientFilename}
+					head={Helmet.rewind()}
 					initialState={store.getState()}
 					scripts={scripts}
 				/>

--- a/tests/integration/render.int.js
+++ b/tests/integration/render.int.js
@@ -217,7 +217,32 @@ describe('Full dummy app render', () => {
 			};
 			return server
 				.inject(request)
+				.then(response => {
+					expect(response.statusCode).toBe(500);
+				})
+				.then(() => server.stop())
+				.catch(err => {
+					server.stop();
+					throw err;
+				});
+		}));
+	it('returns 200 OK after a 500 error', () =>
+		start(getMockRenderRequestMap(), {}).then(server => {
+			const errorRequest = {
+				method: 'get',
+				url: '/badImplementation',
+				credentials: 'whatever',
+			};
+			const goodRequest = {
+				method: 'get',
+				url: '/foo',
+				credentials: 'whatever',
+			};
+			return server
+				.inject(errorRequest)
 				.then(response => expect(response.statusCode).toBe(500))
+				.then(() => server.inject(goodRequest))
+				.then(response => expect(response.statusCode).toBe(200))
 				.then(() => server.stop())
 				.catch(err => {
 					server.stop();

--- a/tests/mockApp.jsx
+++ b/tests/mockApp.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Helmet from 'react-helmet';
 import makeRootReducer from '../src/reducers/platform';
 import Redirect from '../src/components/Redirect';
 
@@ -14,6 +15,7 @@ const MockRootIndex = props =>
 export const FOO_INDEX_CONTENT = 'yo dawg i heard you like foo';
 const MockFooIndex = props =>
 	<div>
+		<Helmet />
 		{FOO_INDEX_CONTENT}
 	</div>;
 export const EXTERNAL_REDIRECT_URL = 'http://example.com/foo?return=foo';
@@ -65,8 +67,12 @@ export const routes = [
 			{
 				path: '/badImplementation',
 				component: () => {
-					throw new Error('your implementation is bad and you should feel bad');
-					return <div />; // eslint-disable-line no-unreachable
+					// eslint-disable-next-line no-unreachable
+					return (
+						<Helmet>
+							<meta property={{}} content={undefined} />
+						</Helmet>
+					);
 				},
 			},
 			{

--- a/tests/mockApp.jsx
+++ b/tests/mockApp.jsx
@@ -67,10 +67,19 @@ export const routes = [
 			{
 				path: '/badImplementation',
 				component: () => {
-					// eslint-disable-next-line no-unreachable
+					/*
+					 * the `property` prop for `meta` must be a string in order for
+					 * <Helmet> to process it correctly - this is a 'bad implementation'
+					 * that will throw an error because `property` is an object.
+					 * It's possible that 'react-helmet' will change this behavior in the
+					 * future and related tests will start failing because they expect the
+					 * error to be thrown, but this implementation exposes a tricky bug in
+					 * the platform that was fixed in WP-429 and is useful for preventing
+					 * regression
+					 */
 					return (
 						<Helmet>
-							<meta property={{}} content={undefined} />
+							<meta property={{}} content="foo" />
 						</Helmet>
 					);
 				},


### PR DESCRIPTION
When there was an error thrown while rendering the application, `Helmet` and a few other 'react-side-effect' components were not getting correctly re-set on the server. When there was an error _inside_ one of these components in the application, all subsequent requests would try to re-render the same erroring instances, and the server could not recover.

This PR wraps the app-rendering call in a `try`/`catch` that will force the react-side-effect classes to re-set in the case of a rendering error. It also consolidates the references to these classes in a `resolveSideEffects` function so that it easier to keep track of this special behavior.