### PR TITLE
set config in `initialState`

### DIFF
--- a/src/renderers/server-render.jsx
+++ b/src/renderers/server-render.jsx
@@ -13,8 +13,6 @@ import { getServerCreateStore } from '../store/server'; // mwp-store
 import Dom from '../render/components/Dom'; // mwp-render/components/Dom
 import ServerApp from '../render/components/ServerApp'; // mwp-render/components/ServerApp
 
-import configure from '../actions/configActionCreators';
-
 // Ensure global Intl for use with FormatJS
 Intl.NumberFormat = IntlPolyfill.NumberFormat;
 Intl.DateTimeFormat = IntlPolyfill.DateTimeFormat;
@@ -226,8 +224,18 @@ const makeRenderer = (
 	const domain = headers['x-forwarded-host'] || info.host;
 	const host = `${requestProtocol}://${domain}`;
 
-	// create the store
-	const initialState = {};
+	// create the store with populated `config`
+	const initialState = {
+		config: {
+			apiUrl: API_ROUTE_PATH,
+			baseUrl: host,
+			enableServiceWorker,
+			requestLanguage,
+			supportedLangs,
+			initialNow: new Date().getTime(),
+		},
+	};
+
 	const createStore = getServerCreateStore(
 		routes,
 		middleware,
@@ -236,17 +244,6 @@ const makeRenderer = (
 	);
 	const store = createStore(reducer, initialState);
 
-	// load initial config
-	store.dispatch(
-		configure({
-			apiUrl: API_ROUTE_PATH,
-			baseUrl: host,
-			enableServiceWorker,
-			requestLanguage,
-			supportedLangs,
-			initialNow: new Date().getTime(),
-		})
-	);
 	// render skeleton if requested - the store is ready
 	if ('skeleton' in request.query) {
 		return Observable.of({


### PR DESCRIPTION
This is just something I saw when working on another ticket - setting `config` as part of the server-side `initialState` makes the behavior of the system a little simpler to see and reason about because it avoids dispatching actions and activating the whole middleware->reducer processing chain just to assign a few static values to `state.config`