### PR TITLE
WP 563 parse variants cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [9.1]
+
+- Support for reading `MEETUP_VARIANT_...` cookies into `state.config.variants`
+
 ## [9.0]
 
 ### BREAKING CHANGES

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CI_BUILD_NUMBER ?= $(USER)-snapshot
-VERSION ?= 9.0.$(CI_BUILD_NUMBER)
+VERSION ?= 9.1.$(CI_BUILD_NUMBER)
 
 version:
 	@echo $(VERSION)

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "jest": "20.0.4",
     "joi": "13.0.1",
     "lint-staged": "4.0.1",
-    "meetup-web-components": "3.2.1577",
+    "meetup-web-components": "3.2.1580",
     "meetup-web-mocks": "1.0.217",
     "mwp-cli": "1.1.268",
     "mwp-router": ">=0.0.1",

--- a/packages/mwp-core/src/renderers/server-render.jsx
+++ b/packages/mwp-core/src/renderers/server-render.jsx
@@ -14,6 +14,8 @@ import { getServerCreateStore } from 'mwp-store/lib/server';
 import Dom from 'mwp-app-render/lib/components/Dom';
 import ServerApp from 'mwp-app-render/lib/components/ServerApp';
 
+import { getVariants } from '../util/cookieUtils';
+
 // Ensure global Intl for use with FormatJS
 Intl.NumberFormat = IntlPolyfill.NumberFormat;
 Intl.DateTimeFormat = IntlPolyfill.DateTimeFormat;
@@ -220,6 +222,7 @@ const makeRenderer = (
 		url,
 		server: { app: { logger }, settings: { app: { supportedLangs } } },
 		raw: { req },
+		state,
 	} = request;
 	const requestLanguage = request.getLanguage();
 
@@ -240,6 +243,7 @@ const makeRenderer = (
 			requestLanguage,
 			supportedLangs,
 			initialNow: new Date().getTime(),
+			variants: getVariants(state),
 		},
 	};
 

--- a/packages/mwp-core/src/util/cookieUtils.js
+++ b/packages/mwp-core/src/util/cookieUtils.js
@@ -17,3 +17,17 @@ export const parseMemberCookie = state => {
 	member.id = parseInt(member.id, 10) || 0;
 	return member;
 };
+
+/*
+ * Some variant settings can be passed in from MEETUP_VARIANT_XXX cookies. This
+ * function reads those cookie values from `state` and returns a map of values
+ */
+export const getVariants = state =>
+	Object.keys(state).reduce((variants, cookieName) => {
+		const isEnvCookie = !(appConfig.isProd ^ !cookieName.endsWith('_DEV')); // XNOR - both conditions or neither condition
+		if (cookieName.startsWith('MEETUP_VARIANT_') && isEnvCookie) {
+			variants[cookieName.replace(/^MEETUP_VARIANT_|_DEV$/g, '')] =
+				state[cookieName];
+		}
+		return variants;
+	}, {});

--- a/packages/mwp-core/src/util/cookieUtils.test.js
+++ b/packages/mwp-core/src/util/cookieUtils.test.js
@@ -1,4 +1,4 @@
-import { MEMBER_COOKIE, parseMemberCookie } from './cookieUtils';
+import { MEMBER_COOKIE, parseMemberCookie, getVariants } from './cookieUtils';
 
 describe('parseMemberCookie', () => {
 	it('returns the parsed cookie', () => {
@@ -35,5 +35,23 @@ describe('parseMemberCookie', () => {
 	});
 	it('returns {id:0} for no-cookie case', () => {
 		expect(parseMemberCookie({})).toEqual({ id: 0 });
+	});
+});
+
+describe('getVariants', () => {
+	it('creates an object', () => {
+		expect(getVariants({})).toEqual(expect.any(Object));
+		expect(getVariants({ foo: 'bar' })).toEqual(expect.any(Object));
+		expect(getVariants({ MEETUP_VARIANT_FOO_DEV: 'bar' })).toEqual(
+			expect.any(Object)
+		);
+	});
+	it('extracts prefix-free key from MEETUP_VARIANT_XXX', () => {
+		const val = 'bar';
+		expect(getVariants({ MEETUP_VARIANT_FOO_DEV: val }).FOO).toEqual(val);
+	});
+	it('extracts suffix-free key from MEETUP_VARIANT_XXX_DEV', () => {
+		const val = 'bar';
+		expect(getVariants({ MEETUP_VARIANT_FOO_DEV: val }).FOO).toEqual(val);
 	});
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5339,9 +5339,9 @@ media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
 
-meetup-web-components@3.2.1577:
-  version "3.2.1577"
-  resolved "https://registry.yarnpkg.com/meetup-web-components/-/meetup-web-components-3.2.1577.tgz#3b7b70d4948546dec36f44cb47e999c366b79c20"
+meetup-web-components@3.2.1580:
+  version "3.2.1580"
+  resolved "https://registry.yarnpkg.com/meetup-web-components/-/meetup-web-components-3.2.1580.tgz#922351eb7b5461a60ba03316fc1b97ce09f06c4b"
   dependencies:
     autosize "3.0.21"
     base64-image-loader "1.2.0"
@@ -7844,9 +7844,9 @@ sw-toolbox@^3.4.0:
     path-to-regexp "^1.0.1"
     serviceworker-cache-polyfill "^4.0.0"
 
-"swarm-animation@https://github.com/meetup/swarm-animation.git":
+"swarm-animation@git+https://github.com/meetup/swarm-animation.git":
   version "0.0.1"
-  resolved "https://github.com/meetup/swarm-animation.git#81a070a49a54f2e3ef78aec2f16a82778ae49f16"
+  resolved "git+https://github.com/meetup/swarm-animation.git#81a070a49a54f2e3ef78aec2f16a82778ae49f16"
   dependencies:
     autoprefixer "^7.1.1"
     jasmine-jquery "^2.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7844,9 +7844,9 @@ sw-toolbox@^3.4.0:
     path-to-regexp "^1.0.1"
     serviceworker-cache-polyfill "^4.0.0"
 
-"swarm-animation@git+https://github.com/meetup/swarm-animation.git":
+"swarm-animation@https://github.com/meetup/swarm-animation.git":
   version "0.0.1"
-  resolved "git+https://github.com/meetup/swarm-animation.git#81a070a49a54f2e3ef78aec2f16a82778ae49f16"
+  resolved "https://github.com/meetup/swarm-animation.git#81a070a49a54f2e3ef78aec2f16a82778ae49f16"
   dependencies:
     autoprefixer "^7.1.1"
     jasmine-jquery "^2.1.1"


### PR DESCRIPTION
Variants can be passed into the app on server render using `MEETUP_VARIANT_FOO` cookies - this PR adds the ability to read those cookies into Redux `state.config.variants` as a plain object.