### PR TITLE
Convert remaining SyncEpic to Promises

### DIFF
--- a/packages/mwp-api-state/src/index.js
+++ b/packages/mwp-api-state/src/index.js
@@ -3,13 +3,9 @@ import {
 	combineEpics as combineEpicsRO,
 	createEpicMiddleware as createEpicMiddlewareRO,
 } from 'redux-observable';
-import { createEpicMiddleware, combineEpics } from './redux-promise-epic';
+import { createEpicMiddleware } from './redux-promise-epic';
 
-import getSyncEpic, {
-	getFetchQueriesEpic,
-	getNavEpic,
-	apiRequestToApiReq,
-} from './sync';
+import getSyncEpic from './sync';
 import getCacheEpic from './cache';
 import { postEpic, deleteEpic } from './mutate'; // DEPRECATED
 

--- a/packages/mwp-api-state/src/index.js
+++ b/packages/mwp-api-state/src/index.js
@@ -44,7 +44,6 @@ export const getApiMiddleware = (routes, fetchQueriesFn, baseUrl) =>
 	composeMiddleware(
 		createEpicMiddlewareRO(
 			combineEpicsRO(
-				getSyncEpic(),
 				getCacheEpic(),
 				postEpic, // DEPRECATED
 				deleteEpic // DEPRECATED

--- a/packages/mwp-api-state/src/index.js
+++ b/packages/mwp-api-state/src/index.js
@@ -1,11 +1,15 @@
 import { compose } from 'redux';
 import {
-	combineEpics,
+	combineEpics as combineEpicsRO,
 	createEpicMiddleware as createEpicMiddlewareRO,
 } from 'redux-observable';
-import { createEpicMiddleware } from './redux-promise-epic';
+import { createEpicMiddleware, combineEpics } from './redux-promise-epic';
 
-import getSyncEpic, { getFetchQueriesEpic } from './sync';
+import getSyncEpic, {
+	getFetchQueriesEpic,
+	getNavEpic,
+	apiRequestToApiReq,
+} from './sync';
 import getCacheEpic from './cache';
 import { postEpic, deleteEpic } from './mutate'; // DEPRECATED
 
@@ -39,12 +43,12 @@ const composeMiddleware = (...middleware) => store =>
 export const getApiMiddleware = (routes, fetchQueriesFn, baseUrl) =>
 	composeMiddleware(
 		createEpicMiddlewareRO(
-			combineEpics(
-				getSyncEpic(routes, baseUrl),
+			combineEpicsRO(
+				getSyncEpic(),
 				getCacheEpic(),
 				postEpic, // DEPRECATED
 				deleteEpic // DEPRECATED
 			)
 		),
-		createEpicMiddleware(getFetchQueriesEpic(fetchQueriesFn))
+		createEpicMiddleware(getSyncEpic(routes, fetchQueriesFn, baseUrl))
 	);

--- a/packages/mwp-api-state/src/redux-promise-epic/index.js
+++ b/packages/mwp-api-state/src/redux-promise-epic/index.js
@@ -7,3 +7,7 @@ export const createEpicMiddleware = epic => {
 		return next(action);
 	};
 };
+
+const flattenArray = arrays => [].concat.apply([], arrays);
+export const combineEpics = (...epics) => (action, store) =>
+	Promise.all(epics.map(e => e(action, store))).then(flattenArray);

--- a/packages/mwp-api-state/src/redux-promise-epic/index.js
+++ b/packages/mwp-api-state/src/redux-promise-epic/index.js
@@ -1,9 +1,13 @@
 // type Epic = (action: Action, store: ReduxStore) => Promise<Array<Action>>
 export const createEpicMiddleware = epic => {
 	return store => next => action => {
-		epic(action, store).then(actions => {
-			actions.forEach(a => store.dispatch(a));
-		});
+		// need to execute epics in the next tick in order to ensure that that state
+		// has been updated by reducers
+		Promise.resolve().then(() =>
+			epic(action, store).then(actions => {
+				actions.forEach(a => store.dispatch(a));
+			})
+		);
 		return next(action);
 	};
 };

--- a/packages/mwp-api-state/src/sync/index.js
+++ b/packages/mwp-api-state/src/sync/index.js
@@ -52,6 +52,9 @@ export function getDeprecatedSuccessPayload(successes, errors) {
  * metadata about the navigation action can also be sent to the `apiRequest`
  * here.
  *
+ * note that this function executes _downstream_ of reducers, so the
+ * new `routing` data has already been populated in `state`
+ *
  * @param {Object} routes The application's React Router routes
  * @returns {Function} an Epic function that emits an API_REQUEST action
  */
@@ -71,9 +74,6 @@ export const getNavEpic = (routes, baseUrl) => {
 			clickTracking: state.clickTracking,
 			retainRefs: [],
 		};
-		// note that this function executes _downstream_ of reducers, so the
-		// new `routing` data has already been populated in `state`
-
 		const cacheAction = requestMetadata.logout && { type: 'CACHE_CLEAR' };
 
 		const resolvePrevQueries = referrer.pathname


### PR DESCRIPTION
This PR converts the remaining observable-based epics in the SyncEpic to Promise-based equivalents.

It also introduces a new Promise-based `combineEpics` function that is equivalent to `redux-observable`'s `combineEpics` (i.e. it makes an array of epics resolve a single array of actions instead of making an array of observable epics emit a single stream of actions)

There aren't actually that many code changes, but the indentation changes make the diff a little hard to read - sorry about that.