### PR TITLE
MP-735: Added GTM dataLayer init snippet

### DIFF
--- a/packages/mwp-app-render/src/util/__snapshots__/googleTagManager.test.js.snap
+++ b/packages/mwp-app-render/src/util/__snapshots__/googleTagManager.test.js.snap
@@ -1,5 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`getDataLayerInitSnippet() should match the snapshot with some \`data\` 1`] = `"dataLayer=[{\\"foo\\":\\"bar\\"}]"`;
+
+exports[`getDataLayerInitSnippet() should match the snapshot without \`data\` passed 1`] = `"dataLayer=[]"`;
+
 exports[`getGoogleTagManagerSnippet() matches snap 1`] = `
 "(function(w,d,s,l,i){
 		w[l]=w[l]||[];

--- a/packages/mwp-app-render/src/util/googleTagManager.js
+++ b/packages/mwp-app-render/src/util/googleTagManager.js
@@ -5,6 +5,14 @@ const GTM_KEY =
 	process.env.NODE_ENV === 'production' ? 'GTM-T2LNGD' : 'GTM-W9W847';
 
 /**
+ * @description Gets dataLayer initialization snippet with initial values provided
+ * It's important to use this snippet before getGoogleTagManagerSnippet()
+ * @see {@link https://developers.google.com/tag-manager/devguide#datalayer}
+ */
+export const getDataLayerInitSnippet = (data: { [string]: string }): string =>
+	`dataLayer=[${data ? JSON.stringify(data) : ''}]`;
+
+/**
  * @description Method for passing additional variables to GTM
  * @see {@link https://developers.google.com/tag-manager/devguide}
  */

--- a/packages/mwp-app-render/src/util/googleTagManager.test.js
+++ b/packages/mwp-app-render/src/util/googleTagManager.test.js
@@ -1,6 +1,8 @@
-import React from 'react';
-import { getGoogleTagManagerSnippet, gtmPush } from './googleTagManager';
-
+import {
+	getGoogleTagManagerSnippet,
+	getDataLayerInitSnippet,
+	gtmPush,
+} from './googleTagManager';
 
 describe('getGoogleTagManagerSnippet()', () => {
 	it('matches snap', () => {
@@ -8,8 +10,20 @@ describe('getGoogleTagManagerSnippet()', () => {
 	});
 });
 
+describe('getDataLayerInitSnippet()', () => {
+	const MOCK_INIT_DATA = { foo: 'bar' };
+
+	it('should match the snapshot without `data` passed', () => {
+		expect(getDataLayerInitSnippet()).toMatchSnapshot();
+	});
+
+	it('should match the snapshot with some `data`', () => {
+		expect(getDataLayerInitSnippet(MOCK_INIT_DATA)).toMatchSnapshot();
+	});
+});
+
 describe('gtmPush()', () => {
-	const MOCK_VARS = { 'foo': 'bar' };
+	const MOCK_VARS = { foo: 'bar' };
 
 	it('should push mocked variables to `dataLayer`', () => {
 		global.window = {};


### PR DESCRIPTION
Initialization of dataLayer will help to provide initial data which can be used by GTM for PageView event.
It is going to be used in the same way as getGoogleTagManagerSnippet() e.g.
`<script>{getGoogleTagManagerSnippet()}</script>`
