### PR TITLE
WP-468 Add support for browser ID

### DIFF
--- a/flow-typed/activityPlugin.js
+++ b/flow-typed/activityPlugin.js
@@ -3,8 +3,9 @@ declare type Logger = (Object, Object) => mixed;
 declare type Tracker = (...args: Array<any>) => mixed;
 declare type TrackOpts = {
 	log: Logger,
+	browserIdCookieName: string,
+	memberCookieName: string,
 	trackIdCookieName: string,
-	sessionIdCookieName: string,
 };
 type Request = Object;
-declare type TrackGetter = TrackOpts => Request => Tracker;
+declare type TrackGetter = (TrackOpts) => Request => Tracker;

--- a/flow-typed/platform.js
+++ b/flow-typed/platform.js
@@ -27,6 +27,10 @@ declare type HapiRequest = {
 	state: {
 		[string]: string,
 	},
+	info: {
+		referrer: string,
+		[string]: mixed,
+	},
 	[string]: any,
 };
 const HapiReplyFn = (reply: string | Object) => HapiReplyFn;

--- a/src/plugins/api-proxy/index.js
+++ b/src/plugins/api-proxy/index.js
@@ -68,7 +68,7 @@ register.attributes = {
 	version: '1.0.0',
 	dependencies: [
 		'requestAuth', // provides request.plugins.requestAuth.oauth_token
-		'tracking', // provides request.trackApi()
+		'tracking', // provides request.trackActivity()
 		'electrode-csrf-jwt', // provides csrf protection for POST
 	],
 };

--- a/src/plugins/api-proxy/proxy.js
+++ b/src/plugins/api-proxy/proxy.js
@@ -1,5 +1,5 @@
 // @flow
-// Implicit dependency: tracking plugin providing request.trackApi method
+// Implicit dependency: tracking plugin providing request.trackActivity method
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/observable/zip';
 
@@ -35,6 +35,6 @@ export default (request: HapiRequest) => {
 
 		// zip them together to make requests in parallel and return responses in order
 		// $FlowFixMe - .zip is not currently defined in Observable static properties
-		return Observable.zip(...apiRequests$).do(request.trackApi);
+		return Observable.zip(...apiRequests$).do(request.trackActivity);
 	};
 };

--- a/src/plugins/api-proxy/proxy.test.js
+++ b/src/plugins/api-proxy/proxy.test.js
@@ -25,7 +25,7 @@ describe('apiProxy$', () => {
 			},
 			server: getServer(),
 			log: () => {},
-			trackApi: () => {},
+			trackActivity: () => {},
 			getLanguage: () => 'en-US',
 		};
 		const requestResult = {

--- a/src/plugins/app-route/handler.js
+++ b/src/plugins/app-route/handler.js
@@ -30,7 +30,6 @@ export default (languageRenderers: { [string]: LanguageRenderer$ }) => (
 					.redirect(renderResult.redirect.url)
 					.permanent(Boolean(renderResult.redirect.permanent));
 			}
-			request.trackSession();
 			return reply(renderResult.result).code(renderResult.statusCode);
 		},
 		err => reply(err) // 500 error - will only be thrown on bad implementation

--- a/src/plugins/tracking/README.md
+++ b/src/plugins/tracking/README.md
@@ -2,6 +2,12 @@
 
 ## Activity tracking
 
+Activity tracking is provided by a `request.trackApi` method, which has two
+responsibilities:
+
+1. Manage tracking IDs that are passed into the request through cookies
+2. Log the formatted, encoded tracking ID state of the request to `stdout`
+
 ## Click tracking
 
 Click tracking consists of 3 related modules:

--- a/src/plugins/tracking/README.md
+++ b/src/plugins/tracking/README.md
@@ -2,7 +2,7 @@
 
 ## Activity tracking
 
-Activity tracking is provided by a `request.trackApi` method, which has two
+Activity tracking is provided by a `request.trackActivity` method, which has two
 responsibilities:
 
 1. Manage tracking IDs that are passed into the request through cookies

--- a/src/plugins/tracking/_activityTrackers.js
+++ b/src/plugins/tracking/_activityTrackers.js
@@ -38,7 +38,7 @@ export const getTrackApiResponses: TrackGetter = trackOpts => request => (
  * This is the core tracking handler - called on every request that generates
  * REST API call(s)
  */
-export const getTrackApi: TrackGetter = trackOpts => request => (
+export const getTrackActivity: TrackGetter = trackOpts => request => (
 	queryResponses: Array<Object>
 ) => {
 	const { method, payload, query, info: { referrer } } = request;

--- a/src/plugins/tracking/_activityTrackers.js
+++ b/src/plugins/tracking/_activityTrackers.js
@@ -25,9 +25,9 @@ export const getTrackApiResponses: TrackGetter = trackOpts => request => (
 	}));
 	return trackOpts.log(request, {
 		description: 'nav',
-		memberId: parseIdCookie(request.state[trackOpts.memberCookieName], true),
-		browserId: updateId(trackOpts.browserIdCookieName)(request),
-		trackId: updateId(trackOpts.trackIdCookieName)(request),
+		memberId: parseIdCookie(request.state[trackOpts.memberCookieName], true), // read memberId
+		browserId: updateId(trackOpts.browserIdCookieName)(request), // read/add browserId
+		trackId: updateId(trackOpts.trackIdCookieName)(request), // read/add trackId
 		url: url || '',
 		referer: referrer || '',
 		apiRequests,

--- a/src/plugins/tracking/activity.js
+++ b/src/plugins/tracking/activity.js
@@ -1,6 +1,6 @@
 // @flow
 import avro from './util/avro';
-import { getTrackApi, getTrackApiResponses } from './_activityTrackers';
+import { getTrackActivity, getTrackApiResponses } from './_activityTrackers';
 
 const YEAR_IN_MS: number = 1000 * 60 * 60 * 24 * 365;
 export const ACTIVITY_PLUGIN_NAME = 'tracking';
@@ -10,10 +10,7 @@ export const ACTIVITY_PLUGIN_NAME = 'tracking';
  * particular server responses, e.g. new sesssions and navigation activity.
  *
  * Available trackers:
- * - `trackApi`
- * - `trackSession`
- * - `trackLogin`
- * - `trackLogout`
+ * - `trackActivity`
  */
 
 export const getLogger: string => (Object, Object) => mixed = (
@@ -67,7 +64,7 @@ export function getTrackers(options: {
 	};
 	// These are the tracking methods that will be set on the `request` interface
 	const trackers: { [string]: Tracker } = {
-		trackApi: getTrackApi(trackOpts),
+		trackActivity: getTrackActivity(trackOpts),
 		trackApiResponses: getTrackApiResponses(trackOpts),
 	};
 	return trackers;
@@ -86,7 +83,7 @@ const onRequest = (request, reply) => {
  * tracking cookies that need to be set using request.response.state.
  */
 const getOnPreResponse = cookieConfig => (request, reply) => {
-	const { browserIdCookieName, trackIdCookieName, isProd } = cookieConfig;
+	const { browserIdCookieName, trackIdCookieName } = cookieConfig;
 	const pluginData = request.plugins[ACTIVITY_PLUGIN_NAME];
 	const browserId = pluginData.browserIdCookieName;
 	const trackId = pluginData.trackIdCookieName;
@@ -95,7 +92,6 @@ const getOnPreResponse = cookieConfig => (request, reply) => {
 		encoding: 'none',
 		path: '/',
 		isHttpOnly: true,
-		isSecure: isProd,
 		ttl: YEAR_IN_MS * 20,
 	};
 
@@ -150,7 +146,6 @@ export default function register(
 			browserIdCookieName,
 			memberCookieName,
 			trackIdCookieName,
-			isProd,
 		})
 	);
 

--- a/src/plugins/tracking/activity.js
+++ b/src/plugins/tracking/activity.js
@@ -1,10 +1,6 @@
 // @flow
 import avro from './util/avro';
-import {
-	getTrackApi,
-	getTrackSession,
-	getTrackApiResponses,
-} from './_activityTrackers';
+import { getTrackApi, getTrackApiResponses } from './_activityTrackers';
 
 const YEAR_IN_MS: number = 1000 * 60 * 60 * 24 * 365;
 export const ACTIVITY_PLUGIN_NAME = 'tracking';
@@ -51,21 +47,27 @@ export const getLogger: string => (Object, Object) => mixed = (
  */
 export function getTrackers(options: {
 	agent: string,
+	browserIdCookieName: string,
+	memberCookieName: string,
 	trackIdCookieName: string,
-	sessionIdCookieName: string,
 }): { [string]: Tracker } {
-	const { agent, trackIdCookieName, sessionIdCookieName } = options;
+	const {
+		agent,
+		browserIdCookieName,
+		memberCookieName,
+		trackIdCookieName,
+	} = options;
 
 	const log: Logger = getLogger(agent);
 	const trackOpts: TrackOpts = {
 		log,
+		browserIdCookieName,
+		memberCookieName,
 		trackIdCookieName,
-		sessionIdCookieName,
 	};
 	// These are the tracking methods that will be set on the `request` interface
 	const trackers: { [string]: Tracker } = {
 		trackApi: getTrackApi(trackOpts),
-		trackSession: getTrackSession(trackOpts),
 		trackApiResponses: getTrackApiResponses(trackOpts),
 	};
 	return trackers;
@@ -84,23 +86,24 @@ const onRequest = (request, reply) => {
  * tracking cookies that need to be set using request.response.state.
  */
 const getOnPreResponse = cookieConfig => (request, reply) => {
-	const { sessionId, trackId } = request.plugins[ACTIVITY_PLUGIN_NAME];
-	const { sessionIdCookieName, trackIdCookieName, isProd } = cookieConfig;
-	const cookieOpts: CookieOpts = {
+	const { browserIdCookieName, trackIdCookieName, isProd } = cookieConfig;
+	const pluginData = request.plugins[ACTIVITY_PLUGIN_NAME];
+	const browserId = pluginData.browserIdCookieName;
+	const trackId = pluginData.trackIdCookieName;
+
+	const FOREVER: CookieOpts = {
 		encoding: 'none',
 		path: '/',
 		isHttpOnly: true,
 		isSecure: isProd,
+		ttl: YEAR_IN_MS * 20,
 	};
 
-	if (sessionId) {
-		request.response.state(sessionIdCookieName, sessionId, cookieOpts);
+	if (browserId) {
+		request.response.state(browserIdCookieName, browserId, FOREVER);
 	}
 	if (trackId) {
-		request.response.state(trackIdCookieName, trackId, {
-			...cookieOpts,
-			ttl: YEAR_IN_MS * 20,
-		});
+		request.response.state(trackIdCookieName, trackId, FOREVER);
 	}
 	reply.continue();
 };
@@ -117,13 +120,21 @@ export default function register(
 ) {
 	const { agent, isProd } = options;
 
-	const sessionIdCookieName: string = isProd ? 'SESSION_ID' : 'SESSION_ID_DEV';
-	const trackIdCookieName: string = isProd ? 'TRACK_ID' : 'TRACK_ID_DEV';
+	const trackIdCookieName: string = isProd
+		? 'MEETUP_TRACK'
+		: 'MEETUP_TRACK_DEV';
+	const browserIdCookieName: string = isProd
+		? 'MEETUP_BROWSER_ID'
+		: 'MEETUP_BROWSER_ID_DEV';
+	const memberCookieName: string = isProd
+		? 'MEETUP_MEMBER'
+		: 'MEETUP_MEMBER_DEV';
 
 	const trackers: { [string]: Tracker } = getTrackers({
 		agent,
+		browserIdCookieName,
+		memberCookieName,
 		trackIdCookieName,
-		sessionIdCookieName,
 	});
 
 	Object.keys(trackers).forEach((trackType: string) => {
@@ -135,7 +146,12 @@ export default function register(
 	server.ext('onRequest', onRequest);
 	server.ext(
 		'onPreResponse',
-		getOnPreResponse({ sessionIdCookieName, trackIdCookieName, isProd })
+		getOnPreResponse({
+			browserIdCookieName,
+			memberCookieName,
+			trackIdCookieName,
+			isProd,
+		})
 	);
 
 	next();

--- a/src/plugins/tracking/activity.test.js
+++ b/src/plugins/tracking/activity.test.js
@@ -29,9 +29,10 @@ describe('updateId', () => {
 	});
 	it('does not set cookiename in plugin data if already set', () => {
 		const trackId = 'foo';
+		const trackIdCookie = `id=${trackId}`;
 		const request = {
 			...getMockRequest(),
-			state: { [trackIdCookieName]: trackId },
+			state: { [trackIdCookieName]: trackIdCookie },
 		};
 		const updatedTrackId = updateId(trackIdCookieName)(request);
 		expect(updatedTrackId).toBe(trackId); // no change

--- a/src/plugins/tracking/activity.test.js
+++ b/src/plugins/tracking/activity.test.js
@@ -1,14 +1,8 @@
-import { MEMBER_COOKIE } from '../../util/cookieUtils';
-import { newSessionId, updateTrackId } from './util/idUtils';
-import { getTrackSession } from './_activityTrackers';
+import { updateId } from './util/idUtils';
 // RegEx to verify UUID
 const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
-const MEMBER_ID = 1234;
-const sessionIdCookieName = 'session_foo';
 const trackIdCookieName = 'track_bar';
-const MEMBER_COOKIE_VALUE = `id=${MEMBER_ID}&name=Boo`;
-const cookieOpts = {};
 
 const MOCK_HAPI_RESPONSE = {
 	state: (name, value, opts) => {},
@@ -24,28 +18,24 @@ const getMockRequest = () => ({
 	plugins: { tracking: {} },
 });
 
-describe('tracking state setters', () => {
-	it('sets session id', () => {
-		const requestWithoutSessionId = getMockRequest();
-		const sessionId = newSessionId(requestWithoutSessionId);
-		expect(requestWithoutSessionId.plugins.tracking.sessionId).toBe(sessionId);
-		expect(UUID_V4_REGEX.test(sessionId)).toBe(true);
-	});
-	it('sets track id if not set', () => {
+describe('updateId', () => {
+	it('sets cookiename if not set', () => {
 		const requestWithoutTrackId = getMockRequest();
-		const trackId = updateTrackId({ trackIdCookieName })(requestWithoutTrackId);
+		const trackId = updateId(trackIdCookieName)(requestWithoutTrackId);
 		expect(UUID_V4_REGEX.test(trackId)).toBe(true);
-		expect(requestWithoutTrackId.plugins.tracking.trackId).toBe(trackId);
+		expect(requestWithoutTrackId.plugins.tracking[trackIdCookieName]).toContain(
+			trackId
+		);
 	});
-	it('does not set trackId in plugin data if already set', () => {
+	it('does not set cookiename in plugin data if already set', () => {
 		const trackId = 'foo';
 		const request = {
 			...getMockRequest(),
 			state: { [trackIdCookieName]: trackId },
 		};
-		const updatedTrackId = updateTrackId({ trackIdCookieName })(request);
+		const updatedTrackId = updateId(trackIdCookieName)(request);
 		expect(updatedTrackId).toBe(trackId); // no change
-		expect(request.plugins.tracking.trackId).toBeUndefined();
+		expect(request.plugins.tracking[trackIdCookieName]).toBeUndefined();
 	});
 	it('sets new track id if doRefresh is true', () => {
 		const trackId = 'foo';
@@ -54,62 +44,11 @@ describe('tracking state setters', () => {
 			state: { [trackIdCookieName]: trackId },
 		};
 		const doRefresh = true;
-		const updatedTrackId = updateTrackId({ trackIdCookieName })(
-			request,
-			doRefresh
-		);
+		const updatedTrackId = updateId(trackIdCookieName)(request, doRefresh);
 		expect(updatedTrackId).not.toBe(trackId); // no change
-		expect(request.plugins.tracking.trackId).not.toBeUndefined();
-		expect(request.plugins.tracking.trackId).toBe(updatedTrackId);
-	});
-});
-
-describe('tracking loggers', () => {
-	const spyable = {
-		log: (response, info) => info,
-	};
-	it('getTrackSession: calls logger with "session", new sessionId, old trackId & memberId', () => {
-		spyOn(spyable, 'log').and.callThrough();
-		const request = {
-			...getMockRequest(),
-			state: {
-				[MEMBER_COOKIE]: MEMBER_COOKIE_VALUE,
-				[trackIdCookieName]: 3456,
-			},
-		};
-		getTrackSession({
-			log: spyable.log,
-			trackIdCookieName,
-			sessionIdCookieName,
-			cookieOpts,
-		})(request)();
-		expect(spyable.log).toHaveBeenCalled();
-		const trackInfo = spyable.log.calls.mostRecent().args[1];
-		expect(trackInfo.description).toEqual('session'); // this may change, but need to ensure tag is always correct
-		// new
-		expect(trackInfo.sessionId).toBeDefined();
-		expect(trackInfo.sessionId).not.toEqual(request.state[sessionIdCookieName]);
-		// old
-		expect(trackInfo.trackId).toBeDefined();
-		expect(trackInfo.trackId).toEqual(request.state[trackIdCookieName]);
-		expect(trackInfo.memberId).toEqual(MEMBER_ID);
-	});
-	it('getTrackSession: does not call logger when sessionId exists', () => {
-		spyOn(spyable, 'log').and.callThrough();
-		const request = {
-			...getMockRequest(),
-			state: {
-				[MEMBER_COOKIE]: MEMBER_COOKIE_VALUE,
-				[sessionIdCookieName]: 2345,
-				[trackIdCookieName]: 3456,
-			},
-		};
-		getTrackSession({
-			log: spyable.log,
-			trackIdCookieName,
-			sessionIdCookieName,
-			cookieOpts,
-		})(request)();
-		expect(spyable.log).not.toHaveBeenCalled();
+		expect(request.plugins.tracking[trackIdCookieName]).not.toBeUndefined();
+		expect(request.plugins.tracking[trackIdCookieName]).toContain(
+			updatedTrackId
+		);
 	});
 });

--- a/src/plugins/tracking/util/avro.js
+++ b/src/plugins/tracking/util/avro.js
@@ -58,12 +58,12 @@ const click = {
 };
 
 // currently the schema is manually copied from
-// https://github.dev.meetup.com/meetup/meetup/blob/master/modules/base/src/main/versioned_avro/Activity_v5.avsc
+// https://github.com/meetup/meetup/blob/master/modules/base/src/main/versioned_avro/Activity_v6.avsc
 const activity = {
 	namespace: 'com.meetup.base.avro',
 	type: 'record',
 	name: 'Activity',
-	doc: 'v5',
+	doc: 'v6',
 	fields: [
 		{ name: 'requestId', type: 'string' },
 		{ name: 'timestamp', type: 'string' },
@@ -95,6 +95,7 @@ const activity = {
 			default: 'UNKNOWN',
 		},
 		{ name: 'isUserActivity', type: 'boolean', default: true },
+		{ name: 'browserId', type: 'string', default: '' },
 	],
 };
 

--- a/src/plugins/tracking/util/avro.test.js
+++ b/src/plugins/tracking/util/avro.test.js
@@ -67,6 +67,7 @@ describe('Activity tracking', () => {
 		const expectedTrackedInfo = {
 			...trackInfo,
 			aggregratedUrl: '', // misspelled, unused field in v3 spec, default ''
+			browserId: '',
 		};
 		delete expectedTrackedInfo.sessionId; // not part of v3 spec
 		expect(recordedInfo).toEqual(expectedTrackedInfo);

--- a/src/plugins/tracking/util/idUtils.js
+++ b/src/plugins/tracking/util/idUtils.js
@@ -1,8 +1,9 @@
 // @flow
+import querystring from 'qs';
 import uuid from 'uuid';
 import { ACTIVITY_PLUGIN_NAME } from '../activity';
 
-type UpdateTrackId = TrackOpts => (Object, ?boolean) => string;
+type UpdateId = string => (Object, ?boolean) => string;
 /*
  * Initialize the trackId for member or anonymous user - the longest-living id
  * we can assign to a user. Stays in place until login or logout, when it is
@@ -11,20 +12,20 @@ type UpdateTrackId = TrackOpts => (Object, ?boolean) => string;
  *  - If the user has a tracking cookie already set, do nothing.
  *  - Otherwise, generate a new uuid and set a tracking cookie.
  */
-export const updateTrackId: UpdateTrackId = (options: TrackOpts) => (
+export const updateId: UpdateId = cookieName => (
 	request: Object,
 	doRefresh: ?boolean
 ) => {
-	const { trackIdCookieName } = options;
-	let trackId: string = request.state[trackIdCookieName];
+	let id: string =
+		request.state[cookieName] || // cookie in original request
+		request.plugins[ACTIVITY_PLUGIN_NAME][cookieName]; // cookie added to outgoing response
 
-	if (!trackId || doRefresh) {
-		// Generate a new trackId value and store in request. Cookie will be
+	if (!id || doRefresh) {
+		// Generate a new id value and store in request. Cookie will be
 		// set in the plugin's onResponse handler
-		trackId = uuid.v4();
-		request.plugins[ACTIVITY_PLUGIN_NAME].trackId = trackId;
+		return newId(cookieName)(request);
 	}
-	return trackId;
+	return id;
 };
 
 /*
@@ -32,8 +33,14 @@ export const updateTrackId: UpdateTrackId = (options: TrackOpts) => (
  * A corresponding cookie will be set in the plugin's onResponse handler in
  * order to share the session cookie across browser tabs.
  */
-export const newSessionId: Object => string = request => {
-	const sessionId: string = uuid.v4();
-	request.plugins[ACTIVITY_PLUGIN_NAME].sessionId = sessionId;
-	return sessionId;
+export const newId = (cookieName: string) => (request: HapiRequest): string => {
+	const id: string = uuid.v4();
+	request.plugins[ACTIVITY_PLUGIN_NAME][cookieName] = makeIdCookie(id);
+	return id;
+};
+
+export const makeIdCookie = (id: string) => `id=${id}`;
+export const parseIdCookie = (cookieVal: string, doParseInt?: boolean) => {
+	const parsed = querystring.parse(cookieVal);
+	return doParseInt ? parseInt(parsed.id, 10) || 0 : parsed.id;
 };

--- a/src/plugins/tracking/util/idUtils.js
+++ b/src/plugins/tracking/util/idUtils.js
@@ -5,12 +5,7 @@ import { ACTIVITY_PLUGIN_NAME } from '../activity';
 
 type UpdateId = string => (Object, ?boolean) => string;
 /*
- * Initialize the trackId for member or anonymous user - the longest-living id
- * we can assign to a user. Stays in place until login or logout, when it is
- * exchanged for a new trackId
- *
- *  - If the user has a tracking cookie already set, do nothing.
- *  - Otherwise, generate a new uuid and set a tracking cookie.
+ * This is a 'get or set' function for the `cookieName` passed in.
  */
 export const updateId: UpdateId = cookieName => (
 	request: Object,
@@ -29,9 +24,9 @@ export const updateId: UpdateId = cookieName => (
 };
 
 /*
- * This function creates a new browser session id and stores it in the request.
- * A corresponding cookie will be set in the plugin's onResponse handler in
- * order to share the session cookie across browser tabs.
+ * This function creates a new uuid and stores it in the request using a
+ * `cookieName` key. The actual cookie will be set in the plugin's `onResponse`
+ * handler in order to share the cookie across browser tabs.
  */
 export const newId = (cookieName: string) => (request: HapiRequest): string => {
 	const id: string = uuid.v4();

--- a/src/plugins/tracking/util/idUtils.js
+++ b/src/plugins/tracking/util/idUtils.js
@@ -16,16 +16,16 @@ export const updateId: UpdateId = cookieName => (
 	request: Object,
 	doRefresh: ?boolean
 ) => {
-	let id: string =
+	let cookieVal: string =
 		request.state[cookieName] || // cookie in original request
 		request.plugins[ACTIVITY_PLUGIN_NAME][cookieName]; // cookie added to outgoing response
 
-	if (!id || doRefresh) {
+	if (!cookieVal || doRefresh) {
 		// Generate a new id value and store in request. Cookie will be
 		// set in the plugin's onResponse handler
 		return newId(cookieName)(request);
 	}
-	return id;
+	return parseIdCookie(cookieVal).toString(); // toString used to satisfy Flow
 };
 
 /*
@@ -41,6 +41,10 @@ export const newId = (cookieName: string) => (request: HapiRequest): string => {
 
 export const makeIdCookie = (id: string) => `id=${id}`;
 export const parseIdCookie = (cookieVal: string, doParseInt?: boolean) => {
-	const parsed = querystring.parse(cookieVal);
-	return doParseInt ? parseInt(parsed.id, 10) || 0 : parsed.id;
+	const parsed: { id: string } = querystring.parse(cookieVal) || { id: '' };
+	parsed.id = parsed.id || '';
+	if (doParseInt) {
+		return parseInt(parsed.id, 10) || 0;
+	}
+	return parsed.id;
 };

--- a/src/store/server/fetchQueries.test.js
+++ b/src/store/server/fetchQueries.test.js
@@ -12,7 +12,7 @@ describe('serverFetchQueries', () => {
 				require('rxjs/add/observable/of');
 				return Observable.of('response');
 			}),
-			trackApi: jest.fn(),
+			trackActivity: jest.fn(),
 		};
 		const queries = [];
 		const expectedParsedResponse = 'foo';

--- a/src/util/testUtils.js
+++ b/src/util/testUtils.js
@@ -69,8 +69,7 @@ export const getServer = () => {
 		request => () => Observable.of(request),
 		{ apply: true }
 	);
-	server.decorate('request', 'trackApi', () => ({}));
-	server.decorate('request', 'trackSession', () => ({}));
+	server.decorate('request', 'trackActivity', () => ({}));
 	server.decorate('request', 'getLangPrefixPath', () => '/');
 	server.decorate('request', 'getLanguage', () => 'en-US');
 	server.logger = () => MOCK_LOGGER;


### PR DESCRIPTION
This PR probably looks much more complicated than necessary to add browser ID tracking, BUT I went ahead and did a significant refactor because there was some legacy 'session id' behavior that I had left in place from an early iteration of the code that is no longer necessary, and made the 'browser id' behavior more difficult to define.