### PR TITLE
add query to ref in state, clear response for non-GET queries on nav

### DIFF
--- a/flow-typed/platform.js
+++ b/flow-typed/platform.js
@@ -90,6 +90,7 @@ declare type QueryResponse = {
 	type?: string,
 	flags?: Array<string>,
 	meta?: Object,
+	query?: Query,
 };
 
 declare type QueryFunction = (location: { [string]: mixed }) => Query;

--- a/packages/mwp-api-proxy-plugin/src/proxy.js
+++ b/packages/mwp-api-proxy-plugin/src/proxy.js
@@ -35,7 +35,6 @@ export default (request: HapiRequest) => {
 		);
 
 		// zip them together to make requests in parallel and return responses in order
-		// $FlowFixMe - .zip is not currently defined in Observable static properties
 		return Observable.zip(...apiRequests$).do(request.trackActivity);
 	};
 };

--- a/packages/mwp-api-state/src/reducer.test.js
+++ b/packages/mwp-api-state/src/reducer.test.js
@@ -1,3 +1,4 @@
+import { LOCATION_CHANGE } from 'mwp-router';
 import {
 	DEFAULT_API_STATE,
 	DEFAULT_APP_STATE, // DEPRECATED
@@ -57,6 +58,29 @@ describe('api reducer', () => {
 			inFlight: [ref],
 		});
 	});
+	it('clears refs corresponding to non-GET queries', () => {
+		const bar = {
+			query: {
+				meta: {
+					method: 'post',
+				},
+			},
+		};
+		const baz = {
+			query: {
+				meta: {
+					method: 'get',
+				},
+			},
+		};
+		const populatedState = {
+			...DEFAULT_API_STATE,
+			bar,
+			baz,
+		};
+		const action = { type: LOCATION_CHANGE };
+		expect(api(populatedState, action)).toEqual({ ...DEFAULT_API_STATE, baz });
+	});
 	it('clears refs corresponding to new requests', function() {
 		const ref = 'foobar';
 		const populatedState = {
@@ -74,15 +98,16 @@ describe('api reducer', () => {
 		});
 	});
 	it('adds success response to state tree', () => {
-		const API_RESP_SUCCESS = apiActions.success({
+		const resp = {
 			query: {},
 			response: { ref: 'bing', value: 'baz' },
-		});
+		};
+		const API_RESP_SUCCESS = apiActions.success(resp);
 		expect(
 			api({ ...DEFAULT_API_STATE, foo: 'bar' }, API_RESP_SUCCESS)
 		).toEqual({
 			foo: 'bar',
-			bing: { ref: 'bing', value: 'baz' },
+			bing: { ref: 'bing', value: 'baz', query: resp.query },
 			inFlight: [],
 		});
 	});

--- a/packages/mwp-sw-plugin/src/index.js
+++ b/packages/mwp-sw-plugin/src/index.js
@@ -1,5 +1,4 @@
 // @flow
-// $FlowFixMe
 const buildPaths = require('mwp-cli/src/config').paths;
 const path = require('path');
 


### PR DESCRIPTION
This PR addresses 2 feature requests from product work

1. Include some reference to the originating `query` for each response value in redux state - this PR adds the `query` object as `state.api[REF].query`. We may need to do a followup at some point to give this a unique ID when it is created
2. When navigating, clear all data from `state.api` that was populated using a non-GET (and therefore non-cacheable) request.