### PR TITLE
check for __disable_sw in query to override service worker setting

### DIFF
--- a/packages/mwp-core/src/renderers/server-render.jsx
+++ b/packages/mwp-core/src/renderers/server-render.jsx
@@ -239,7 +239,7 @@ const makeRenderer = (
 
 		// service worker can be disabled per-request with __disable_sw querystring param
 		const enableServiceWorkerReq =
-			'__disable_sw' in request.query || enableServiceWorker;
+			!('__disable_sw' in request.query) && enableServiceWorker;
 
 		// create the store with populated `config`
 		const initializeStore = resolvedRoutes => {

--- a/packages/mwp-core/src/renderers/server-render.jsx
+++ b/packages/mwp-core/src/renderers/server-render.jsx
@@ -237,13 +237,17 @@ const makeRenderer = (
 		const userAgent = headers['user-agent'];
 		const userAgentDevice = headers['x-ua-device'] || ''; // set by fastly
 
+		// service worker can be disabled per-request with __disable_sw querystring param
+		const enableServiceWorkerReq =
+			'__disable_sw' in request.query || enableServiceWorker;
+
 		// create the store with populated `config`
 		const initializeStore = resolvedRoutes => {
 			const initialState = {
 				config: {
 					apiUrl: API_ROUTE_PATH,
 					baseUrl: host,
-					enableServiceWorker,
+					enableServiceWorker: enableServiceWorkerReq,
 					requestLanguage,
 					supportedLangs,
 					initialNow: new Date().getTime(),


### PR DESCRIPTION
This will allow profiling requests unencumbered by precache requests