### PR TITLE
Suppress 400 errors

### DIFF
--- a/src/plugins/api-proxy/util/receive.js
+++ b/src/plugins/api-proxy/util/receive.js
@@ -196,14 +196,11 @@ export const makeLogResponse = request => ([response, body]) => {
 		statusCode >= 500 || // REST API had an internal error
 		(method.toLowerCase() === 'get' && statusCode >= 400) // something fishy with a GET
 	) {
-		// use console.error to highlight these cases in Stackdriver
-		if (
-			statusCode === 400 &&
-			(pathname === '/members/self' || pathname === '/members/home')
-		) {
+		if (statusCode === 400) {
 			console.info(`swallowing 400 error for ${pathname}`);
 			return;
 		}
+		// use console.error to highlight these cases in Stackdriver
 		console.error(
 			JSON.stringify({
 				message: 'REST API error response',

--- a/src/plugins/api-proxy/util/receive.js
+++ b/src/plugins/api-proxy/util/receive.js
@@ -197,6 +197,13 @@ export const makeLogResponse = request => ([response, body]) => {
 		(method.toLowerCase() === 'get' && statusCode >= 400) // something fishy with a GET
 	) {
 		// use console.error to highlight these cases in Stackdriver
+		if (
+			statusCode === 400 &&
+			(pathname === '/members/self' || pathname === '/members/home')
+		) {
+			console.info(`swallowing 400 error for ${pathname}`);
+			return;
+		}
 		console.error(
 			JSON.stringify({
 				message: 'REST API error response',


### PR DESCRIPTION
Not logging an error for 400 errors right now. They all seem related to auth, and they don't seem to break anything (other than alert us), and we are gonna be making a lot of these happen soon.