### PR TITLE
Added localized language names to mwp-i18n

### DIFF
--- a/packages/mwp-i18n/src/localizedLanguageMap.js
+++ b/packages/mwp-i18n/src/localizedLanguageMap.js
@@ -1,0 +1,19 @@
+const localizedLanguageMap = {
+	'en-US': 'English',
+	'en-AU': 'English (Australia)',
+	'de-DE': 'Deutsch',
+	es: 'Español',
+	'es-ES': 'Español (España)',
+	'fr-FR': 'Français',
+	'it-IT': 'Italiano',
+	'nl-NL': 'Nederlands',
+	'pl-PL': 'Polski',
+	'pt-BR': 'Português',
+	'tr-TR': 'Türkçe',
+	'th-TH': 'ไทย',
+	'ja-JP': '日本語',
+	'ko-KR': '한국어',
+	'ru-RU': 'Русский',
+};
+
+export default localizedLanguageMap;

--- a/packages/mwp-i18n/src/localizedLanguageMap.test.js
+++ b/packages/mwp-i18n/src/localizedLanguageMap.test.js
@@ -1,0 +1,10 @@
+import localizedLanguageMap from './localizedLanguageMap';
+import { locales } from 'mwp-config';
+
+describe('localizedLanguageMap', () => {
+	it('has a localized name for every item in `mwp-config/locales`', () => {
+		locales.forEach(locale => {
+			expect(Object.keys(localizedLanguageMap).includes(locale)).toBeTruthy();
+		});
+	});
+});


### PR DESCRIPTION
Related issue: https://meetup.atlassian.net/browse/WC-178

This is to support the use of `Footer` across both web apps, and potentially for supporting `AppBadges` in MWC