### PR TITLE
Wp 549 rest api error message

### DIFF
--- a/packages/mwp-api-proxy-plugin/src/util/receive.js
+++ b/packages/mwp-api-proxy-plugin/src/util/receive.js
@@ -1,5 +1,5 @@
 import querystring from 'qs';
-import { logger, serializers } from 'mwp-logger-plugin';
+import { logger } from 'mwp-logger-plugin';
 
 import { API_PROXY_PLUGIN_NAME } from '../config';
 import { coerceBool, toCamelCase } from './stringUtils';
@@ -203,11 +203,12 @@ export const makeLogResponse = request => ([response, body]) => {
 			errorMessage = JSON.stringify(info.errors[0]) || body;
 		} catch (err) {
 			// probably not JSON, could be an HTML response
-			errorMessage = 'REST API error';
+			const titleContent = /<title>(.+?)<\/title>/.exec(body);
+			errorMessage = titleContent ? titleContent[1] : 'REST API error';
 		}
 		logError({
 			...logBase,
-			err: new Error(`REST API error ${errorMessage}`),
+			err: new Error(errorMessage),
 			context: response,
 		});
 		return;

--- a/packages/mwp-api-proxy-plugin/src/util/receive.js
+++ b/packages/mwp-api-proxy-plugin/src/util/receive.js
@@ -214,7 +214,7 @@ export const makeLogResponse = request => ([response, body]) => {
 	}
 	// not an error response
 	logger.info({
-		logBase,
+		...logBase,
 		httpRequest: response,
 	});
 };

--- a/packages/mwp-api-proxy-plugin/src/util/receive.js
+++ b/packages/mwp-api-proxy-plugin/src/util/receive.js
@@ -184,7 +184,6 @@ export const makeApiResponseToQueryResponse = query => ({
 export const makeLogResponse = request => ([response, body]) => {
 	const { request: { method }, statusCode } = response;
 	const logBase = {
-		httpRequest: response,
 		body: body.length > 256 ? `${body.substr(0, 256)}...` : body,
 		...request.raw,
 	};
@@ -214,7 +213,10 @@ export const makeLogResponse = request => ([response, body]) => {
 		return;
 	}
 	// not an error response
-	logger.info(logBase);
+	logger.info({
+		logBase,
+		httpRequest: response,
+	});
 };
 
 /**

--- a/packages/mwp-api-proxy-plugin/src/util/receive.test.js
+++ b/packages/mwp-api-proxy-plugin/src/util/receive.test.js
@@ -298,4 +298,21 @@ describe('makeLogResponse', () => {
 		expect(loggedObject.body.startsWith(body300.substr(0, 256))).toBe(true);
 		expect(loggedObject.body.startsWith(body300)).toBe(false);
 	});
+	it('logs error on non-JSON error', () => {
+		const body = 'This is not JSON';
+		const responseErr = { ...MOCK_INCOMINGMESSAGE_GET, statusCode: 500 };
+		MOCK_LOGGER.error.mockClear();
+		makeLogResponse(request)([responseErr, body]);
+		expect(MOCK_LOGGER.error).toHaveBeenCalled();
+	});
+	it('logs html <title> content on HTML error', () => {
+		const title = 'Doom doom ruin';
+		const body = `<html><head><title>${title}</title></head></html>`;
+		const responseErr = { ...MOCK_INCOMINGMESSAGE_GET, statusCode: 500 };
+		MOCK_LOGGER.error.mockClear();
+		makeLogResponse(request)([responseErr, body]);
+		expect(MOCK_LOGGER.error).toHaveBeenCalled();
+		const loggedObject = MOCK_LOGGER.error.mock.calls[0][0];
+		expect(loggedObject.err.message).toBe(title);
+	});
 });


### PR DESCRIPTION
"Error: REST API error REST API error" isn't that informative. From the logs, this usually happens when we get an HTML response, and the REST API HTML responses usually includes better error info in the `<title>` tag. This PR logs _that_ for better Error Reporting and Stackdriver logs