### PR TITLE
allow array for mockResponse

### DIFF
--- a/packages/mwp-api-proxy-plugin/src/util/validation.js
+++ b/packages/mwp-api-proxy-plugin/src/util/validation.js
@@ -9,7 +9,7 @@ export const querySchema = Joi.object({
 	endpoint: Joi.string().required(),
 	ref: Joi.string().required(),
 	flags: Joi.array(),
-	mockResponse: Joi.object(),
+	mockResponse: [Joi.object(), Joi.array()],
 	params: Joi.object(), // can be FormData
 	type: Joi.string(),
 	meta: Joi.object({


### PR DESCRIPTION
https://console.cloud.google.com/errors/11754463858072996644

not a problem with the data, just the validation