### PR TITLE
use commonJS export for StyleWith mock in mwp-test-utils

### DIFF
--- a/packages/mwp-test-utils/__mocks__/StyleWith.jsx
+++ b/packages/mwp-test-utils/__mocks__/StyleWith.jsx
@@ -5,4 +5,4 @@
  */
 const StyleWith = props => props.children;
 
-export default StyleWith;
+module.exports = StyleWith;


### PR DESCRIPTION
Using commonJS exports for the `StyleWith` mock in `mwp-test-utils` means less configuration for consumers, as the mock will not need to be transformed in any way.