### PR TITLE
use Array instead of Set for IE11 support

### DIFF
--- a/packages/mwp-app-render/src/components/StyleWith.jsx
+++ b/packages/mwp-app-render/src/components/StyleWith.jsx
@@ -26,16 +26,16 @@ import Helmet from 'react-helmet';
 const StyleWith = props => {
 	const { styles, children } = props;
 
-	const moduleCSS = new Set();
+	const moduleCSS = [];
 	styles.forEach(style => {
-		moduleCSS.add(style._getCss()); // eslint-disable-line no-underscore-dangle
+		moduleCSS.push(style._getCss()); // eslint-disable-line no-underscore-dangle
 	});
 
 	return (
 		<div>
 			<Helmet defer={false}>
 				<style type="text/css">
-					{[...moduleCSS].join('')}
+					{moduleCSS.join('')}
 				</style>
 			</Helmet>
 			{children}


### PR DESCRIPTION
fixes https://meetup.atlassian.net/browse/SDS-612

IE11 does not support `Set`. This meant that server render was working fine, but client render in IE11 resulted in empty style strings.

We _could_ polyfill `Set` instead, but we rarely use that JS feature and will likely drop support for IE11 soon anyway. This is a quick fix until we drop support for this browser.