### PR TITLE
WP-629: update duotone home endpoint logic to support most_popular row

### DIFF
--- a/packages/mwp-api-proxy-plugin/src/util/duotone.js
+++ b/packages/mwp-api-proxy-plugin/src/util/duotone.js
@@ -169,13 +169,7 @@ export const apiResponseDuotoneSetter = duotoneUrls => {
 				groups.forEach(setGroupDuotone);
 				break;
 			case 'home':
-				(value.rows || [])
-					.map(({ items }) => items)
-					.forEach(items =>
-						items
-							.filter(({ type }) => type === 'group')
-							.forEach(({ group }) => setGroupDuotone(group))
-					);
+				(value.most_popular || []).map(event => setGroupDuotone(event.group || {}));
 				break;
 		}
 		return queryResponse;

--- a/packages/mwp-api-proxy-plugin/src/util/duotone.js
+++ b/packages/mwp-api-proxy-plugin/src/util/duotone.js
@@ -169,7 +169,7 @@ export const apiResponseDuotoneSetter = duotoneUrls => {
 				groups.forEach(setGroupDuotone);
 				break;
 			case 'home':
-				(value.most_popular || []).map(event => setGroupDuotone(event.group || {}));
+				(value.most_popular || []).forEach(event => event.group = setGroupDuotone(event.group || {}));
 				break;
 		}
 		return queryResponse;

--- a/packages/mwp-api-proxy-plugin/src/util/duotone.test.js
+++ b/packages/mwp-api-proxy-plugin/src/util/duotone.test.js
@@ -103,17 +103,12 @@ describe('apiResponseDuotoneSetter', () => {
 		// self/home endpoint and then look for a property deep inside it
 		const group = { ...MOCK_GROUP, duotoneUrl: undefined };
 		const homeApiResponse = {
-			ref: 'memberHome',
+			ref: 'exploreHome',
 			type: 'home',
 			value: {
-				rows: [
+				most_popular: [
 					{
-						items: [
-							{
-								type: 'group',
-								group,
-							},
-						],
+						group,
 					},
 				],
 			},


### PR DESCRIPTION
We're launching a guest homepage split test later this week, and we want to duotone the images that get returned in the `explore/home` api request as part of the most popular events nearby. 

These changes continue the use of type to identify the endpoint, however, since we no longer have "rows" of groups, i've replaced the existing logic with this new logic.