### PR TITLE
inject member id for cache key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [12.4]
+
+* **Bugfix** the Redux cache middleware will now key the cache with the logged-in
+  member's ID in order to avoid incorrectly returning cached results corresponding
+  to other members or logged-out responses.
+
+
 ## [12.3]
 
 - **New feature** `SEOHead` a component for rendering SEO content in the document head. Also adds related utils under `src/util/seo`. [WP-532](https://meetup.atlassian.net/browse/WP-532)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CI_BUILD_NUMBER ?= $(USER)-snapshot
-VERSION ?= 12.3.$(CI_BUILD_NUMBER)
+VERSION ?= 12.4.$(CI_BUILD_NUMBER)
 
 version:
 	@echo $(VERSION)

--- a/packages/mwp-api-state/src/cache/index.test.js
+++ b/packages/mwp-api-state/src/cache/index.test.js
@@ -17,24 +17,34 @@ const MOCK_SUCCESS_ACTION = api.success({
 });
 const apiRequestAction = api.get(MOCK_QUERY);
 
+const fakeStore = {
+	getState() {
+		return { api: {} };
+	},
+	dispatch() {},
+	subscribe() {},
+};
+
 function makeCacheEpic() {
 	return Promise.resolve(getCacheEpic(makeCache()));
 }
 function populateCacheEpic(CacheEpic) {
 	// set the cache with API_SUCCESS
-	return CacheEpic(MOCK_SUCCESS_ACTION).then(() => CacheEpic);
+	return CacheEpic(MOCK_SUCCESS_ACTION, fakeStore).then(() => CacheEpic);
 }
 
 function clearCacheEpic(CacheEpic) {
 	// clear the cache with CACHE_CLEAR
-	return CacheEpic({ type: CACHE_CLEAR }).then(() => CacheEpic);
+	return CacheEpic({ type: CACHE_CLEAR }, fakeStore).then(() => CacheEpic);
 }
 
 const testForEmptyCache = (action = apiRequestAction) => CacheEpic =>
-	CacheEpic(action).then(actions => expect(actions).toHaveLength(0));
+	CacheEpic(action, fakeStore).then(actions =>
+		expect(actions).toHaveLength(0)
+	);
 
 const testForPopulatedCache = (action = apiRequestAction) => CacheEpic =>
-	CacheEpic(action).then(actions =>
+	CacheEpic(action, fakeStore).then(actions =>
 		expect(actions.map(({ type }) => type)).toContain(CACHE_SUCCESS)
 	);
 

--- a/packages/mwp-api-state/src/cache/util.js
+++ b/packages/mwp-api-state/src/cache/util.js
@@ -40,14 +40,17 @@ export function makeCache(): Cache {
 	return require('idb-keyval');
 }
 
+const makeKey = (memberId: string, query: Query) =>
+	`${memberId}${JSON.stringify(query)}`;
+
 /**
  * Generates a function that can read queries and return hits in the supplied cache
  */
-export const cacheReader = (cache: Cache) => (
+export const cacheReader = (cache: Cache, memberId: string) => (
 	query: Query
 ): Promise<QueryState> =>
 	cache
-		.get(JSON.stringify(query))
+		.get(makeKey(memberId, query))
 		.then((response: QueryResponse) => ({ query, response }))
 		.catch(err => ({ query, response: null })); // errors don't matter - just return null
 
@@ -57,7 +60,7 @@ export const cacheReader = (cache: Cache) => (
  * It will ignore non-GET responses and any responses to queries that have
  * opted-out of caching with `query.meta.noCache`
  */
-export const cacheWriter = (cache: Cache) => (
+export const cacheWriter = (cache: Cache, memberId: string) => (
 	query: Query,
 	response: QueryResponse
 ): Promise<boolean> => {
@@ -66,5 +69,5 @@ export const cacheWriter = (cache: Cache) => (
 		// skip cache writing
 		return Promise.resolve(true);
 	}
-	return cache.set(JSON.stringify(query), response);
+	return cache.set(makeKey(memberId, query), response);
 };

--- a/packages/mwp-api-state/src/cache/util.test.js
+++ b/packages/mwp-api-state/src/cache/util.test.js
@@ -34,8 +34,8 @@ describe('cache utils', () => {
 		const cache = makeCache();
 		const query = { foo: 'baz' };
 		const response = 'bar';
-		return cacheWriter(cache)(query, response)
-			.then(() => cache.get(JSON.stringify(query)))
+		return cacheWriter(cache, 'memberId')(query, response)
+			.then(() => cache.get(`memberId${JSON.stringify(query)}`))
 			.then(cachedResponse => expect(cachedResponse).toEqual(response));
 	});
 


### PR DESCRIPTION
By adding the current `memberId` into the cache key, we can avoid stale state errors coming from changes in logged-in/out status.

It also provides a minor additional privacy layer for cached data