### PR TITLE
Clean up API middleware signatures

### DIFF
--- a/packages/mwp-api-state/README.md
+++ b/packages/mwp-api-state/README.md
@@ -56,9 +56,3 @@ To send/receive data to/from the REST API, use `get`, `post`,
 `patch`, and `del` action creators from `api-state`.
 
 See the [Queries documentation](Queries.md) for more details on usage.
-
-## Dependencies
-
-- mwp-tracking-plugin/util/clickState
-- mwp-router
-- mwp-router/util

--- a/packages/mwp-api-state/src/index.js
+++ b/packages/mwp-api-state/src/index.js
@@ -27,11 +27,11 @@ export { api, app, DEFAULT_API_STATE } from './reducer';
  * order to render the application. We may want to write a server-specific
  * middleware that doesn't include the other epics if performance is an issue
  */
-export const getApiMiddleware = (routes, fetchQueriesFn, baseUrl) =>
+export const getApiMiddleware = (routeResolver, fetchQueriesFn) =>
 	createEpicMiddleware(
 		combineEpics(
 			getCacheEpic(),
-			getSyncEpic(routes, fetchQueriesFn, baseUrl),
+			getSyncEpic(routeResolver, fetchQueriesFn),
 			postEpic, // DEPRECATED
 			deleteEpic // DEPRECATED
 		)

--- a/packages/mwp-api-state/src/index.js
+++ b/packages/mwp-api-state/src/index.js
@@ -27,11 +27,11 @@ export { api, app, DEFAULT_API_STATE } from './reducer';
  * order to render the application. We may want to write a server-specific
  * middleware that doesn't include the other epics if performance is an issue
  */
-export const getApiMiddleware = (routeResolver, fetchQueriesFn) =>
+export const getApiMiddleware = (resolveRoutes, fetchQueriesFn) =>
 	createEpicMiddleware(
 		combineEpics(
 			getCacheEpic(),
-			getSyncEpic(routeResolver, fetchQueriesFn),
+			getSyncEpic(resolveRoutes, fetchQueriesFn),
 			postEpic, // DEPRECATED
 			deleteEpic // DEPRECATED
 		)

--- a/packages/mwp-api-state/src/sync/index.js
+++ b/packages/mwp-api-state/src/sync/index.js
@@ -198,9 +198,9 @@ export const getFetchQueriesEpic = fetchQueriesFn => {
 		);
 	};
 };
-export default (routeResolver, fetchQueriesFn) =>
+export default (resolveRoutes, fetchQueriesFn) =>
 	combineEpics(
-		getNavEpic(routeResolver),
+		getNavEpic(resolveRoutes),
 		getFetchQueriesEpic(fetchQueriesFn),
 		apiRequestToApiReq
 	);

--- a/packages/mwp-api-state/src/sync/index.test.js
+++ b/packages/mwp-api-state/src/sync/index.test.js
@@ -24,6 +24,8 @@ import { API_RESP_COMPLETE } from '../../lib/sync/apiActionCreators';
 
 MOCK_APP_STATE.config = {};
 MOCK_APP_STATE.routing = {};
+const MAKE_MOCK_RESOLVE_ROUTES = (queryFn = () => ({ params: {} })) => () =>
+	Promise.resolve([{ route: { query: queryFn }, match: { params: {} } }]);
 
 /**
  * @module SyncEpicTest
@@ -45,7 +47,7 @@ describe('Sync epic', () => {
 			};
 
 			const fakeStore = createFakeStore(MOCK_APP_STATE);
-			const navEpic = getNavEpic(MOCK_ROUTES);
+			const navEpic = getNavEpic(MAKE_MOCK_RESOLVE_ROUTES());
 			return Promise.all([
 				navEpic(locationChange, fakeStore),
 				navEpic(serverRender, fakeStore),
@@ -68,7 +70,7 @@ describe('Sync epic', () => {
 			};
 
 			const fakeStore = createFakeStore(MOCK_APP_STATE);
-			return getNavEpic(MOCK_ROUTES)(
+			return getNavEpic(MAKE_MOCK_RESOLVE_ROUTES())(
 				locationChange,
 				fakeStore
 			).then(actions => {
@@ -91,13 +93,15 @@ describe('Sync epic', () => {
 			};
 
 			const fakeStore = createFakeStore(MOCK_APP_STATE);
-			const navEpic = getNavEpic(MOCK_ROUTES);
+			const navEpic = getNavEpic(MAKE_MOCK_RESOLVE_ROUTES(null));
 			return Promise.all([
 				navEpic(locationChange, fakeStore),
 				navEpic(serverRender, fakeStore),
 			]).then(actionArrays => {
 				actionArrays.forEach(actions => {
-					expect(actions.map(({ type }) => type)).toEqual([API_RESP_COMPLETE]);
+					expect(actions.map(({ type }) => type)).toEqual([
+						API_RESP_COMPLETE,
+					]);
 				});
 			});
 		});
@@ -114,22 +118,23 @@ describe('Sync epic', () => {
 			};
 
 			const fakeStore = createFakeStore(MOCK_APP_STATE);
-			const navEpic = getNavEpic([
-				{ path: pathname, component: () => {}, query: () => null },
-			]);
+			const navEpic = getNavEpic(MAKE_MOCK_RESOLVE_ROUTES(() => null));
 			return Promise.all([
 				navEpic(locationChange, fakeStore),
 				navEpic(serverRender, fakeStore),
 			]).then(actionArrays => {
 				actionArrays.forEach(actions => {
-					expect(actions.map(({ type }) => type)).toEqual([API_RESP_COMPLETE]);
+					expect(actions.map(({ type }) => type)).toEqual([
+						API_RESP_COMPLETE,
+					]);
 				});
 			});
 		});
 	});
 	describe('getFetchQueriesEpic', () => {
 		it('emits API_RESP_SUCCESS and API_RESP_COMPLETE on successful API_REQ', function() {
-			const mockFetchQueries = () => () => Promise.resolve({ successes: [{}] });
+			const mockFetchQueries = () => () =>
+				Promise.resolve({ successes: [{}] });
 
 			const queries = [mockQuery({})];
 			const apiRequest = api.get(queries);
@@ -205,7 +210,9 @@ describe('Sync epic', () => {
 				apiRequest,
 				fakeStore
 			).then(actions => {
-				expect(apiRequest.meta.resolve).toHaveBeenCalledWith(expectedSuccesses);
+				expect(apiRequest.meta.resolve).toHaveBeenCalledWith(
+					expectedSuccesses
+				);
 			});
 		});
 
@@ -239,7 +246,9 @@ describe('Sync epic', () => {
 				apiRequest,
 				fakeStore
 			).then(actions =>
-				expect(apiRequest.meta.reject).toHaveBeenCalledWith(expectedError)
+				expect(apiRequest.meta.reject).toHaveBeenCalledWith(
+					expectedError
+				)
 			);
 		});
 	});

--- a/packages/mwp-core/package.json
+++ b/packages/mwp-core/package.json
@@ -35,6 +35,7 @@
     "mwp-api-proxy-plugin": ">=0.0.1",
     "mwp-app-render": ">=0.0.1",
     "mwp-logger-plugin": ">=0.0.1",
+    "mwp-router": ">=0.0.1",
     "mwp-store": ">=0.0.1",
     "node-fetch": "1.7.2",
     "pino": "4.7.1",

--- a/packages/mwp-core/src/renderers/browser-render.jsx
+++ b/packages/mwp-core/src/renderers/browser-render.jsx
@@ -26,10 +26,10 @@ export function resolveAppProps(
 	middleware: Array<Object> = []
 ): Promise<AppProps> {
 	const basename = window.APP_RUNTIME.baseUrl || '';
-	const routeResolver = getRouteResolver(routes, basename);
-	const createStore = getBrowserCreateStore(routeResolver, middleware);
+	const resolveRoutes = getRouteResolver(routes, basename);
+	const createStore = getBrowserCreateStore(resolveRoutes, middleware);
 	const store = createStore(reducer, getInitialState(window.APP_RUNTIME));
-	return routeResolver(window.location).then(() => ({
+	return resolveRoutes(window.location).then(() => ({
 		routes,
 		store,
 		basename,

--- a/packages/mwp-core/src/renderers/browser-render.jsx
+++ b/packages/mwp-core/src/renderers/browser-render.jsx
@@ -26,9 +26,10 @@ export function resolveAppProps(
 	middleware: Array<Object> = []
 ): Promise<AppProps> {
 	const basename = window.APP_RUNTIME.baseUrl || '';
-	const createStore = getBrowserCreateStore(routes, middleware, basename);
+	const routeResolver = getRouteResolver(routes, basename);
+	const createStore = getBrowserCreateStore(routeResolver, middleware);
 	const store = createStore(reducer, getInitialState(window.APP_RUNTIME));
-	return getRouteResolver(routes, basename)(window.location).then(() => ({
+	return routeResolver(window.location).then(() => ({
 		routes,
 		store,
 		basename,

--- a/packages/mwp-core/src/renderers/server-render.jsx
+++ b/packages/mwp-core/src/renderers/server-render.jsx
@@ -7,6 +7,7 @@ import MobileDetect from 'mobile-detect';
 
 import { API_ROUTE_PATH } from 'mwp-api-proxy-plugin';
 import { Forbidden, NotFound, Redirect, SERVER_RENDER } from 'mwp-router';
+import { getRouteResolver } from 'mwp-router/lib/util';
 import { getServerCreateStore } from 'mwp-store/lib/server';
 import Dom from 'mwp-app-render/lib/components/Dom';
 import ServerApp from 'mwp-app-render/lib/components/ServerApp';
@@ -72,7 +73,7 @@ const getMedia = (userAgent: string) => {
 			userAgent === 'mobilebot' ||
 			userAgent === 'mobile';
 		isTablet = userAgent === 'tablet';
-	};
+	}
 	return {
 		isAtSmallUp,
 		isAtMediumUp: isTablet || !isMobile,
@@ -260,10 +261,9 @@ const makeRenderer = (
 	};
 
 	const createStore = getServerCreateStore(
-		routes,
+		getRouteResolver(routes, baseUrl),
 		middleware,
-		request,
-		baseUrl
+		request
 	);
 	const store = createStore(reducer, initialState);
 

--- a/packages/mwp-store/src/browser/index.js
+++ b/packages/mwp-store/src/browser/index.js
@@ -40,10 +40,10 @@ export const getInitialState = (APP_RUNTIME: {
 	return JSON.parse(unescapedStateJSON);
 };
 
-export function getBrowserCreateStore(routeResolver, middleware = []) {
+export function getBrowserCreateStore(resolveRoutes, middleware = []) {
 	const middlewareToApply = [
 		catchMiddleware(console.error),
-		getApiMiddleware(routeResolver, fetchQueries),
+		getApiMiddleware(resolveRoutes, fetchQueries),
 		...middleware,
 		window.mupDevTools ? window.mupDevTools() : noopMiddleware, // must be last middleware
 	];

--- a/packages/mwp-store/src/browser/index.js
+++ b/packages/mwp-store/src/browser/index.js
@@ -40,10 +40,10 @@ export const getInitialState = (APP_RUNTIME: {
 	return JSON.parse(unescapedStateJSON);
 };
 
-export function getBrowserCreateStore(routes, middleware = [], baseUrl) {
+export function getBrowserCreateStore(routeResolver, middleware = []) {
 	const middlewareToApply = [
 		catchMiddleware(console.error),
-		getApiMiddleware(routes, fetchQueries, baseUrl),
+		getApiMiddleware(routeResolver, fetchQueries),
 		...middleware,
 		window.mupDevTools ? window.mupDevTools() : noopMiddleware, // must be last middleware
 	];

--- a/packages/mwp-store/src/server/index.js
+++ b/packages/mwp-store/src/server/index.js
@@ -12,7 +12,7 @@ import catchMiddleware from '../middleware/catch';
  * @param {Array} middleware additional middleware to inject into store
  * @param {Object} request the Hapi request for this store
  */
-export function getServerCreateStore(routes, middleware, request, baseUrl) {
+export function getServerCreateStore(routeResolver, middleware, request) {
 	const middlewareToApply = [
 		catchMiddleware(err =>
 			request.server.app.logger.error({
@@ -21,7 +21,7 @@ export function getServerCreateStore(routes, middleware, request, baseUrl) {
 				...request.raw,
 			})
 		),
-		getApiMiddleware(routes, getFetchQueries(request), baseUrl),
+		getApiMiddleware(routeResolver, getFetchQueries(request)),
 		...middleware,
 	];
 

--- a/packages/mwp-store/src/server/index.js
+++ b/packages/mwp-store/src/server/index.js
@@ -12,7 +12,7 @@ import catchMiddleware from '../middleware/catch';
  * @param {Array} middleware additional middleware to inject into store
  * @param {Object} request the Hapi request for this store
  */
-export function getServerCreateStore(routeResolver, middleware, request) {
+export function getServerCreateStore(resolveRoutes, middleware, request) {
 	const middlewareToApply = [
 		catchMiddleware(err =>
 			request.server.app.logger.error({
@@ -21,7 +21,7 @@ export function getServerCreateStore(routeResolver, middleware, request) {
 				...request.raw,
 			})
 		),
-		getApiMiddleware(routeResolver, getFetchQueries(request)),
+		getApiMiddleware(resolveRoutes, getFetchQueries(request)),
 		...middleware,
 	];
 


### PR DESCRIPTION
instead of passing `routes` and `baseUrl` to `getApiMiddleware`, we can instead just pass a route-resolving function. This reduces the `mwp-router` dependency in `mwp-api-state` (although it doesn't eliminate it) and makes the middleware function signatures a little simpler. It also brings the power of the `routeResolver` function to `server-render`, which will be useful for WP-547