### PR TITLE
check if getCss is defined in StylesWith to prevent test errors

### DIFF
--- a/packages/mwp-app-render/src/components/StyleWith.jsx
+++ b/packages/mwp-app-render/src/components/StyleWith.jsx
@@ -28,7 +28,9 @@ const StyleWith = props => {
 
 	const moduleCSS = new Set();
 	styles.forEach(style => {
-		moduleCSS.add(style._getCss()); // eslint-disable-line no-underscore-dangle
+		if (typeof style._getCss === 'function') {
+			moduleCSS.add(style._getCss()); // eslint-disable-line no-underscore-dangle
+		}
 	});
 
 	return (


### PR DESCRIPTION
Because tests do not run style imports through our webpack loaders, the `_getCss` function will not be defined in any style objects passed into `StyleWith` when run in a unit test.

This branch adds a check to see if the function is defined before invoking it.