### PR TITLE
Ensure that already-encoded UTF-8 endpoints don't get double-encoded

### DIFF
--- a/packages/mwp-api-proxy-plugin/src/util/send.js
+++ b/packages/mwp-api-proxy-plugin/src/util/send.js
@@ -85,7 +85,8 @@ export const buildRequestArgs = externalRequestOpts => ({
 }) => {
 	const dataParams = querystring.stringify(params);
 	const headers = { ...externalRequestOpts.headers };
-	let url = encodeURI(`/${endpoint}`);
+	// endpoint may or may not be URI-encoded, so we decode before encoding
+	let url = encodeURI(`/${decodeURI(endpoint)}`);
 	let body;
 	const jar = createCookieJar(url);
 

--- a/packages/mwp-api-proxy-plugin/src/util/send.test.js
+++ b/packages/mwp-api-proxy-plugin/src/util/send.test.js
@@ -205,7 +205,6 @@ describe('buildRequestArgs', () => {
 	});
 
 	const testQueryResults_utf8 = mockQuery(MOCK_RENDERPROPS_UTF8);
-
 	it('Properly encodes the URL', () => {
 		const method = 'get';
 		const getArgs = buildRequestArgs({ ...options, method })(
@@ -213,6 +212,16 @@ describe('buildRequestArgs', () => {
 		);
 		const { pathname } = require('url').parse(getArgs.url);
 		expect(/^[\x00-\xFF]*$/.test(pathname)).toBe(true); // eslint-disable-line no-control-regex
+	});
+	it('Does not double-encode the URL', () => {
+		const method = 'get';
+		const decodedQuery = {
+			endpoint: encodeURI('バ-京'), // 'pre-encode' the endpoint
+			params: {},
+		};
+		const getArgs = buildRequestArgs({ ...options, method })(decodedQuery);
+		const { pathname } = require('url').parse(getArgs.url);
+		expect(pathname).toBe(`/${decodedQuery.endpoint}`); // eslint-disable-line no-control-regex
 	});
 });
 


### PR DESCRIPTION
If we decode the endpoint before encoding, we can be sure that it is correctly 'single-encoded'