### PR TITLE
implemented individual API request timeouts and err objects

### DIFF
--- a/__mocks__/request.js
+++ b/__mocks__/request.js
@@ -46,7 +46,7 @@ const request = jest.fn((requestOpts, cb) => {
 		requestOpts.url
 	);
 	return setTimeout(
-		() => cb(null, mockResponse, mockBody),
+		() => cb(requestOpts.err, mockResponse, mockBody),
 		mockResponse.elapsedTime
 	);
 });

--- a/packages/mwp-api-proxy-plugin/src/proxy.test.js
+++ b/packages/mwp-api-proxy-plugin/src/proxy.test.js
@@ -75,7 +75,7 @@ describe('apiProxy$', () => {
 			{
 				ref: query.ref,
 				meta: {
-					requestId: 'mock request',
+					requestId: 'mock-request',
 					endpoint,
 					statusCode: 200,
 				},

--- a/packages/mwp-api-proxy-plugin/src/util/__snapshots__/send.test.js.snap
+++ b/packages/mwp-api-proxy-plugin/src/util/__snapshots__/send.test.js.snap
@@ -19,6 +19,7 @@ Object {
   "method": "get",
   "mode": "no-cors",
   "time": true,
+  "timeout": 100,
 }
 `;
 
@@ -38,5 +39,6 @@ Object {
   "method": "get",
   "mode": "no-cors",
   "time": true,
+  "timeout": 100,
 }
 `;

--- a/packages/mwp-api-proxy-plugin/src/util/send.test.js
+++ b/packages/mwp-api-proxy-plugin/src/util/send.test.js
@@ -1,3 +1,4 @@
+import request from 'request';
 import fs from 'fs';
 import { getServer } from 'mwp-test-utils';
 
@@ -279,21 +280,25 @@ describe('makeExternalApiRequest', () => {
 			.then(() => require('request').mock.calls.pop()[0])
 			.then(arg => expect(arg).toBe(requestOpts));
 	});
-	it('throws an error when the API times out', () => {
-		const API_TIMEOUT = 1;
+	it('Returns an ETIMEDOUT error object for timeouts', () => {
+		const err = new Error('ETIMEDOUT');
+		err.code = 'ETIMEDOUT';
 		const requestOpts = {
 			foo: 'bar',
 			url: 'http://example.com',
+			err,
 		};
+
 		return makeExternalApiRequest({
 			server: {
-				settings: { app: { api: { timeout: API_TIMEOUT } } },
+				app: { logger: { error: () => {} } },
+				settings: { app: { api: { timeout: 100 } } },
 			},
+			raw: {},
 		})(requestOpts)
 			.toPromise()
-			.then(
-				() => expect(true).toBe(false), // should not be called
-				err => expect(err).toEqual(jasmine.any(Error))
+			.then(([resp, body]) =>
+				expect(JSON.parse(body).errors[0].code).toBe('ETIMEDOUT')
 			);
 	});
 	it('returns the requestOpts jar at array index 2', () => {

--- a/packages/mwp-api-proxy-plugin/src/util/send.test.js
+++ b/packages/mwp-api-proxy-plugin/src/util/send.test.js
@@ -1,4 +1,3 @@
-import request from 'request';
 import fs from 'fs';
 import { getServer } from 'mwp-test-utils';
 


### PR DESCRIPTION
Instead of failing the entire parent request when one REST API endpoint fails (either through timeout or some other 'Internal Server Error'), this PR updates the proxy logic to apply timeouts to each individual API request, and will inject a 'mocked' error object when a request fails - other responses will be collected normally and the overall batched response to the parent request from the client should response normally.

REST API request errors will still be logged, but we should _not_ see as many 500 errors on our end, and I'm hoping that this setup will bypass the error logging in New Relic, which shouldn't send us PagerDuty alerts for API timeouts, which our team can't do anything about anyway.