### PR TITLE
Use x-forwarded-host when available to set baseUrl.

### DIFF
--- a/src/renderers/server-render.jsx
+++ b/src/renderers/server-render.jsx
@@ -213,11 +213,12 @@ const makeRenderer = (
 		raw: { req },
 	} = request;
 
-	// request protocol might be different from original request that hit proxy
-	// we want to use the proxy's protocol
+	// request protocol and host might be different from original request that hit proxy
+	// we want to use the proxy's protocol and host
 	const requestProtocol =
 		headers['x-forwarded-proto'] || connection.info.protocol;
-	const host = `${requestProtocol}://${info.host}`;
+	const domain = headers['x-forwarded-host'] || info.host;
+	const host = `${requestProtocol}://${domain}`;
 	const apiUrl = '/mu_api';
 
 	// create the store


### PR DESCRIPTION
Did some testing with our fastly QA VCL file and stackdriver, and fastly sets an `x-forwarded-host` that should have the correct domain.

I did take a look at only using non-domain-specific URLs everywhere (we are already using them in some places), but it would end up being a bigger change -- probably worth doing, but would be good to get this out so we can make sure foundation is unblocked.