### PR TITLE
logging improvements across the board

### DIFF
--- a/packages/mwp-api-proxy-plugin/src/index.js
+++ b/packages/mwp-api-proxy-plugin/src/index.js
@@ -16,16 +16,10 @@ const onResponse = request => {
 	const { uploads } = request.plugins[API_PROXY_PLUGIN_NAME];
 	const { logger } = request.server.app;
 	if (uploads.length) {
-		const info = { info: uploads, req: request.raw.req };
 		// $FlowFixMe - promisify not yet defined in flow-typed
-		Promise.all(uploads.map(util.promisify(fs.unlink))).then(
-			() => {
-				logger.info(info, 'Deleted uploaded file(s)');
-			},
-			err => {
-				logger.error(info, 'Could not delete uploaded file(s)');
-			}
-		);
+		Promise.all(uploads.map(util.promisify(fs.unlink))).catch(err => {
+			logger.error({ err, uploads, ...request.raw });
+		});
 	}
 };
 

--- a/packages/mwp-api-proxy-plugin/src/util/send.js
+++ b/packages/mwp-api-proxy-plugin/src/util/send.js
@@ -276,16 +276,11 @@ export const makeExternalApiRequest = request => requestOpts => {
 			// log errors
 			null,
 			err => {
-				console.error(
-					JSON.stringify({
-						err: err.stack,
-						message: 'REST API request error',
-						request: {
-							id: request.id,
-						},
-						context: requestOpts,
-					})
-				);
+				request.server.app.logger.error({
+					err,
+					externalRequest: requestOpts,
+					...request.raw,
+				});
 			}
 		)
 		.timeout(request.server.settings.app.api.timeout)

--- a/packages/mwp-app-server/src/index.js
+++ b/packages/mwp-app-server/src/index.js
@@ -48,6 +48,9 @@ export default function start(
 				'electrode-csrf-jwt': {
 					enabled: false,
 				},
+				'mwp-logger-plugin': {
+					enabled: true,
+				},
 			},
 		},
 	};

--- a/packages/mwp-app-server/src/routes/index.js
+++ b/packages/mwp-app-server/src/routes/index.js
@@ -3,7 +3,14 @@ export default function getRoutes() {
 		path: '/ping',
 		method: 'GET',
 		handler: (request, reply) => reply('pong!'),
-		config: { auth: false },
+		config: {
+			auth: false,
+			plugins: {
+				'mwp-logger-plugin': {
+					enabled: false,
+				},
+			},
+		},
 	};
 
 	// simple 200 response for all lifecycle requests
@@ -11,7 +18,14 @@ export default function getRoutes() {
 	const appEngineLifecycleRoutes = {
 		method: 'GET',
 		path: '/_ah/{param*}',
-		config: { auth: false },
+		config: {
+			auth: false,
+			plugins: {
+				'mwp-logger-plugin': {
+					enabled: false,
+				},
+			},
+		},
 		handler: (request, reply) => {
 			if (request.params.param === 'error') {
 				throw new Error('Simulated error via url');

--- a/packages/mwp-app-server/src/util/index.js
+++ b/packages/mwp-app-server/src/util/index.js
@@ -23,51 +23,8 @@ export function checkForDevUrl(value) {
 }
 
 export function onRequestExtension(request, reply) {
-	request.id = uuid.v4();
-
-	request.server.app.logger.info(
-		`Incoming request ${request.method.toUpperCase()} ${request.url.href}`
-	);
-
+	request.id = uuid.v4(); // provide uuid for request instead of default Hapi id
 	return reply.continue();
-}
-
-export function logResponse(request) {
-	const {
-		method,
-		response,
-		id,
-		info,
-		server: { app: { logger } },
-		url,
-	} = request;
-
-	if (response.isBoom) {
-		// response is an Error object
-		logger.error(`Internal error ${response.message} ${url.pathname}`, {
-			error: response.stack,
-		});
-	}
-
-	const log = ((response.statusCode >= 400 && logger.error) ||
-		(response.statusCode >= 300 && logger.warn) ||
-		logger.info)
-		.bind(logger);
-
-	log(
-		{
-			headers: response.headers,
-			id,
-			method,
-			referrer: info.referrer,
-			remoteAddress: info.remoteAddress,
-			elapsedTime: info.responded - info.received,
-			href: url.href,
-		},
-		`Outgoing response ${method.toUpperCase()} ${url.pathname} ${response.statusCode}`
-	);
-
-	return;
 }
 
 /**
@@ -83,7 +40,6 @@ export function registerExtensionEvents(server) {
 			method: onRequestExtension,
 		},
 	]);
-	server.on('response', logResponse);
 	return server;
 }
 

--- a/packages/mwp-app-server/src/util/index.test.js
+++ b/packages/mwp-app-server/src/util/index.test.js
@@ -83,35 +83,4 @@ describe('onRequestExtension', () => {
 		serverUtils.onRequestExtension(request, reply);
 		expect(reply.continue).toHaveBeenCalled();
 	});
-
-	it('calls console.log with request headers and id', () => {
-		const reply = {
-			continue: () => {},
-		};
-		MOCK_LOGGER.info.mockClear();
-		serverUtils.onRequestExtension(request, reply);
-		const calledWith = MOCK_LOGGER.info.mock.calls[0][0];
-		expect(calledWith).toEqual(expect.stringContaining(request.url.href));
-	});
-});
-
-describe('logResponse', () => {
-	const request = {
-		headers: 'foo',
-		id: 'bar',
-		method: 'get',
-		info: {},
-		url: {},
-		response: {
-			headers: { foo: 'bar' },
-		},
-		server: getServer(),
-	};
-
-	it('calls console.log with response headers and request id', () => {
-		MOCK_LOGGER.info.mockClear();
-		serverUtils.logResponse(request);
-		const [data] = MOCK_LOGGER.info.mock.calls[0];
-		expect(data).toEqual(expect.any(Object));
-	});
 });

--- a/packages/mwp-logger-plugin/package.json
+++ b/packages/mwp-logger-plugin/package.json
@@ -25,7 +25,8 @@
   "homepage": "https://github.com/meetup/meetup-web-platform#readme",
   "dependencies": {
     "@google-cloud/logging-bunyan": "0.5.0",
-    "bunyan": "1.8.12"
+    "bunyan": "1.8.12",
+    "bunyan-debug-stream": "1.0.8"
   },
   "devDependencies": {
     "babel-jest": "21.0.0",

--- a/packages/mwp-logger-plugin/src/index.js
+++ b/packages/mwp-logger-plugin/src/index.js
@@ -25,6 +25,7 @@ export function logResponse(request) {
 	return;
 }
 
+// this might be redundant with the `logResponse` behavior
 const onRequestError = (request, err) => {
 	logger.error({
 		err,
@@ -32,17 +33,17 @@ const onRequestError = (request, err) => {
 	});
 };
 
-export default function register(server, options, next) {
-	// might also want to add default logging for 'onPostStart', 'onPostStop',
-	//'response' in the future
-	const onRequestExtension = (request, reply) => {
-		logger.debug({
-			httpRequest: request,
-			...request.raw,
-		});
-		return reply.continue();
-	};
+const onRequestExtension = (request, reply) => {
+	// log at debug level to make it easy to filter out
+	logger.debug({
+		httpRequest: request,
+		...request.raw,
+	});
+	return reply.continue();
+};
 
+export default function register(server, options, next) {
+	// might also want to add default logging for 'onPostStart', 'onPostStop'
 	server.ext([
 		{
 			type: 'onRequest',

--- a/packages/mwp-logger-plugin/src/index.js
+++ b/packages/mwp-logger-plugin/src/index.js
@@ -1,19 +1,56 @@
 import logger from './logger';
 
-const onRequestError = (request, err) => {
-	logger.error(
-		{
-			err,
+export function logResponse(request) {
+	const { response, id, server: { app: { logger } } } = request;
+
+	if (response.isBoom) {
+		// response is an Error object
+		logger.error({
+			err: response,
 			...request.raw,
-		},
-		`500 Internal server error: ${err.message}`
-	);
+		});
+	}
+
+	const log = ((response.statusCode >= 500 && logger.error) ||
+		(response.statusCode >= 400 && logger.warn) ||
+		logger.info)
+		.bind(logger);
+
+	const routePluginSettings =
+		request.route.settings.plugins['mwp-logger-plugin'];
+	if (!routePluginSettings || routePluginSettings.enabled) {
+		log({ httpRequest: request, id });
+	}
+
+	return;
+}
+
+const onRequestError = (request, err) => {
+	logger.error({
+		err,
+		...request.raw,
+	});
 };
 
 export default function register(server, options, next) {
 	// might also want to add default logging for 'onPostStart', 'onPostStop',
 	//'response' in the future
+	const onRequestExtension = (request, reply) => {
+		logger.debug({
+			httpRequest: request,
+			...request.raw,
+		});
+		return reply.continue();
+	};
+
+	server.ext([
+		{
+			type: 'onRequest',
+			method: onRequestExtension,
+		},
+	]);
 	server.on('request-error', onRequestError);
+	server.on('response', logResponse);
 	server.app.logger = logger;
 
 	next();

--- a/packages/mwp-logger-plugin/src/logger.js
+++ b/packages/mwp-logger-plugin/src/logger.js
@@ -1,12 +1,55 @@
 import bunyan from 'bunyan';
+import bunyanDebugStream from 'bunyan-debug-stream';
 import LoggingBunyan from '@google-cloud/logging-bunyan';
 
-const streams = [{ stream: process.stdout }]; // stdout by default
-const { GAE_INSTANCE, GCLOUD_PROJECT, GAE_VERSION, GAE_SERVICE } = process.env;
+const formatDuration = ms => {
+	const seconds = Math.floor(ms / 1000);
+	const nanos = ms % 1000 * 1000 * 1000;
+	return {
+		seconds,
+		nanos,
+	};
+};
+
+const serializers = {
+	...bunyan.stdSerializers,
+};
+serializers.httpRequest = request => {
+	const requestInfo = {
+		requestMethod: request.method.toUpperCase(),
+		requestUrl: request.url.href,
+		requestSize: request.headers['content-length'],
+		userAgent: request.headers['user-agent'],
+		remoteIp: request.info.remoteAddress,
+		serverIp: request.server.info.address, // internal IP
+		referer: request.info.referrer,
+	};
+	if (request.response) {
+		requestInfo.responseSize = request.response.headers['content-length'];
+		requestInfo.status = request.response.statusCode;
+		requestInfo.latency = formatDuration(
+			request.info.responded - request.info.received
+		);
+	}
+	return requestInfo;
+};
+
+const streams = []; // stdout by default
+const {
+	NODE_ENV,
+	GAE_INSTANCE,
+	GCLOUD_PROJECT,
+	GAE_VERSION,
+	GAE_SERVICE,
+} = process.env;
+if (!NODE_ENV || NODE_ENV === 'development') {
+	streams.push({
+		type: 'raw',
+		stream: bunyanDebugStream({ forceColor: true, basepath: process.cwd() }),
+	});
+}
+
 if (GAE_INSTANCE) {
-	console.log(
-		`Activating GAE logging for ${GCLOUD_PROJECT} - ${GAE_SERVICE} v${GAE_VERSION}`
-	);
 	streams.push(
 		LoggingBunyan({
 			resource: {
@@ -21,10 +64,18 @@ if (GAE_INSTANCE) {
 	);
 }
 
+if (
+	streams.length === 0 &&
+	(NODE_ENV !== 'test' || process.argv.includes('--verbose'))
+) {
+	// fallback if no stream specified
+	streams.push({ stream: process.stdout });
+}
+
 const logger = bunyan.createLogger({
 	name: 'mwp-logger',
 	logName: 'mwp-log',
-	serializers: bunyan.stdSerializers,
+	serializers,
 	streams,
 });
 

--- a/packages/mwp-logger-plugin/yarn.lock
+++ b/packages/mwp-logger-plugin/yarn.lock
@@ -546,6 +546,13 @@ builtin-modules@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
+bunyan-debug-stream@1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/bunyan-debug-stream/-/bunyan-debug-stream-1.0.8.tgz#df612852d5d0b6d6df3f30214d8a7e4ee925106d"
+  dependencies:
+    colors "^1.0.3"
+    exception-formatter "^1.0.4"
+
 bunyan@1.8.12:
   version "1.8.12"
   resolved "https://registry.yarnpkg.com/bunyan/-/bunyan-1.8.12.tgz#f150f0f6748abdd72aeae84f04403be2ef113797"
@@ -660,6 +667,10 @@ color-convert@^1.9.0:
 color-name@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
+
+colors@^1.0.3:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
 
 colour@~0.7.1:
   version "0.7.1"
@@ -882,6 +893,12 @@ eventid@^0.1.0:
   dependencies:
     d64 "^1.0.0"
     uuid "^3.0.1"
+
+exception-formatter@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/exception-formatter/-/exception-formatter-1.0.5.tgz#bda957319789cbabdf36848fb5288c59634b73a5"
+  dependencies:
+    colors "^1.0.3"
 
 exec-sh@^0.2.0:
   version "0.2.1"


### PR DESCRIPTION
This addresses a number of logging updates/improvements:

1. https://meetup.atlassian.net/browse/WP-518
   - adding an `httpRequest` property to the log so that response logs will highlight
      - request method
      - statusCode
      - agent
      - payload size

![screen shot 2017-09-29 at 2 34 22 pm](https://user-images.githubusercontent.com/1885153/30997296-56724c0c-a523-11e7-86d7-9e0b3a4d54ea.png)

2. https://meetup.atlassian.net/browse/WP-525
   - don't log requests to `/ping`
      - can be viewed in the `nginx.request` log
   - don't log requests to `/_ah/health`
      - can be viewed in the `nginx.health_check` log

3. remove the 'incoming request' log
   - this is mainly noise because we are much more interested in response logs

4. Make sure errors are logged correctly using an `err` key, along with the corresponding `req`/`res` info when available. This ensures that errors are captured correctly by the GAE Error Reporting tool and are clearly visible in the regular log viewer

5. Don't log status code 3xx responses with a 'warning' - just 'info'.

6. Integrate a pretty-print stream directly into the logger plugin rather than requiring output to be piped through the `bunyan` CLI in consumer apps (this fixes a bug that prevents testing multiple languages in dev in mup-web currently)