### PR TITLE
Add full url to X-Meetup-External-Track-Url header

### DIFF
--- a/packages/mwp-api-proxy-plugin/src/util/send.js
+++ b/packages/mwp-api-proxy-plugin/src/util/send.js
@@ -212,7 +212,7 @@ export function getTrackingHeaders(request) {
 	if (trackingParam) {
 		return {
 			'X-Meetup-External-Track': trackingParam,
-			'X-Meetup-External-Track-Url': `${host}` + request.url.href,
+			'X-Meetup-External-Track-Url': `${host}${request.url.href}`,
 		};
 	}
 	return {};

--- a/packages/mwp-api-proxy-plugin/src/util/send.test.js
+++ b/packages/mwp-api-proxy-plugin/src/util/send.test.js
@@ -112,13 +112,18 @@ describe('getTrackingHeaders', () => {
 	it('returns a x-meetup-external-track and x-meetup-external-track-url header when the _xtd query param exists', () => {
 		const externalTrackHeaders = {
 			'X-Meetup-External-Track': 'helloIAmRandom',
-			'X-Meetup-External-Track-Url': 'https://www.meetup.com/cool-meetup/events/123',
+			'X-Meetup-External-Track-Url':
+				'https://www.meetup.com/cool-meetup/events/123',
 		};
 		const request = {
-			query: { '_xtd': 'helloIAmRandom' },
+			query: { _xtd: 'helloIAmRandom' },
 			url: {
-				href: 'https://www.meetup.com/cool-meetup/events/123'
-			}
+				href: '/cool-meetup/events/123',
+			},
+			headers: {
+				'x-forwarded-proto': 'https',
+				'x-meetup-host': 'www.meetup.com',
+			},
 		};
 		expect(getTrackingHeaders(request)).toEqual(externalTrackHeaders);
 	});
@@ -126,6 +131,10 @@ describe('getTrackingHeaders', () => {
 	it('Does not set the header if query param is not set', () => {
 		const request = {
 			query: {},
+			headers: {
+				'x-forwarded-proto': 'https',
+				'x-meetup-host': 'www.meetup.com',
+			},
 		};
 		expect(getTrackingHeaders(request)).toEqual({});
 	});


### PR DESCRIPTION
This is the original ticket: https://meetup.atlassian.net/browse/MG-719
This is a follow up to this: https://github.com/meetup/meetup-web-platform/pull/457

Originally, the 'route' or everything after `https://meetup.com` was being logged as the track url. 
For tracking purposes, we need log the full url. This adds that. 