### PR TITLE
ensure that API_RESP_COMPLETE is called in LOCATION_CHANGE interrupt

### DIFF
--- a/packages/mwp-api-state/src/sync/index.test.js
+++ b/packages/mwp-api-state/src/sync/index.test.js
@@ -18,7 +18,7 @@ import {
 
 import * as api from './apiActionCreators';
 import * as syncActionCreators from './syncActionCreators';
-import getSyncEpic from './';
+import getSyncEpic, { getFetchQueriesEpic } from './';
 
 const EMPTY_ROUTES = {};
 
@@ -26,7 +26,7 @@ const EMPTY_ROUTES = {};
  * @module SyncEpicTest
  */
 describe('Sync epic', () => {
-	it.only(
+	it(
 		'does not pass through arbitrary actions',
 		epicIgnoreAction(getSyncEpic(MOCK_ROUTES))
 	);
@@ -129,6 +129,47 @@ describe('Sync epic', () => {
 			});
 	});
 
+	it('does not emit API_RESP_SUCCESS when API_REQ is interrupted by LOCATION_CHANGE', () => {
+		const mockFetchQueries = () => () =>
+			new Promise((resolve, reject) =>
+				setTimeout(() => resolve({ successes: [{}] }), 10)
+			);
+
+		const queries = [mockQuery({})];
+		const apiRequest = api.requestAll(queries);
+		const action$ = ActionsObservable.of(apiRequest, { type: LOCATION_CHANGE }); // request immediately followed by LOCATION_CHANGE
+		const fakeStore = createFakeStore(MOCK_APP_STATE);
+		return getFetchQueriesEpic(mockFetchQueries)(action$, fakeStore)
+			.toArray()
+			.toPromise()
+			.then(actions => {
+				expect(actions.map(({ type }) => type)).not.toContain(
+					api.API_RESP_SUCCESS
+				);
+			});
+	});
+	it('emits API_RESP_COMPLETE when API_REQ is interrupted by LOCATION_CHANGE', function() {
+		const mockFetchQueries = () => () =>
+			new Promise((resolve, reject) =>
+				setTimeout(() => resolve({ successes: [{}] }), 10)
+			);
+
+		const queries = [mockQuery({})];
+		const apiRequest = api.requestAll(queries);
+		const action$ = ActionsObservable.of(apiRequest, {
+			type: LOCATION_CHANGE,
+		}); // request immediately followed by LOCATION_CHANGE
+		const fakeStore = createFakeStore(MOCK_APP_STATE);
+		return getFetchQueriesEpic(mockFetchQueries)(action$, fakeStore)
+			.toArray()
+			.toPromise()
+			.then(actions => {
+				expect(actions.map(({ type }) => type)).toContain(
+					api.API_RESP_COMPLETE
+				);
+			});
+	});
+
 	it('calls action.meta.resolve successful API_REQ', function() {
 		const expectedSuccesses = [{}];
 		const mockFetchQueries = () => () =>
@@ -148,7 +189,8 @@ describe('Sync epic', () => {
 	});
 
 	it('emits API_RESP_FAIL on failed API_REQ', function() {
-		const mockFetchQueries = () => () => Promise.reject(new Error());
+		const mockFetchQueries = () => () =>
+			Promise.reject(new Error('mock error'));
 
 		const queries = [mockQuery({})];
 		const apiRequest = api.requestAll(queries);
@@ -157,13 +199,13 @@ describe('Sync epic', () => {
 		return getSyncEpic(EMPTY_ROUTES, mockFetchQueries)(action$, fakeStore)
 			.toArray()
 			.toPromise()
-			.then(actions =>
+			.then(actions => {
 				expect(actions.map(a => a.type)).toEqual([
 					api.API_RESP_FAIL,
 					'API_ERROR',
 					api.API_RESP_COMPLETE, // DO NOT REMOVE - must _ALWAYS_ be called in order to clean up inFlight state
-				])
-			);
+				]);
+			});
 	});
 	it('calls action.meta.reject on failed API_REQ', function() {
 		const expectedError = new Error();


### PR DESCRIPTION
This is a small refactor to the sync epic used to interact with the API, along with a couple of tests that verify behavior.

The update ensures that API_RESP_COMPLETE is called even when a query fetch is interrupted by a LOCATION_CHANGE action. This ensures that refs in `state.inFlight` are cleared out even when they haven't returned any data, which should prevent _some_ cases of spinners never clearing because they think their corresponding API request hasn't completed - the request has completed, but because the user has navigated away from the page, the data will not be populated in `state.api`