### PR TITLE
send the whole member object to all_flags

### DIFF
--- a/packages/mwp-app-route-plugin/src/index.js
+++ b/packages/mwp-app-route-plugin/src/index.js
@@ -21,18 +21,19 @@ export default function register(
 	const ldClient = LaunchDarkly.init(options.ldkey || LAUNCH_DARKLY_SDK_KEY, {
 		offline: process.env.NODE_ENV === 'test',
 	});
-	server.expose('getFlags', memberId =>
-		ldClient.all_flags({ key: memberId, anonymous: memberId === 0 }).then(
+	server.expose('getFlags', memberObj => {
+		const key = (memberObj && memberObj.id) || 0;
+		return ldClient.all_flags({ ...memberObj, key, anonymous: key === 0 }).then(
 			flags => flags,
 			err => {
 				server.app.logger.error({
 					err,
-					memberId,
+					member: memberObj,
 				});
 				return {}; // return empty flags on error
 			}
-		)
-	);
+		);
+	});
 	// set up launchdarkly instance before continuing
 	server.on('stop', ldClient.close);
 	ldClient.once(`ready`, () => next());


### PR DESCRIPTION
In order to work with feature flag segmentation by anything other than member ID, we need to send all the member info we have, which means we need to wait for the REST API to populate `state.api.self` before injecting the flag values into the initial state.