### PR TITLE
Start of refactor from redux-observable to a Promise-based API middleware

### DIFF
--- a/packages/mwp-api-state/src/index.js
+++ b/packages/mwp-api-state/src/index.js
@@ -1,6 +1,10 @@
-import { combineEpics, createEpicMiddleware } from 'redux-observable';
+import {
+	combineEpics,
+	createEpicMiddleware as createEpicMiddlewareRO,
+} from 'redux-observable';
+import { createEpicMiddleware } from './redux-promise-epic';
 
-import getSyncEpic from './sync';
+import getSyncEpic, { getFetchQueriesEpic } from './sync';
 import getCacheEpic from './cache';
 import { postEpic, deleteEpic } from './mutate'; // DEPRECATED
 
@@ -28,12 +32,14 @@ export { api, app, DEFAULT_API_STATE } from './reducer';
  * order to render the application. We may want to write a server-specific
  * middleware that doesn't include the other epics if performance is an issue
  */
-export const getApiMiddleware = (routes, fetchQueries, baseUrl) =>
-	createEpicMiddleware(
+export const getApiMiddleware = (routes, baseUrl) =>
+	createEpicMiddlewareRO(
 		combineEpics(
-			getSyncEpic(routes, fetchQueries, baseUrl),
+			getSyncEpic(routes, baseUrl),
 			getCacheEpic(),
 			postEpic, // DEPRECATED
 			deleteEpic // DEPRECATED
 		)
 	);
+export const getFetchQueriesMiddleware = fetchQueriesFn =>
+	createEpicMiddleware(getFetchQueriesEpic(fetchQueriesFn));

--- a/packages/mwp-api-state/src/index.js
+++ b/packages/mwp-api-state/src/index.js
@@ -1,3 +1,4 @@
+import { compose } from 'redux';
 import {
 	combineEpics,
 	createEpicMiddleware as createEpicMiddlewareRO,
@@ -23,6 +24,9 @@ export {
 } from './sync/apiActionCreators';
 export { api, app, DEFAULT_API_STATE } from './reducer';
 
+const composeMiddleware = (...middleware) => store =>
+	compose(...middleware.map(m => m(store)));
+
 /**
  * The middleware is exported as a getter because it needs the application's
  * routes in order to set up the nav-related epic(s) that are part of the
@@ -32,14 +36,15 @@ export { api, app, DEFAULT_API_STATE } from './reducer';
  * order to render the application. We may want to write a server-specific
  * middleware that doesn't include the other epics if performance is an issue
  */
-export const getApiMiddleware = (routes, baseUrl) =>
-	createEpicMiddlewareRO(
-		combineEpics(
-			getSyncEpic(routes, baseUrl),
-			getCacheEpic(),
-			postEpic, // DEPRECATED
-			deleteEpic // DEPRECATED
-		)
+export const getApiMiddleware = (routes, fetchQueriesFn, baseUrl) =>
+	composeMiddleware(
+		createEpicMiddlewareRO(
+			combineEpics(
+				getSyncEpic(routes, baseUrl),
+				getCacheEpic(),
+				postEpic, // DEPRECATED
+				deleteEpic // DEPRECATED
+			)
+		),
+		createEpicMiddleware(getFetchQueriesEpic(fetchQueriesFn))
 	);
-export const getFetchQueriesMiddleware = fetchQueriesFn =>
-	createEpicMiddleware(getFetchQueriesEpic(fetchQueriesFn));

--- a/packages/mwp-api-state/src/redux-promise-epic/index.js
+++ b/packages/mwp-api-state/src/redux-promise-epic/index.js
@@ -1,0 +1,9 @@
+// type Epic = (action: Action, store: ReduxStore) => Promise<Array<Action>>
+export const createEpicMiddleware = epic => {
+	return store => next => action => {
+		epic(action, store).then(actions => {
+			actions.forEach(a => store.dispatch(a));
+		});
+		return next(action);
+	};
+};

--- a/packages/mwp-api-state/src/sync/index.js
+++ b/packages/mwp-api-state/src/sync/index.js
@@ -6,6 +6,7 @@ import 'rxjs/add/observable/fromPromise';
 import 'rxjs/add/observable/merge';
 import 'rxjs/add/observable/of';
 import 'rxjs/add/operator/catch';
+import 'rxjs/add/operator/first';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/mergeMap';
 import 'rxjs/add/operator/takeUntil';
@@ -20,6 +21,7 @@ import {
 	apiSuccess, // DEPRECATED
 	apiError, // DEPRECATED
 } from './syncActionCreators';
+import { currentId } from 'async_hooks';
 
 /**
  * @deprecated
@@ -158,52 +160,71 @@ export const apiRequestToApiReq = action$ =>
  * - API_ERROR  // deprecated
  * - API_COMPLETE
  */
-export const getFetchQueriesEpic = fetchQueriesFn => (action$, store) =>
-	action$.ofType(api.API_REQ).mergeMap(({ payload: queries, meta }) => {
+export const getFetchQueriesEpic = fetchQueriesFn => {
+	let locationIndex = 0; // keep track of location changes
+
+	// set up a closure that will compare a passed-in index to the current value
+	// of `locationIndex` - if `locationIndex` has changed since `currentLocation`
+	// was passed in, return an empty array instead of the supplied actions array
+	// This is a way of ignoring API return values that happen after a location change
+	const ignoreIfLocationChange = currentLocation => actions => {
+		if (currentLocation !== locationIndex) {
+			return [];
+		}
+		return actions;
+	};
+
+	// return the epic
+	return (action, store) => {
+		if (action.type === LOCATION_CHANGE) {
+			locationIndex = locationIndex + 1;
+		}
+		if (action.type !== api.API_REQ) {
+			return Promise.resolve([]);
+		}
+		const { payload: queries, meta } = action;
 		// set up the fetch call to the app server
 		const { config, api: { self } } = store.getState();
 		const fetchQueries = fetchQueriesFn(config.apiUrl, (self || {}).value);
-		const queryFetcher$ = Observable.fromPromise(fetchQueries(queries, meta)) // call fetch
-			.takeUntil(action$.ofType(LOCATION_CHANGE)) // cancel this fetch when nav happens
-			.mergeMap(({ successes = [], errors = [] }) => {
-				// meta contains a Promise that must be resolved
-				meta.resolve([...successes, ...errors]);
-				const deprecatedSuccessPayload = getDeprecatedSuccessPayload(
-					successes,
-					errors
-				);
-				const deprecatedActions = [apiSuccess(deprecatedSuccessPayload)];
-				if (meta && meta.onSuccess) {
-					deprecatedActions.push(meta.onSuccess(deprecatedSuccessPayload));
-				}
-				const actions = [
-					...successes.map(api.success), // send the successes to success
-					...errors.map(api.error), // send errors to error
-					...deprecatedActions,
-				];
-				return Observable.of(...actions);
-			})
-			.catch(err => {
-				// meta contains a Promise that must be rejected
-				meta.reject(err);
-				const deprecatedActions = [apiError(err)];
-				if (meta && meta.onError) {
-					deprecatedActions.push(meta.onError(err));
-				}
-				return Observable.of(api.fail(err), ...deprecatedActions);
-			});
 
-		return Observable.concat(
-			queryFetcher$,
-			Observable.of(api.complete(queries))
+		return (
+			fetchQueries(queries, meta) // call fetch
+				// .takeUntil(action$.ofType(LOCATION_CHANGE)) // cancel this fetch when nav happens
+				.then(({ successes = [], errors = [] }) => {
+					// meta contains a Promise that must be resolved
+					meta.resolve([...successes, ...errors]);
+					const deprecatedSuccessPayload = getDeprecatedSuccessPayload(
+						successes,
+						errors
+					);
+					const deprecatedActions = [apiSuccess(deprecatedSuccessPayload)];
+					if (meta && meta.onSuccess) {
+						deprecatedActions.push(meta.onSuccess(deprecatedSuccessPayload));
+					}
+					return [
+						...successes.map(api.success), // send the successes to success
+						...errors.map(api.error), // send errors to error
+						...deprecatedActions,
+					];
+				})
+				.catch(err => {
+					// meta contains a Promise that must be rejected
+					meta.reject(err);
+					const deprecatedActions = [apiError(err)];
+					if (meta && meta.onError) {
+						deprecatedActions.push(meta.onError(err));
+					}
+					return [api.fail(err), ...deprecatedActions];
+				})
+				.then(actions => [...actions, api.complete(queries)])
+				.then(ignoreIfLocationChange(locationIndex))
 		);
-	});
-
-export default function getSyncEpic(routes, fetchQueries, baseUrl) {
+	};
+};
+export default function getSyncEpic(routes, baseUrl) {
 	return combineEpics(
 		getNavEpic(routes, baseUrl),
-		// locationSyncEpic,
-		getFetchQueriesEpic(fetchQueries),
+		// locationSyncEpic, // OLD, not needed
 		apiRequestToApiReq // TODO: remove in v3 - apiRequest is deprecated
 	);
 }

--- a/packages/mwp-api-state/src/sync/index.js
+++ b/packages/mwp-api-state/src/sync/index.js
@@ -21,7 +21,6 @@ import {
 	apiSuccess, // DEPRECATED
 	apiError, // DEPRECATED
 } from './syncActionCreators';
-import { currentId } from 'async_hooks';
 
 /**
  * @deprecated
@@ -216,8 +215,8 @@ export const getFetchQueriesEpic = fetchQueriesFn => {
 					}
 					return [api.fail(err), ...deprecatedActions];
 				})
-				.then(actions => [...actions, api.complete(queries)])
 				.then(ignoreIfLocationChange(locationIndex))
+				.then(actions => [...actions, api.complete(queries)])
 		);
 	};
 };

--- a/packages/mwp-app-route-plugin/src/handler.js
+++ b/packages/mwp-app-route-plugin/src/handler.js
@@ -23,7 +23,7 @@ export default (languageRenderers: { [string]: LanguageRenderer$ }) => (
 	const requestLanguage = request.getLanguage();
 	const renderRequest = languageRenderers[requestLanguage];
 
-	renderRequest(request).subscribe(
+	renderRequest(request, reply).subscribe(
 		(renderResult: RenderResult) => {
 			if (renderResult.redirect) {
 				return reply

--- a/packages/mwp-app-route-plugin/src/handler.js
+++ b/packages/mwp-app-route-plugin/src/handler.js
@@ -23,7 +23,7 @@ export default (languageRenderers: { [string]: LanguageRenderer$ }) => (
 	const requestLanguage = request.getLanguage();
 	const renderRequest = languageRenderers[requestLanguage];
 
-	renderRequest(request, reply).subscribe(
+	renderRequest(request).subscribe(
 		(renderResult: RenderResult) => {
 			if (renderResult.redirect) {
 				return reply


### PR DESCRIPTION
This PR provides the first refactor of an observable-based 'epic' into a Promise-based 'epic'. There are a number of other epics that will need to be refactored, but this is the first step.

I'm using an 'epic' pattern similar to what redux-observable defines, where instead of creating an observable stream that takes a stream of actions as an input and emits a stream of actions, (actions in, actions out), the new epics create a new Promise for each action that comes in, which returns an array of actions (could be empty, a single action, or multiple actions, but it always resolves to a single array).

This conversion allows the core functional blocks of the API middleware and the tests to remain largely the same.

redux-observable also provides utilities for composing epics and turning them into proper Redux middleware functions. For this first refactor, I've written a couple of parallel helpers that work with Promises: `createEpicMiddleware` and `composeMiddleware` that allows the top-level `getApiMiddleware` export to remain the same - consumers do not have to be aware of the implementation details since the behavior of dispatched Redux actions is the same.