### PR TITLE
allow CSS head tags to be passed into server-side render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [7.1]
+
+- **Feature**: Pass in an array of string `cssLinks` to `makeServerRenderer$` in
+  order to add static CSS `<link>` tags to the document `<head>`. These tags
+  will not be affected by `<link>`s defined within `<Helmet>` tags of the
+  application, and therefore will not be subject to being clobbered by
+  client-side rendering that will cause a FOUC (as described in
+  [this react-helmet issue](https://github.com/nfl/react-helmet/issues/98)).
+
+  **Important**: The consumer application must ensure that the CSS _files_ are
+  bundled with the browser application script as well, even though the links
+  themselves are not required by the browser app renderer.
+
 ## [7.0]
 
 ### BREAKING CHANGES

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CI_BUILD_NUMBER ?= $(USER)-snapshot
-VERSION ?= 7.0.$(CI_BUILD_NUMBER)
+VERSION ?= 7.1.$(CI_BUILD_NUMBER)
 
 version:
 	@echo $(VERSION)

--- a/src/render/components/Dom.jsx
+++ b/src/render/components/Dom.jsx
@@ -36,7 +36,7 @@ const DOM = props => {
 		head,
 		initialState = {},
 		scripts,
-		globalHead,
+		cssLinks,
 	} = props;
 
 	/**
@@ -60,11 +60,14 @@ const DOM = props => {
 	return (
 		<html>
 			<head>
-				{globalHead}
 				{head.title.toComponent()}
 				{head.meta.toComponent()}
 				{head.link.toComponent()}
 				{head.script.toComponent()}
+				{cssLinks &&
+					cssLinks.map((href, key) =>
+						<link rel="stylesheet" type="text/css" href={href} key={key} />
+					)}
 			</head>
 			<body>
 				<div id="outlet" dangerouslySetInnerHTML={getInnerHTML(appMarkup)} />
@@ -92,7 +95,7 @@ DOM.propTypes = {
 	}),
 	initialState: PropTypes.object.isRequired,
 	scripts: PropTypes.array.isRequired,
-	globalHead: PropTypes.arrayOf(PropTypes.node),
+	cssLinks: PropTypes.arrayOf(PropTypes.string),
 };
 
 export default DOM;

--- a/src/render/components/Dom.jsx
+++ b/src/render/components/Dom.jsx
@@ -36,6 +36,7 @@ const DOM = props => {
 		head,
 		initialState = {},
 		scripts,
+		globalHead,
 	} = props;
 
 	/**
@@ -59,6 +60,7 @@ const DOM = props => {
 	return (
 		<html>
 			<head>
+				{globalHead}
 				{head.title.toComponent()}
 				{head.meta.toComponent()}
 				{head.link.toComponent()}
@@ -90,6 +92,7 @@ DOM.propTypes = {
 	}),
 	initialState: PropTypes.object.isRequired,
 	scripts: PropTypes.array.isRequired,
+	globalHead: PropTypes.arrayOf(PropTypes.node),
 };
 
 export default DOM;

--- a/src/renderers/server-render.jsx
+++ b/src/renderers/server-render.jsx
@@ -86,6 +86,7 @@ const getRouterRenderer = ({
 	baseUrl,
 	assetPublicPath,
 	scripts,
+	globalHead,
 }): RenderResult => {
 	// pre-render the app-specific markup, this is the string of markup that will
 	// be managed by React on the client.
@@ -133,6 +134,7 @@ const getRouterRenderer = ({
 			initialState={initialState}
 			appMarkup={appMarkup}
 			scripts={scripts}
+			globalHead={globalHead}
 		/>
 	);
 
@@ -153,6 +155,7 @@ const makeRenderer$ = (renderConfig: {
 	baseUrl: string,
 	scripts: Array<string>,
 	enableServiceWorker: boolean,
+	globalHead: ?Array<React$Element>,
 }) =>
 	makeRenderer(
 		renderConfig.routes,
@@ -162,7 +165,8 @@ const makeRenderer$ = (renderConfig: {
 		renderConfig.middleware,
 		renderConfig.baseUrl,
 		renderConfig.scripts,
-		renderConfig.enableServiceWorker
+		renderConfig.enableServiceWorker,
+		renderConfig.globalHead
 	);
 
 /**
@@ -192,7 +196,8 @@ const makeRenderer = (
 	middleware: Array<Function> = [],
 	baseUrl: string = '',
 	scripts: Array<string> = [],
-	enableServiceWorker: boolean
+	enableServiceWorker: boolean,
+	globalHead: ?Array<React$Element>
 ) => (request: Object) => {
 	middleware = middleware || [];
 
@@ -255,6 +260,7 @@ const makeRenderer = (
 					head={Helmet.rewind()}
 					initialState={store.getState()}
 					scripts={scripts}
+					globalHead={globalHead}
 				/>
 			),
 			statusCode: 200,
@@ -284,6 +290,7 @@ const makeRenderer = (
 			baseUrl,
 			assetPublicPath,
 			scripts,
+			globalHead,
 		})
 	);
 };

--- a/src/renderers/server-render.jsx
+++ b/src/renderers/server-render.jsx
@@ -86,7 +86,7 @@ const getRouterRenderer = ({
 	baseUrl,
 	assetPublicPath,
 	scripts,
-	globalHead,
+	cssLinks,
 }): RenderResult => {
 	// pre-render the app-specific markup, this is the string of markup that will
 	// be managed by React on the client.
@@ -134,7 +134,7 @@ const getRouterRenderer = ({
 			initialState={initialState}
 			appMarkup={appMarkup}
 			scripts={scripts}
-			globalHead={globalHead}
+			cssLinks={cssLinks}
 		/>
 	);
 
@@ -155,7 +155,7 @@ const makeRenderer$ = (renderConfig: {
 	baseUrl: string,
 	scripts: Array<string>,
 	enableServiceWorker: boolean,
-	globalHead: ?Array<React$Element>,
+	cssLinks: ?Array<string>,
 }) =>
 	makeRenderer(
 		renderConfig.routes,
@@ -166,7 +166,7 @@ const makeRenderer$ = (renderConfig: {
 		renderConfig.baseUrl,
 		renderConfig.scripts,
 		renderConfig.enableServiceWorker,
-		renderConfig.globalHead
+		renderConfig.cssLinks
 	);
 
 /**
@@ -197,7 +197,7 @@ const makeRenderer = (
 	baseUrl: string = '',
 	scripts: Array<string> = [],
 	enableServiceWorker: boolean,
-	globalHead: ?Array<React$Element>
+	cssLinks: ?Array<string>
 ) => (request: Object) => {
 	middleware = middleware || [];
 
@@ -260,7 +260,7 @@ const makeRenderer = (
 					head={Helmet.rewind()}
 					initialState={store.getState()}
 					scripts={scripts}
-					globalHead={globalHead}
+					cssLinks={cssLinks}
 				/>
 			),
 			statusCode: 200,
@@ -290,7 +290,7 @@ const makeRenderer = (
 			baseUrl,
 			assetPublicPath,
 			scripts,
-			globalHead,
+			cssLinks,
 		})
 	);
 };


### PR DESCRIPTION
Rendering `<head>` tags _without_ React-Helmet avoids the problem of Helmet 'clobbering' SSR tags, a problem described in https://github.com/nfl/react-helmet/issues/98 that causes a FOUC for `<link rel='stylesheet' ... />` tags.

This PR updates the server renderer to accept an array of strings corresponding to the `href` of CSS `<link>` tags. These strings will be used to create 'static' `<link>` elements in the document `<head>` that will not be affected by the client application render.