### PR TITLE
retain refs that correspond to exact query matches

### DIFF
--- a/packages/mwp-router/src/SyncContainer.jsx
+++ b/packages/mwp-router/src/SyncContainer.jsx
@@ -26,13 +26,12 @@ export class SyncContainer extends React.Component {
 	 * @return {undefined} side effect only - dispatch
 	 */
 	componentWillReceiveProps({ location, history }) {
-		if (
-			location.pathname !== this.props.location.pathname ||
-			location.search !== this.props.location.search
-		) {
+		const isPathChange = location.pathname !== this.props.location.pathname;
+		const isSearchChange = location.search !== this.props.location.search;
+		if (isPathChange || isSearchChange) {
 			this.props.dispatchLocationChange(location);
-			if (history.action === 'PUSH') {
-				// new navigation - scroll to top
+			if (history.action === 'PUSH' && isPathChange) {
+				// new page - scroll to top
 				window.scrollTo(0, 0);
 			}
 			// eventually we might want to try setting up some scroll logic for 'POP'


### PR DESCRIPTION
This PR updates the 'retainRef' logic to be smarter about retaining state that isn't expected to change from one request to the next.

Instead of just keeping all `ref`s that were populated by the 'referrer' route, it does a deep comparison between the queries that were dispatched by the previous route and the queries that will be dispatched by the current route - only _exact_ query matches will retain their corresponding state data.

This will prevent stale data from being retained when a `ref` is re-used with slightly different query `params`.