### PR TITLE
add jest mocks for style modules to mwp-test-utils

### DIFF
--- a/packages/mwp-test-utils/__mocks__/StyleWith.jsx
+++ b/packages/mwp-test-utils/__mocks__/StyleWith.jsx
@@ -1,0 +1,8 @@
+/**
+ * @module StyleWith (mock)
+ * For tests, we do not need to write styles to a document.
+ * This mock simply returns the wrapped component(s).
+ */
+const StyleWith = props => props.children;
+
+export default StyleWith;

--- a/packages/mwp-test-utils/__mocks__/styleModule.js
+++ b/packages/mwp-test-utils/__mocks__/styleModule.js
@@ -1,0 +1,20 @@
+/**
+ * Style module objects are expected to have className keys with
+ * localized className values.
+ *
+ * This Proxy will return the name of the key being accessed, so snapshots
+ * will be rendered with plain, unlocalized class names.
+ */
+const styleMock = new Proxy(
+	{},
+	{
+		get: (target, key) => {
+			if (key === '__esModule') {
+				return false;
+			}
+			return key;
+		},
+	}
+);
+
+module.exports = styleMock;


### PR DESCRIPTION
Adds jest `__mocks__` for style module handling to `mwp-test-utils`.

- `__mocks__/styleModule.js` ensures the plain className will render in snapshots
- `__mocks__/StyleWith.jsx` returns wrapped components without adding anything to `Helmet` (we don't need to write styles to a document in tests)