### PR TITLE
use `Intl.DateTimeFormat` to automatically track NYC timestamp

### DIFF
--- a/packages/mwp-tracking-plugin/src/activity.js
+++ b/packages/mwp-tracking-plugin/src/activity.js
@@ -8,7 +8,7 @@ const YEAR_IN_MS: number = 1000 * 60 * 60 * 24 * 365;
 /*
  * Get a date object that is shifted by the offset of the supplied timezone
  */
-const fakeUTCinTimezone = (timezone: string) => {
+export const fakeUTCinTimezone = (timezone: string) => {
 	const formatOptions = {
 		year: 'numeric',
 		month: 'numeric',
@@ -32,7 +32,7 @@ const fakeUTCinTimezone = (timezone: string) => {
 				return parts;
 			}, {});
 
-		return new Date(Date.UTC(year, month, day, hour, minute, second));
+		return new Date(Date.UTC(year, month - 1, day, hour, minute, second));
 	};
 };
 

--- a/packages/mwp-tracking-plugin/src/activity.js
+++ b/packages/mwp-tracking-plugin/src/activity.js
@@ -18,17 +18,29 @@ export const getLogger: string => (Object, Object) => mixed = (
 ) => (request: Object, trackInfo: Object) => {
 	const requestHeaders = request.headers;
 
-	// Takes in desired time to convert and applies offset
-	const offset = new Date().getTimezoneOffset() * 60000; // gets detected timezone + converts to milliseconds
-	const nowUTC = new Date(Date.now() + offset);
-
-	// generates new date object taking the time in milliseconds and
-	// adds the runtime environment's timezone offset
-	const NY_OFFSET = -14400000;
-	const newNow = new Date(nowUTC.getTime() - NY_OFFSET);
+	// get an iso8601 timestamp that represents the time in 'America/New York'
+	// instead of the default UTC
+	const formatOptions = {
+		year: 'numeric',
+		month: 'numeric',
+		day: 'numeric',
+		hour: 'numeric',
+		minute: 'numeric',
+		second: 'numeric',
+		timeZone: 'America/New_York',
+		hour12: false,
+	};
+	const nycFormatter = new Intl.DateTimeFormat('en-US', formatOptions);
+	const { year, month, day, hour, minute, second } = nycFormatter
+		.formatToParts(new Date())
+		.reduce((parts, part) => {
+			parts[part.type] = parseInt(part.value, 10);
+			return parts;
+		}, {});
+	const fakeUTC = new Date(Date.UTC(year, month, day, hour, minute, second));
 
 	const record = {
-		timestamp: newNow.toISOString(),
+		timestamp: fakeUTC.toISOString(),
 		requestId: request.id,
 		ip: requestHeaders['remote-addr'] || '',
 		agent: requestHeaders['user-agent'] || '',

--- a/packages/mwp-tracking-plugin/src/activity.test.js
+++ b/packages/mwp-tracking-plugin/src/activity.test.js
@@ -1,3 +1,4 @@
+import { fakeUTCinTimezone } from './activity';
 import { updateId } from './util/idUtils';
 // RegEx to verify UUID
 const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -18,6 +19,17 @@ const getMockRequest = () => ({
 	plugins: { tracking: {} },
 });
 
+describe('fakeUTCinTimezone', () => {
+	const fakeTime = new Date(Date.UTC(2017, 6, 4)); // midnight July 4th in UTC
+	it('shifts the time correctly', () => {
+		expect(fakeUTCinTimezone('America/New_York')(fakeTime).toISOString()).toBe(
+			'2017-07-03T20:00:00.000Z' // 10PM July 3rd in NYC
+		);
+		expect(fakeUTCinTimezone('Pacific/Auckland')(fakeTime).toISOString()).toBe(
+			'2017-07-04T12:00:00.000Z' // noon July 4th in New Zealand
+		);
+	});
+});
 describe('updateId', () => {
 	it('sets cookiename if not set', () => {
 		const requestWithoutTrackId = getMockRequest();


### PR DESCRIPTION
This refactor will automatically account for daylight savings, and doesn't require any hard-coded knowledge about timezones or offsets.

Still annoying that we are sending an ISO 8601 string pretending that NYC is UTC, but whatevs