### PR TITLE
specify 'query.meta.noCache' behavior

### DIFF
--- a/flow-typed/platform.js
+++ b/flow-typed/platform.js
@@ -81,6 +81,7 @@ declare type Query = {
 	meta?: {
 		flags?: Array<string>,
 		method?: string,
+		noCache?: boolean,
 	},
 };
 

--- a/packages/mwp-api-proxy-plugin/src/util/validation.js
+++ b/packages/mwp-api-proxy-plugin/src/util/validation.js
@@ -14,6 +14,7 @@ export const querySchema = Joi.object({
 	type: Joi.string(),
 	meta: Joi.object({
 		method: Joi.string().valid('get', 'post', 'delete', 'patch').insensitive(),
+		noCache: Joi.bool(),
 		flags: Joi.array(),
 		variants: Joi.object().pattern(/\w+/, stringOrArray),
 		metaRequestHeaders: Joi.array(),

--- a/packages/mwp-api-state/src/cache/util.test.js
+++ b/packages/mwp-api-state/src/cache/util.test.js
@@ -48,6 +48,15 @@ describe('cache utils', () => {
 			.then(cachedResponse => expect(cachedResponse).toEqual(undefined));
 	});
 
+	it('cacheWriter does not write `noCache` queries to cache', function() {
+		const cache = makeCache();
+		const query = { foo: 'baz', meta: { noCache: true } };
+		const response = 'bar';
+		return cacheWriter(cache)(query, response)
+			.then(() => cache.get(JSON.stringify(query)))
+			.then(cachedResponse => expect(cachedResponse).toEqual(undefined));
+	});
+
 	it('cacheReader reads from cache and returns result with query', function() {
 		const cache = makeCache();
 		const requestCache = cacheReader(cache);


### PR DESCRIPTION
Some 'get' requests should never be cached because the data changes quickly _or_ is not idempotent (i.e. requesting it once will prevent it from being returned again)