### PR TITLE
GoogleTagManager component

### DIFF
--- a/packages/mwp-app-render/src/components/GoogleTagManager.jsx
+++ b/packages/mwp-app-render/src/components/GoogleTagManager.jsx
@@ -1,0 +1,36 @@
+// @flow
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+// Production and dev keys
+const GTM_KEY = process.env.NODE_ENV === 'production' ? 'GTM-T2LNGD' : 'GTM-W9W847';
+
+/*
+ * @description Gets google tag manager script tag
+ * @see {@link https://developers.google.com/tag-manager/quickstart}
+*/
+export const GoogleTagManagerScript = (key : string = GTM_KEY) => {
+	const script = `
+		(function(w,d,s,l,i){
+			w[l]=w[l]||[];
+			w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});
+			var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';
+			j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;
+			f.parentNode.insertBefore(j,f);
+		})(window,document,'script','dataLayer','${GTM_KEY}');`
+	return <script dangerouslySetInnerHtml={{ __html: script }}></script>
+};
+
+/*
+ * @description Gets google tag manager noscript tag
+ * @see {@link https://developers.google.com/tag-manager/quickstart}
+*/
+export const GoogleTagManagerNoscript = (key : string  = GTM_KEY) => {
+	const iframe = `
+		<iframe
+			src="https://www.googletagmanager.com/ns.html?id=${GTM_KEY}"
+			height="0" width="0" style="display:none;visibility:hidden">
+		</iframe>`;
+	return <noscript dangerouslySetInnerHtml={{ __html: iframe }}></noscript>
+};

--- a/packages/mwp-app-render/src/components/GoogleTagManager.test.jsx
+++ b/packages/mwp-app-render/src/components/GoogleTagManager.test.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { GoogleTagManagerScript, GoogleTagManagerNoscript } from './GoogleTagManager';
+
+describe('<GoogleTagManagerScript />', () => {
+	it('matches snap', () => {
+		expect(shallow(<GoogleTagManagerScript />)).toMatchSnapshot();
+	});
+});
+
+describe('<GoogleTagManagerNoscript />', () => {
+	it('matches snap', () => {
+		expect(shallow(<GoogleTagManagerNoscript />)).toMatchSnapshot();
+	});
+});

--- a/packages/mwp-app-render/src/components/__snapshots__/GoogleTagManager.test.jsx.snap
+++ b/packages/mwp-app-render/src/components/__snapshots__/GoogleTagManager.test.jsx.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<GoogleTagManagerNoscript /> matches snap 1`] = `
+<noscript
+  dangerouslySetInnerHtml={
+    Object {
+      "__html": "
+    		<iframe
+    			src=\\"https://www.googletagmanager.com/ns.html?id=GTM-W9W847\\"
+    			height=\\"0\\" width=\\"0\\" style=\\"display:none;visibility:hidden\\">
+    		</iframe>",
+    }
+  }
+/>
+`;
+
+exports[`<GoogleTagManagerScript /> matches snap 1`] = `
+<script
+  dangerouslySetInnerHtml={
+    Object {
+      "__html": "
+    		(function(w,d,s,l,i){
+    			w[l]=w[l]||[];
+    			w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});
+    			var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';
+    			j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;
+    			f.parentNode.insertBefore(j,f);
+    		})(window,document,'script','dataLayer','GTM-W9W847');",
+    }
+  }
+/>
+`;


### PR DESCRIPTION
Draft version of what a bespoke `<GoogleTagManager />` comp could look like.

https://developers.google.com/tag-manager/quickstart

The basic idea.
```
<head>
    <!-- Part 1: GTM script (because Google wants this close to the top of the head tag) -->
    <GoogleTagManagerScript />
</head>
<body>
    <!-- Part 2: GTM noscript (because Google wants this right after opening body tag) -->
    <GoogleTagManagerNoscript />
    <div>more app html</div>
</body>
```

To do / discuss:
- ~~Integration touch point.~~ Spoke to Mike M. and we think `Dom.jsx`
- What about a package? (Pro web used this)
-- https://github.com/holidaycheck/react-google-tag-manager
- Performance concerns. 
-- _Note:_ this draft version implements GTM as per Google's suggestions. However, we should probably discuss if we can deviate.
- Supporting data:
-- RTF: I think we can pass a flag to `Dom` from `server-render`?
- `dataLayerName` -- not sure if this is dynamic
