### PR TITLE
Location changes generate ref whitelist to suppress flash of empty content

### DIFF
--- a/packages/mwp-api-state/src/reducer.test.js
+++ b/packages/mwp-api-state/src/reducer.test.js
@@ -2,6 +2,7 @@ import {
 	DEFAULT_API_STATE,
 	DEFAULT_APP_STATE, // DEPRECATED
 	api,
+	filterKeys,
 	app, // DEPRECATED
 } from './reducer';
 import { apiRequest } from './sync/syncActionCreators';
@@ -124,5 +125,18 @@ describe('api reducer', () => {
 			completeAction
 		);
 		expect(apiState).toMatchObject({ inFlight: expectedInFlightState });
+	});
+});
+describe('filterKeys', () => {
+	it('returns an object with all specified keys removed', () => {
+		const orig = { foo: 'bar', baz: 'qux', so: 'what' };
+		expect(filterKeys(orig, [], ['foo', 'so'])).toEqual({ baz: 'qux' });
+	});
+	it('does not remove whitelisted keys when specified', () => {
+		const orig = { foo: 'bar', baz: 'qux', so: 'what' };
+		expect(filterKeys(orig, ['foo'], ['foo', 'so'])).toEqual({
+			foo: 'bar',
+			baz: 'qux',
+		});
 	});
 });

--- a/packages/mwp-api-state/src/sync/index.js
+++ b/packages/mwp-api-state/src/sync/index.js
@@ -98,9 +98,6 @@ export const getNavEpic = (routes, baseUrl) => {
 						return newQueries;
 					})
 				).map(q => api.requestAll(q, requestMetadata));
-				// if requestAll included instructions about which refs to retain,
-				// the reducer could ignore those refs when it would otherwise
-				// clear them in the platform reducer line 49
 
 				const clickAction$ = Observable.of(clickActions.clear());
 

--- a/packages/mwp-api-state/src/sync/index.js
+++ b/packages/mwp-api-state/src/sync/index.js
@@ -8,7 +8,7 @@ import 'rxjs/add/operator/catch';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/mergeMap';
 import 'rxjs/add/operator/takeUntil';
-import { ActionsObservable, combineEpics } from 'redux-observable';
+import { combineEpics } from 'redux-observable';
 
 import { LOCATION_CHANGE, SERVER_RENDER } from 'mwp-router';
 import { getRouteResolver, getMatchedQueries } from 'mwp-router/lib/util';
@@ -74,11 +74,13 @@ export const getNavEpic = (routes, baseUrl) => {
 				// note that this function executes _downstream_ of reducers, so the
 				// new `routing` data has already been populated in `state`
 				const state = store.getState();
+				const { referrer = {} } = state.routing;
 				// inject request metadata from context, including `store.getState()`
 				const requestMetadata = {
-					referrer: (state.routing.referrer || {}).pathname || '',
+					referrer: referrer.pathname || '',
 					logout: location.pathname.endsWith('logout'), // assume logout route ends with logout
 					clickTracking: state.clickTracking,
+					retainRefs: [],
 				};
 
 				const cacheAction$ = requestMetadata.logout
@@ -86,8 +88,19 @@ export const getNavEpic = (routes, baseUrl) => {
 					: Observable.empty();
 
 				const apiAction$ = Observable.fromPromise(
-					resolveRoutes(location, baseUrl).then(getMatchedQueries(location))
+					Promise.all([
+						resolveRoutes(location, baseUrl).then(getMatchedQueries(location)),
+						resolveRoutes(referrer, baseUrl).then(getMatchedQueries(referrer)),
+					]).then(([newQueries, previousQueries]) => {
+						// determine which refs are _new_ relative to the previous location,
+						// and set `retainRefs` in order to avoid clearing the 'stable' refs
+						requestMetadata.retainRefs = previousQueries.map(q => q.ref);
+						return newQueries;
+					})
 				).map(q => api.requestAll(q, requestMetadata));
+				// if requestAll included instructions about which refs to retain,
+				// the reducer could ignore those refs when it would otherwise
+				// clear them in the platform reducer line 49
 
 				const clickAction$ = Observable.of(clickActions.clear());
 


### PR DESCRIPTION
When moving around the app, we can prevent some flashes of 'loading' content by maintaining 'parent route' state when navigation occurs.

Currently, _every_ nav action clears the `ref`s in `state.api` that are expected to be returned by the API. We get 'fast loading' behavior by relying on _cached_ values to immediately replace the cleared data. However, the delay between clearing the data and replacing it with cached data is long enough to be noticeable, and _can_ result in some subtle state errors (e.g. the `self` value gets cleared, which means it's not possible to tell whether a user is logged in or not during this split-second re-render).

This PR adds another metadata option to API request actions, allowing the request to carry information about which `ref`s should be _retained_ in state when the request is made. This will prevent the flash of empty content, although it may also allow stale data to remain in `state` longer than it should if 'very outdated' data is marked in `retainRefs`