### PR TITLE
Prelim / Discussion: New Relic page names

### DIFF
--- a/packages/mwp-router/src/SyncContainer.jsx
+++ b/packages/mwp-router/src/SyncContainer.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import withRouter from 'react-router-dom/withRouter';
+import newrelic from 'newrelic';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { locationChange } from './routeActionCreators';
@@ -19,10 +20,10 @@ export class SyncContainer extends React.Component {
 	 * This container connects route changes to Redux actions. When the router
 	 * inject new props, the container determines whether or not to dispatch a
 	 * 'locationChange' action
-	 * 
+	 *
 	 * In order to prevent data fetches when the hash changes, we only compare
 	 * the new pathname and querystring with the current pathname and querystring
-	 * 
+	 *
 	 * @return {undefined} side effect only - dispatch
 	 */
 	componentWillReceiveProps({ location, history }) {
@@ -36,6 +37,17 @@ export class SyncContainer extends React.Component {
 			}
 			// eventually we might want to try setting up some scroll logic for 'POP'
 			// events (back button) to re-set the previous scroll position
+		}
+
+		if (newrelic && isPathChange) {
+			// example location.pathname
+			//    = "/hq-faff/events/221661049/"
+			//    = "/hq-faff/events/past/"
+			//	  = /
+			// in New Relic we can use reg-exs in NRQL queries to match specific pages
+			// alternatively, we can do the regex -> pageName mapping in the code, but will have to maintain it
+			// for any new pages we want to add.
+			newrelic.setCurrentRouteName(location.pathname);
 		}
 	}
 	/**


### PR DESCRIPTION
There's isn't much to this PR yet. I've just committed where the code would go to for tracking route changes. Still need to implement page load. But before I go down that path I wanted to discuss some implementation options to decide what the best approach will be.

1. Use [newRelic.setCurrentRouteName](https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/spa-set-current-route-name) in `mwp-router` and supply `location.path`.     
    - **PRO**
        - It'll programmatically log `location.path` names for all request.  
        - Code is contained within `mwp-router` and is small.
        - *edit*: It looks like we already have the full URL in [BrowserInteraction.targetUrl](https://insights.newrelic.com/accounts/1238700/explorer/events?eventType=BrowserInteraction&duration=1800000&facet=targetUrl), so if we go with this approach, we wouldn't need to call `setCurrentRouteName`.
    - **CON**
        - `location.path` has values like `/hq-faff/events/221661049/` and `/hq-faff/events/past/` so we're still going to have to group similar URLs together.
        - This grouping will have to be done in the NRQL queiries in New Relic, using reg-exs on the `browserInteractionName`. For some pages, like `/attendees/` that'll be simple. For other pages like differentiating between Event Home (`/events/<id>/`) and Past Events List (`/events/past/`) the regexes in the queries might be more involved.
        - This would make maintaining our New Relic Insights dashboards more tedious anytime we want to make new charts.

2. Use `newRelic.setCurrentRouteName` and supply a string identifier other than `location.path`. This would be more or less the same approach as # 1, except that we would insert the regex/grouping logic in the code in `meetup-web-platform` instead of in the NRQL queries. Then we can call something like `newrelic.setCurrentRouteName('Event Home')`.
    - **PRO**
        - Keeps the NRQL queries simple.
    - **CON**
        - Increases the complexity of the code / logic around page tracking in meetup-web-platform.
        - Anytime we want to group a new page, we have to deploy a code change.

3. Use `newRelic.setCurrentRouteName` within the `mup-web` container components and hardcode a value. In this case, what if we just make the newRelic calls directly from the mup-web JSX logic, and hardcode values like `newrelic.setCurrentRouteName('Event Home')` when we know we're rendering Event Home, for example.
      - **PRO**
          - Easy to implement for our current top 4/5 pages.
          - No grouping logic/ complex regex-es necessary
          - Can even just create a new custom attribute instead of modifying the currentRouteName.
      - **CON**
          - Manual process anytime you want to create a new pageName attribute Requires code deployment.