### PR TITLE
side effect .rewind() tests

### DIFF
--- a/tests/integration/sideEffect.int.js
+++ b/tests/integration/sideEffect.int.js
@@ -1,0 +1,60 @@
+import Helmet from 'react-helmet';
+import { getMockRenderRequestMap } from '../mocks';
+import start from '../../src/server';
+import { Forbidden, NotFound, Redirect } from '../../src/router';
+
+Forbidden.rewind = jest.fn(Forbidden.rewind);
+NotFound.rewind = jest.fn(NotFound.rewind);
+Redirect.rewind = jest.fn(Redirect.rewind);
+Helmet.rewind = jest.fn(Helmet.rewind);
+
+const testSideEffectError = (Component, name) =>
+	start(getMockRenderRequestMap(), {}).then(server => {
+		const request = {
+			method: 'get',
+			url: `/badImplementation?${name}`,
+			credentials: 'whatever',
+		};
+		return server
+			.inject(request)
+			.then(response => {
+				expect(Component.rewind).toHaveBeenCalled();
+			})
+			.then(() => server.stop())
+			.catch(err => {
+				server.stop();
+				throw err;
+			});
+	});
+
+describe('rewind behavior', () => {
+	it('rewind() for all side effect components for normal server render', () =>
+		start(getMockRenderRequestMap(), {}).then(server => {
+			const request = {
+				method: 'get',
+				url: '/foo',
+				credentials: 'whatever',
+			};
+			return server
+				.inject(request)
+				.then(() => {
+					expect(Forbidden.rewind).toHaveBeenCalled();
+					expect(NotFound.rewind).toHaveBeenCalled();
+					expect(Redirect.rewind).toHaveBeenCalled();
+					expect(Helmet.rewind).toHaveBeenCalled();
+				})
+				.then(() => server.stop())
+				.catch(err => {
+					server.stop();
+					throw err;
+				});
+		}));
+	it('calls Helmet.rewind when Helmet is called with invalid content', () =>
+		testSideEffectError(Helmet, 'helmet'));
+	it('calls Forbidden.rewind when Forbidden is called with invalid content', () =>
+		testSideEffectError(Forbidden, 'forbidden'));
+	it('calls Redirect.rewind when Redirect is called with invalid content', () =>
+		testSideEffectError(Redirect, 'redirect'));
+	it('calls NotFound.rewind when NotFound is called with invalid content', () =>
+		testSideEffectError(NotFound, 'notfound'));
+});

--- a/tests/integration/sideEffect.int.js
+++ b/tests/integration/sideEffect.int.js
@@ -18,6 +18,7 @@ const testSideEffectError = (Component, name) =>
 		return server
 			.inject(request)
 			.then(response => {
+				expect(response.statusCode === 500);
 				expect(Component.rewind).toHaveBeenCalled();
 			})
 			.then(() => server.stop())

--- a/tests/mockApp.jsx
+++ b/tests/mockApp.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Helmet from 'react-helmet';
 import makeRootReducer from '../src/store/reducer';
-import { Redirect } from '../src/router';
+import { Forbidden, NotFound, Redirect } from '../src/router';
 
 export const clientFilename = 'client.whatever.js';
 export const assetPublicPath = '//whatever';
@@ -70,7 +70,35 @@ export const routes = [
 			},
 			{
 				path: '/badImplementation',
-				component: () => {
+				component: props => {
+					// use querystring to render 'bad' implementations
+					if (props.location.search.endsWith('forbidden')) {
+						// multiple child components not allowed
+						return (
+							<Forbidden>
+								<div />
+								<div />
+							</Forbidden>
+						);
+					}
+					if (props.location.search.endsWith('redirect')) {
+						// multiple child components not allowed
+						return (
+							<Redirect>
+								<div />
+								<div />
+							</Redirect>
+						);
+					}
+					if (props.location.search.endsWith('notfound')) {
+						// multiple child components not allowed
+						return (
+							<NotFound>
+								<div />
+								<div />
+							</NotFound>
+						);
+					}
 					/*
 					 * the `property` prop for `meta` must be a string in order for
 					 * <Helmet> to process it correctly - this is a 'bad implementation'

--- a/tests/mocks.js
+++ b/tests/mocks.js
@@ -39,10 +39,11 @@ export const getMockRenderRequestMap = () => {
 	const renderRequest$ = makeRenderer(
 		routes,
 		reducer,
-		clientFilename,
+		undefined,
 		assetPublicPath,
 		[],
-		basename
+		basename,
+		[`${assetPublicPath}${clientFilename}`]
 	);
 
 	return {


### PR DESCRIPTION
This ensures that our current `react-side-effect` components get cleaned up correctly both in a 'normal' render case _and_ when there is an error in one of them.