### PR TITLE
WP 589 internal endpoint auth

### DIFF
--- a/packages/mwp-api-proxy-plugin/src/util/receive.js
+++ b/packages/mwp-api-proxy-plugin/src/util/receive.js
@@ -188,7 +188,7 @@ export const makeLogResponse = request => ([response, body]) => {
 	} = response;
 	const logBase = {
 		...request.raw, // request to /mu_api
-		apiRequest: { headers, method, url }, // request to https://api.meetup.com/
+		externalRequest: { headers, method, url }, // request to https://api.meetup.com/
 	};
 
 	if (

--- a/packages/mwp-api-proxy-plugin/src/util/receive.js
+++ b/packages/mwp-api-proxy-plugin/src/util/receive.js
@@ -187,7 +187,6 @@ export const makeLogResponse = request => ([response, body]) => {
 		statusCode,
 	} = response;
 	const logBase = {
-		body: body.length > 256 ? `${body.substr(0, 512)}...` : body,
 		...request.raw, // request to /mu_api
 		apiRequest: { headers, method, url }, // request to https://api.meetup.com/
 	};
@@ -211,6 +210,7 @@ export const makeLogResponse = request => ([response, body]) => {
 		}
 		logError({
 			...logBase,
+			body: body.length > 512 ? `${body.substr(0, 512)}...` : body,
 			err: new Error(errorMessage),
 			context: response, // this will provide limited info - check apiRequest for more detail
 		});

--- a/packages/mwp-api-proxy-plugin/src/util/receive.js
+++ b/packages/mwp-api-proxy-plugin/src/util/receive.js
@@ -209,6 +209,7 @@ export const makeLogResponse = request => ([response, body]) => {
 			...logBase,
 			err: new Error(errorMessage),
 			context: response,
+			httpRequest: response,
 		});
 		return;
 	}

--- a/packages/mwp-api-proxy-plugin/src/util/receive.js
+++ b/packages/mwp-api-proxy-plugin/src/util/receive.js
@@ -182,10 +182,14 @@ export const makeApiResponseToQueryResponse = query => ({
 });
 
 export const makeLogResponse = request => ([response, body]) => {
-	const { request: { method }, statusCode } = response;
+	const {
+		request: { headers, method, uri: { href: url } },
+		statusCode,
+	} = response;
 	const logBase = {
-		body: body.length > 256 ? `${body.substr(0, 256)}...` : body,
-		...request.raw,
+		body: body.length > 256 ? `${body.substr(0, 512)}...` : body,
+		...request.raw, // request to /mu_api
+		apiRequest: { headers, method, url }, // request to https://api.meetup.com/
 	};
 
 	if (
@@ -208,8 +212,7 @@ export const makeLogResponse = request => ([response, body]) => {
 		logError({
 			...logBase,
 			err: new Error(errorMessage),
-			context: response,
-			httpRequest: response,
+			context: response, // this will provide limited info - check apiRequest for more detail
 		});
 		return;
 	}

--- a/packages/mwp-api-proxy-plugin/src/util/receive.test.js
+++ b/packages/mwp-api-proxy-plugin/src/util/receive.test.js
@@ -282,24 +282,6 @@ describe('makeLogResponse', () => {
 		const loggedObject = MOCK_LOGGER.info.mock.calls[0][0];
 		expect(loggedObject).toEqual(jasmine.any(Object));
 	});
-	it('returns the full body of the response if less than 256 characters', () => {
-		const body = 'foo';
-		MOCK_LOGGER.info.mockClear();
-		makeLogResponse(request)([MOCK_INCOMINGMESSAGE_GET, body]);
-		expect(MOCK_LOGGER.info).toHaveBeenCalled();
-		const loggedObject = MOCK_LOGGER.info.mock.calls[0][0];
-		expect(loggedObject.body).toEqual(body);
-	});
-	it('returns a truncated response body if more than 256 characters', () => {
-		const body300 =
-			'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean egestas viverra sem vel congue. Cras vitae malesuada justo. Fusce ut finibus felis, at sagittis leo. Morbi nec velit dignissim, viverra tellus at, pretium nisi. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla turpis duis.';
-		MOCK_LOGGER.info.mockClear();
-		makeLogResponse(request)([MOCK_INCOMINGMESSAGE_GET, body300]);
-		expect(MOCK_LOGGER.info).toHaveBeenCalled();
-		const loggedObject = MOCK_LOGGER.info.mock.calls[0][0];
-		expect(loggedObject.body.startsWith(body300.substr(0, 256))).toBe(true);
-		expect(loggedObject.body.startsWith(body300)).toBe(false);
-	});
 	it('logs error on non-JSON error', () => {
 		const body = 'This is not JSON';
 		const responseErr = { ...MOCK_INCOMINGMESSAGE_GET, statusCode: 500 };

--- a/packages/mwp-api-proxy-plugin/src/util/receive.test.js
+++ b/packages/mwp-api-proxy-plugin/src/util/receive.test.js
@@ -258,12 +258,14 @@ describe('makeLogResponse', () => {
 		elapsedTime: 1234,
 		request: {
 			method: 'get',
+			uri: {},
 		},
 	};
 	const MOCK_INCOMINGMESSAGE_POST = {
 		elapsedTime: 2345,
 		request: {
 			method: 'post',
+			uri: {},
 		},
 	};
 	it('emits parsed request and response data for GET request', () => {

--- a/packages/mwp-api-proxy-plugin/src/util/send.js
+++ b/packages/mwp-api-proxy-plugin/src/util/send.js
@@ -222,7 +222,6 @@ export function parseRequestHeaders(request) {
 	delete externalRequestHeaders['accept-encoding']; // let app server set 'accept'
 	delete externalRequestHeaders['content-length']; // original request content-length is irrelevant
 	delete externalRequestHeaders['content-type']; // the content type will be set in buildRequestArgs
-	console.log(JSON.stringify(externalRequestHeaders, null, 2));
 
 	return externalRequestHeaders;
 }

--- a/packages/mwp-api-proxy-plugin/src/util/send.js
+++ b/packages/mwp-api-proxy-plugin/src/util/send.js
@@ -173,7 +173,7 @@ export function getAuthHeaders(request) {
 			? cookies.MEETUP_CSRF
 			: cookies.MEETUP_CSRF_DEV;
 	if (csrfCookie) {
-		// use existing cookie val in header
+		// only need to set csrf-token - existing cookie header will be passed in unmodified
 		return { 'csrf-token': csrfCookie };
 	}
 	// create a new cookie + header

--- a/packages/mwp-api-proxy-plugin/src/util/send.js
+++ b/packages/mwp-api-proxy-plugin/src/util/send.js
@@ -222,6 +222,7 @@ export function parseRequestHeaders(request) {
 	delete externalRequestHeaders['accept-encoding']; // let app server set 'accept'
 	delete externalRequestHeaders['content-length']; // original request content-length is irrelevant
 	delete externalRequestHeaders['content-type']; // the content type will be set in buildRequestArgs
+	console.log(JSON.stringify(externalRequestHeaders, null, 2));
 
 	return externalRequestHeaders;
 }

--- a/packages/mwp-api-proxy-plugin/src/util/send.js
+++ b/packages/mwp-api-proxy-plugin/src/util/send.js
@@ -165,7 +165,18 @@ export function getAuthHeaders(request) {
 			authorization: `Bearer ${oauth_token}`,
 		};
 	}
+
+	// Cookie + CSRF auth: need have matching UUID in MEETUP_CSRF cookie and 'csrf-token' header
 	const cookies = { ...request.state };
+	const csrfCookie =
+		process.env.NODE_ENV === 'production'
+			? cookies.MEETUP_CSRF
+			: cookies.MEETUP_CSRF_DEV;
+	if (csrfCookie) {
+		// use existing cookie val in header
+		return { 'csrf-token': csrfCookie };
+	}
+	// create a new cookie + header
 	const csrf = uuid.v4();
 	cookies.MEETUP_CSRF = csrf;
 	cookies.MEETUP_CSRF_DEV = csrf;


### PR DESCRIPTION
I had a hard time replicating the prod behavior in dev, even with sending what I think were identical requests to the ones that logged errors in the prod logs.

However, part of the challenge is that the error logs don't contain the header information for the failing API requests - this data is critical for debugging, so this PR mainly adds that in.

It also adds more cautious CSRF setting behavior - instead of _always_ writing a new UUID for MEETUP_CSRF, it instead will re-use a CSRF cookie that is already set. This may make 'internal' errors less common, since the check for 'internal' requests relies primarily on accurate MEETUP_CSRF and handling.

