### PR TITLE
polyfill.io fixes

### DIFF
--- a/packages/mwp-app-render/src/components/Dom.jsx
+++ b/packages/mwp-app-render/src/components/Dom.jsx
@@ -48,9 +48,7 @@ const DOM = props => {
 	 * Add polyfill.io script if needed
 	 */
 	const polyfill = getPolyfill(userAgent, localeCode);
-	if (polyfill) {
-		scripts.unshift(polyfill);
-	}
+	const js = polyfill ? [polyfill, ...scripts] : [...scripts];
 
 	/**
 	 * `initialState` has untrusted user-generated content that needs to be
@@ -96,7 +94,7 @@ const DOM = props => {
 						`window.APP_RUNTIME=${JSON.stringify(APP_RUNTIME)};`
 					)}
 				/>
-				{scripts.map((url, key) => <script src={url} key={key} />)}
+				{js.map((url, key) => <script src={url} key={key} />)}
 			</body>
 		</html>
 	);


### PR DESCRIPTION
There are two issues:

1. Firstly, in production, the userAgent string is being set to the `x-ua-device` header as opposed to `user-agent` header. This was causing 500 errors in environments where there is no fastly layer to supply the `x-ua-device` header but also causing the `getPolyfill` method to return the polyfill.io url for browsers such as Chrome and Firefox that don't need it.

2. In browsers like safari where the polyfill.io script is required, we are seeing it appended multiple times to the page. See prod screenshot. 

<img width="1199" alt="screen shot 2018-03-22 at 10 22 22 am" src="https://user-images.githubusercontent.com/1033572/37787939-928eefe2-2dd6-11e8-8efb-aaf9d4305e83.png">


- [x] Fix useragent and device issues
- [x] Fix multiple script tags issue