### PR TITLE
Fix failing cleanup for uploaded files

### DIFF
--- a/packages/mwp-api-proxy-plugin/src/index.js
+++ b/packages/mwp-api-proxy-plugin/src/index.js
@@ -1,6 +1,5 @@
 // @flow
 import fs from 'fs';
-import util from 'util';
 import { duotones, getDuotoneUrls } from './util/duotone';
 import getApiProxyRoutes from './routes';
 import proxyApi$ from './proxy';
@@ -15,12 +14,11 @@ export { API_ROUTE_PATH } from './config';
 const onResponse = request => {
 	const { uploads } = request.plugins[API_PROXY_PLUGIN_NAME];
 	const { logger } = request.server.app;
-	if (uploads.length) {
-		// $FlowFixMe - promisify not yet defined in flow-typed
-		Promise.all(uploads.map(util.promisify(fs.unlink))).catch(err => {
-			logger.error({ err, uploads, ...request.raw });
-		});
-	}
+	uploads.forEach(f =>
+		fs.unlink(f, err => {
+			logger.error({ err, f, ...request.raw });
+		})
+	);
 };
 
 export const setPluginState = (request: HapiRequest, reply: HapiReply) => {

--- a/packages/mwp-logger-plugin/README.md
+++ b/packages/mwp-logger-plugin/README.md
@@ -31,7 +31,7 @@ instance can also be imported directly at the cost of function purity and
 slightly more complex unit testing configuration to mock the logger module.
 
 ```js
-import logger from 'mwp-logger-plugin/lib/logger';
+import { logger } from 'mwp-logger-plugin';
 
 function doStuff() {
   logger.info('Hello stuff');


### PR DESCRIPTION
Fixes: https://meetup.atlassian.net/browse/WP-535

TIL: When using `util.promisify`, you _must_ supply a `.then()` handler to each call to the promisified function.

This limitation made it so that `Promise.all` couldn't be used to collect all Promise rejections, so I've just rolled back the `promisify` usage entirely, using the vanilla Node callback syntax instead