### PR TITLE
remove temporary file creation for uploads

### DIFF
--- a/packages/mwp-api-proxy-plugin/src/index.js
+++ b/packages/mwp-api-proxy-plugin/src/index.js
@@ -1,5 +1,4 @@
 // @flow
-import fs from 'fs';
 import { duotones, getDuotoneUrls } from './util/duotone';
 import getApiProxyRoutes from './routes';
 import proxyApi$ from './proxy';

--- a/packages/mwp-api-proxy-plugin/src/routes.js
+++ b/packages/mwp-api-proxy-plugin/src/routes.js
@@ -47,10 +47,10 @@ const getApiProxyRoutes = path => {
 		config: {
 			...routeBase.config,
 			payload: {
-				allow: ['application/x-www-form-urlencoded', 'multipart/form-data'],
-				multipart: {
-					output: 'file', // parse file uploads into streams
-				},
+				allow: [
+					'application/x-www-form-urlencoded',
+					'multipart/form-data',
+				],
 				maxBytes: 1024 * 1024 * 10, // 10 MB max upload
 			},
 		},

--- a/packages/mwp-api-proxy-plugin/src/util/send.js
+++ b/packages/mwp-api-proxy-plugin/src/util/send.js
@@ -219,16 +219,16 @@ export function parseRequestHeaders(request) {
 
 /*
  * In multipart form requests, the parsed payload includes string key-value
- * pairs for regular inputs, and file descriptors for file upload inputs
- * ({ filename, path, headers }). This function passes through regular input
- * values unchanged, but converts the file descriptors to readable file streams
- * that will be proxied to the REST API.
+ * pairs for regular inputs, and raw Buffer objects for file uploads
  * 
- * References to the uploaded files are stored here for cleanup later on.
+ * This function passes through regular input values unchanged, but formats the
+ * file buffers into a { value, options } object that can be used in request
+ * formData
+ * @see https://www.npmjs.com/package/request#multipartform-data-multipart-form-uploads
  */
-export const parseMultipart = request =>
-	Object.keys(request.payload).reduce((formData, key) => {
-		const value = request.payload[key];
+export const parseMultipart = payload =>
+	Object.keys(payload).reduce((formData, key) => {
+		const value = payload[key];
 		formData[key] =
 			value instanceof Buffer
 				? { value, options: { filename: 'upload' } }
@@ -261,7 +261,7 @@ export function getExternalRequestOpts(request) {
 	};
 	if (request.mime === 'multipart/form-data') {
 		// multipart form data needs special treatment
-		externalRequestOpts.formData = parseMultipart(request);
+		externalRequestOpts.formData = parseMultipart(request.payload);
 	}
 	return externalRequestOpts;
 }


### PR DESCRIPTION
Hapi has a few different settings for how the payload for multipart requests (i.e. file uploads) can be parsed. It turns out that the default option, which parses the file contents in a Buffer, can be used in the forwarded request to the REST API with only a little tweaking (adding a 'filename' descriptor) - we do not need to write the file to disk and then read from that in order to make the upload to the REST API.

This PR rolls back the write-to-disk file handling and simplifies the logic related to passing the uploaded file to the REST API as a Buffer instead of a file Stream.

I'm really not sure if this will affect memory usage in prod, but it can't hurt. It should also make file uploads marginally faster.

In the future, I'd like to explore the possibility of setting up a proper proxy handler for file uploads using https://github.com/hapijs/h2o2, which _should_ allow files to be sent immediately to the REST API as they are being uploaded rather than the current handling which reads file uploads fully into memory before sending them on to the REST API.