### PR TITLE
Add a check for X-Meetup-Host, because GAE won't allow X-Forwarded-Host

### DIFF
--- a/src/renderers/server-render.jsx
+++ b/src/renderers/server-render.jsx
@@ -223,7 +223,8 @@ const makeRenderer = (
 	// we want to use the proxy's protocol and host
 	const requestProtocol =
 		headers['x-forwarded-proto'] || connection.info.protocol;
-	const domain = headers['x-forwarded-host'] || info.host;
+	const domain =
+		headers['x-forwarded-host'] || headers['x-meetup-host'] || info.host;
 	const host = `${requestProtocol}://${domain}`;
 
 	// create the store


### PR DESCRIPTION
Fixes https://meetup.atlassian.net/browse/WP-465

This is just an additional check for another header that we can set, because it seems that GAE won't accept an x-forwarded-host value from fastly (and doesn't set one itself).

I'm leaving in X-Forwarded-Host while we're still using the GKE deployment, but we can remove once we're all on app engine.