### PR TITLE
SEO util: fix leading comma issue in getGroupKeywords()

### DIFF
--- a/packages/mwp-app-render/src/util/seo/__snapshots__/metaTags.test.js.snap
+++ b/packages/mwp-app-render/src/util/seo/__snapshots__/metaTags.test.js.snap
@@ -341,3 +341,7 @@ Array [
 />,
 ]
 `;
+
+exports[`getGroupKeywords matches snap for group with no topics 1`] = `"Test group,Albuquerque,NM,us"`;
+
+exports[`getGroupKeywords matches snap for group with topics 1`] = `"hiking,beagles,programming,Test group,Albuquerque,NM,us"`;

--- a/packages/mwp-app-render/src/util/seo/metaTags.jsx
+++ b/packages/mwp-app-render/src/util/seo/metaTags.jsx
@@ -47,7 +47,7 @@ export const getKeywordsByProperties = (item, keys) =>
  */
 export const getGroupKeywords = group => {
 	const topics = group.topics || [];
-	const topicKeywords = topics => topics.map(topic => topic.name);
+	const topicKeywords = topics.map(topic => topic.name);
 	const groupKeys = ['name', 'city', 'state', 'country'];
 	return [...topicKeywords, ...getKeywordsByProperties(group, groupKeys)].join(',');
 };

--- a/packages/mwp-app-render/src/util/seo/metaTags.test.js
+++ b/packages/mwp-app-render/src/util/seo/metaTags.test.js
@@ -1,4 +1,12 @@
-import { generateMetaData, generateMetaTags, generateGeoMetaData } from './metaTags';
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import {
+	generateMetaData,
+	generateMetaTags,
+	generateGeoMetaData,
+	getGroupKeywords,
+} from './metaTags';
 
 const MOCK_META = {
 	appPath: '/mock/app/path',
@@ -67,5 +75,25 @@ describe('generateGeoMetaData', () => {
 		delete mockGeo.state;
 		const geoMetaData = generateGeoMetaData(mockGeo);
 		expect(geoMetaData).toMatchSnapshot();
+	});
+});
+
+describe('getGroupKeywords', () => {
+	const group = {
+		name: 'Test group',
+		city: 'Albuquerque',
+		state: 'NM',
+		country: 'us',
+	};
+	it('matches snap for group with topics', () => {
+		const keywords = getGroupKeywords({
+			...group,
+			topics: [{name: 'hiking'},{name: 'beagles'},{name: 'programming'}]
+		});
+		expect(keywords).toMatchSnapshot();
+	});
+	it('matches snap for group with no topics', () => {
+		const keywords = getGroupKeywords(group);
+		expect(keywords).toMatchSnapshot();
 	});
 });


### PR DESCRIPTION
https://meetup.atlassian.net/browse/WP-668

Refactor gone wrong.

Problem -- groups without `topics` results in a unwanted leading comma.
```
const group = {
  name: 'Test group',
  city: 'Albuquerque',
  state: 'NM',
  country: 'us',
};

 // returns ",Test group,Albuquerque,NM,us" instead of  "Test group,Albuquerque,NM,us"
const groupKeywords = getGroupKeywords(group);
```