### PR TITLE
api.track - use query.ref for label

### DIFF
--- a/packages/mwp-api-proxy-plugin/src/proxy.js
+++ b/packages/mwp-api-proxy-plugin/src/proxy.js
@@ -26,6 +26,14 @@ export default (request: HapiRequest) => {
 		request.server.plugins[API_PROXY_PLUGIN_NAME].duotoneUrls
 	);
 	return (queries: Array<Query>): Observable<Array<QueryResponse>> => {
+		const [query] = queries;
+		// special case handling of tracking call
+		if (queries.length === 1 && query.endpoint === 'track') {
+			return Observable.of([]).do(responses =>
+				request.trackActivity(responses, query.ref)
+			);
+		}
+
 		// send$ and receive must be assigned here rather than when the `request`
 		// is first passed in because the `request.state` isn't guaranteed to be
 		// available until after the `queries` have been parsed

--- a/packages/mwp-api-state/src/sync/apiActionCreators.js
+++ b/packages/mwp-api-state/src/sync/apiActionCreators.js
@@ -82,6 +82,10 @@ export const get = _applyMethod('get');
 export const post = _applyMethod('post');
 export const patch = _applyMethod('patch');
 export const del = _applyMethod('delete');
+export const track = (query: Query, meta: ?Object) => {
+	query.endpoint = 'track';
+	return post(query, meta);
+};
 
 type ResponseAction = {
 	query: Query,

--- a/packages/mwp-tracking-plugin/src/_activityTrackers.js
+++ b/packages/mwp-tracking-plugin/src/_activityTrackers.js
@@ -11,11 +11,13 @@ const parseUrl = url.parse;
  * tracking record.
  */
 
-export const getTrackApiResponses: TrackGetter = trackOpts => request => (
+export const getTrackApiResponses: TrackGetter = trackOpts => request => (opts: {
 	queryResponses: Array<Object>,
-	url: ?string,
-	referrer: ?string
-) => {
+	url?: string,
+	referrer?: string,
+	label?: string,
+}) => {
+	const { queryResponses, url, referrer, label } = opts;
 	const apiRequests: Array<{
 		requestId: string,
 		endpoint: string,
@@ -31,6 +33,7 @@ export const getTrackApiResponses: TrackGetter = trackOpts => request => (
 		url: url || '',
 		referer: referrer || '',
 		apiRequests,
+		label,
 	});
 };
 
@@ -39,7 +42,8 @@ export const getTrackApiResponses: TrackGetter = trackOpts => request => (
  * REST API call(s)
  */
 export const getTrackActivity: TrackGetter = trackOpts => request => (
-	queryResponses: Array<Object>
+	queryResponses: Array<Object>,
+	label: ?string
 ) => {
 	const { method, payload, query, info: { referrer } } = request;
 	const requestReferrer = parseUrl(referrer).pathname || '';
@@ -52,12 +56,13 @@ export const getTrackActivity: TrackGetter = trackOpts => request => (
 		const metadataRison = reqData.metadata || rison.encode_object({});
 		const { referrer } = rison.decode_object(metadataRison);
 		const url = parseUrl(requestReferrer).pathname;
-		return request.trackApiResponses(queryResponses, url, referrer);
+		return request.trackApiResponses({ queryResponses, label, url, referrer });
 	}
 
-	return request.trackApiResponses(
+	return request.trackApiResponses({
 		queryResponses,
-		request.url.pathname, // requested url
-		requestReferrer // referer
-	);
+		label,
+		url: request.url.pathname, // requested url
+		referrer: requestReferrer, // referer
+	});
 };


### PR DESCRIPTION
new `api.track` API action creator, which will be handled on the app server as a special case API call that _does not call the REST API_, but does make an activity tracking call in addition to storing click data.

use `query.ref` to 'label' the tracking data - final avro record properties TBD