### PR TITLE
MG-719: Support click tracking headers

### DIFF
--- a/packages/mwp-app-route-plugin/src/route.js
+++ b/packages/mwp-app-route-plugin/src/route.js
@@ -12,7 +12,11 @@ export const onPreResponse = {
 	 */
 	method: (request: HapiRequest, reply: HapiReply) => {
 		const response = request.response;
-
+		const trackingParam = request.query['_xtd'];
+		if (trackingParam) {
+			response.header('X-Meetup-External-Track', trackingParam);
+			response.header('X-Meetup-External-Track-Url', request.response.referer);
+		}
 		if (!response.isBoom || process.env.NODE_ENV === 'production') {
 			return reply.continue();
 		}

--- a/packages/mwp-app-route-plugin/src/route.js
+++ b/packages/mwp-app-route-plugin/src/route.js
@@ -3,6 +3,9 @@ import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 import getHandler from './handler';
 
+export const EXTERNAL_TRACK_HEADER = 'x-meetup-external-track';
+export const EXTERNAL_TRACK_URL_HEADER = 'x-meetup-external-track-url';
+
 export const onPreResponse = {
 	/*
 	 * This function processes the route response before it is sent to the client.
@@ -12,10 +15,12 @@ export const onPreResponse = {
 	 */
 	method: (request: HapiRequest, reply: HapiReply) => {
 		const response = request.response;
-		const trackingParam = request.query['_xtd'];
-		if (trackingParam) {
-			response.header('X-Meetup-External-Track', trackingParam);
-			response.header('X-Meetup-External-Track-Url', request.response.referer);
+		if (request.query) {
+			const trackingParam = request.query['_xtd']
+			if (trackingParam) {
+				response.header(EXTERNAL_TRACK_HEADER, trackingParam);
+				response.header(EXTERNAL_TRACK_URL_HEADER, request.url.href);
+			}
 		}
 		if (!response.isBoom || process.env.NODE_ENV === 'production') {
 			return reply.continue();

--- a/packages/mwp-app-route-plugin/src/route.test.js
+++ b/packages/mwp-app-route-plugin/src/route.test.js
@@ -9,7 +9,7 @@ describe('onPreResponse.method', () => {
 		const errorMessage = 'foobar';
 		const errorCode = 432;
 		const response = Boom.create(errorCode, errorMessage);
-		response.header = ((key,val) =>val)
+		response.header = ((key, val) => val)
 
 		const request = {
 			response,
@@ -17,7 +17,7 @@ describe('onPreResponse.method', () => {
 			server: getServer(),
 		};
 		const replyObj = {
-			code() {},
+			code() { },
 		};
 		const spyable = {
 			reply: () => replyObj,
@@ -29,6 +29,21 @@ describe('onPreResponse.method', () => {
 		const errorMarkup = spyable.reply.calls.mostRecent().args[0];
 		expect(errorMarkup).toContain(errorMessage);
 		expect(replyObj.code).toHaveBeenCalledWith(errorCode);
+	});
+	it('returns X-Meetup-External-Track and X-Meetup-External-Track-Url headers if _xtd query param exists', () => {
+		const server = getServer();
+		const result = 'ok';
+		server.route(
+			getRoute({
+				'en-US': () => Promise.resolve({ statusCode: 200, result }),
+			})
+		);
+		return server
+			.inject({ url: '/?_xtd=helloIAmAJunkParam' })
+			.then(response => {
+				expect(response.headers['X-Meetup-External-Track']).toBe('helloIAmAJunkParam');
+				expect(response.headers['X-Meetup-External-Track-Url']).toBe(request.route);
+			});
 	});
 	it('serves the homepage route', () => {
 		const server = getServer();

--- a/packages/mwp-app-route-plugin/src/route.test.js
+++ b/packages/mwp-app-route-plugin/src/route.test.js
@@ -1,7 +1,7 @@
 import Boom from 'boom';
 import { MOCK_RENDER_RESULT } from 'meetup-web-mocks/lib/app';
 import { getServer } from 'mwp-test-utils';
-import getRoute, { onPreResponse } from './route';
+import getRoute, { onPreResponse, EXTERNAL_TRACK_HEADER, EXTERNAL_TRACK_URL_HEADER } from './route';
 
 describe('onPreResponse.method', () => {
 	it('returns html containing error message', () => {
@@ -38,11 +38,12 @@ describe('onPreResponse.method', () => {
 				'en-US': () => Promise.resolve({ statusCode: 200, result }),
 			})
 		);
+		const mockXtd = 'helloIAmAJunkParam';
 		return server
-			.inject({ url: '/?_xtd=helloIAmAJunkParam' })
+			.inject({ url: `/?junk=junkyjunk&_xtd=${mockXtd}` })
 			.then(response => {
-				expect(response.headers['X-Meetup-External-Track']).toBe('helloIAmAJunkParam');
-				expect(response.headers['X-Meetup-External-Track-Url']).toBe(request.route);
+				expect(response.headers[EXTERNAL_TRACK_HEADER]).toBe(mockXtd);
+				expect(response.headers[EXTERNAL_TRACK_URL_HEADER]).toBe(response.request.url.href);
 			});
 	});
 	it('serves the homepage route', () => {


### PR DESCRIPTION
In order to track urls with `_xtd` query params in mup-web
- check if query param exists
- add `X-Meetup-External-Track` and `X-Meetup-External-Track-Url ` onPreResponse
- add tests