### PR TITLE
Mw 2195 inconsistent duotone

### DIFF
--- a/packages/mwp-api-proxy-plugin/src/util/duotone.js
+++ b/packages/mwp-api-proxy-plugin/src/util/duotone.js
@@ -128,7 +128,7 @@ export const getDuotoneUrls = (duotones, PHOTO_SCALER_SALT) => {
  * @return {Object} the mutated group object
  */
 export const groupDuotoneSetter = duotoneUrls => group => {
-	const photo = group.key_photo || {};
+	const photo = group.key_photo || group.group_photo || {};
 	const duotoneKey =
 		group.photo_gradient &&
 		duotoneRef(

--- a/packages/mwp-api-proxy-plugin/src/util/duotone.test.js
+++ b/packages/mwp-api-proxy-plugin/src/util/duotone.test.js
@@ -61,10 +61,29 @@ describe('groupDuotoneSetter', () => {
 		expect(duotoneUrl.small.startsWith(expectedUrl.small)).toBe(true);
 	});
 });
-
 describe('apiResponseDuotoneSetter', () => {
-	it('adds duotone url to type: "group" api response', () => {
+	it('adds duotone url to type: "group" api response with key_photo', () => {
 		const group = { ...MOCK_GROUP, duotoneUrl: undefined };
+		const { ref, type } = mockQuery({});
+		const groupApiResponse = {
+			ref,
+			type,
+			value: group,
+		};
+		const modifiedResponse = apiResponseDuotoneSetter(MOCK_DUOTONE_URLS)(
+			groupApiResponse
+		);
+		const { duotoneUrl } = modifiedResponse.value;
+		const expectedUrl = MOCK_DUOTONE_URLS.dtaxb;
+		expect(duotoneUrl.large.startsWith(expectedUrl.large)).toBe(true);
+		expect(duotoneUrl.small.startsWith(expectedUrl.small)).toBe(true);
+	});
+	it('adds duotone url to type: "group" api response with only group_photo and no key_photo', () => {
+		const group = {
+			...MOCK_GROUP,
+			key_photo: undefined,
+			duotoneUrl: undefined,
+		};
 		const { ref, type } = mockQuery({});
 		const groupApiResponse = {
 			ref,


### PR DESCRIPTION
Slight modification to the `groupDuotoneSetter` method to use `group.group_photo` as a fallback incase the `group.key_photo` is undefined

This is in reference to [this issue](https://meetup.atlassian.net/browse/MW-2195)