### PR TITLE
log the unencoded tracking data along with encoded

### DIFF
--- a/src/plugins/tracking/util/avro.js
+++ b/src/plugins/tracking/util/avro.js
@@ -141,7 +141,7 @@ const serializers = {
 	click: avroSerializer(schemas.click),
 };
 const deserializers = {
-	avro: avroSerializer,
+	avro: avroDeserializer,
 	activity: avroDeserializer(schemas.activity),
 	click: avroDeserializer(schemas.click),
 };

--- a/src/plugins/tracking/util/avro.test.js
+++ b/src/plugins/tracking/util/avro.test.js
@@ -40,6 +40,28 @@ describe('serializers.avro', () => {
 	});
 });
 
+describe('deserializers.avro', () => {
+	it('decodes an encoded record of provided schema', () => {
+		const schema = {
+			type: 'record',
+			fields: [
+				{ name: 'requestId', type: 'string' },
+				{ name: 'timestamp', type: 'string' },
+			],
+		};
+		const data = {
+			requestId: 'foo',
+			timestamp: new Date().getTime().toString(),
+		};
+
+		const serializer = avro.serializers.avro(schema);
+		const deserializer = avro.deserializers.avro(schema);
+		const serialized = serializer(data);
+		const deserialized = deserializer(serialized);
+		expect(deserialized).toEqual(data);
+	});
+});
+
 describe('Activity tracking', () => {
 	const request = {
 		id: 'foo',


### PR DESCRIPTION
This PR is important for helping us diagnose some odd data in the activity tracking logs - in addition to the 'standard' logging behavior that sends a serialized (encoded+stringified) data to Google PubSub in prod, the system will also then _deserialize_ that data and print it to stdout so that we can be more certain of the message content that is being sent through pubsub.

In dev, we will also be able to see the encoded + unencoded data in the server logs.