### PR TITLE
Turn fastly-client-ip header into X-Meetup-Client-Ip header.

### DIFF
--- a/src/plugins/api-proxy/util/send.js
+++ b/src/plugins/api-proxy/util/send.js
@@ -170,11 +170,19 @@ export function getLanguageHeader(request) {
 	return acceptLang;
 }
 
+export function getClientIpHeader(request) {
+	const clientIP = request.headers['fastly-client-ip'];
+	if (clientIP) {
+		return { 'X-Meetup-Client-Ip': clientIP };
+	}
+}
+
 export function parseRequestHeaders(request) {
 	const externalRequestHeaders = {
 		...request.headers,
 		...getAuthHeaders(request),
 		'accept-language': getLanguageHeader(request),
+		...getClientIpHeader(request),
 	};
 
 	delete externalRequestHeaders['host']; // let app server set 'host'

--- a/src/plugins/api-proxy/util/send.test.js
+++ b/src/plugins/api-proxy/util/send.test.js
@@ -16,6 +16,7 @@ import {
 	getAuthHeaders,
 	getExternalRequestOpts,
 	getLanguageHeader,
+	getClientIpHeader,
 	parseMultipart,
 	API_META_HEADER,
 } from './send';
@@ -63,6 +64,27 @@ describe('getAuthHeaders', () => {
 		expect(cookies['MEETUP_CSRF']).not.toBeUndefined();
 		expect(cookies['MEETUP_CSRF_DEV']).not.toBeUndefined();
 		expect(authHeaders['csrf-token']).toEqual(cookies['MEETUP_CSRF']);
+	});
+});
+
+describe('getClientIpHeader', () => {
+	it('returns a x-meetup-client-ip header when a fastly-client-ip header is set', () => {
+		const clientIpHeader = {
+			'X-Meetup-Client-Ip': '127.0.0.1',
+		};
+		const request = {
+			headers: {
+				'fastly-client-ip': '127.0.0.1',
+			},
+		};
+		expect(getClientIpHeader(request)).toEqual(clientIpHeader);
+	});
+
+	it('Does not set the header if fastly-client-ip is not set', () => {
+		const request = {
+			headers: {},
+		};
+		expect(getClientIpHeader(request)).toBeUndefined();
 	});
 });
 


### PR DESCRIPTION
This just sets a `X-Meetup-Client-Ip` header from a `fastly-client-ip` header.

Unfortunately we can't rely on passing through `fastly-client-ip`, because we pass through fastly again when we call api.meetup.com (so this header gets reset, I assume, before it hits api.meetup.com).