### PR TITLE
adding isQLd prop to config object

### DIFF
--- a/flow-typed/platform.js
+++ b/flow-typed/platform.js
@@ -17,6 +17,7 @@ declare type MWPState = {
 		requestLanguage: string,
 		supportedLangs: Array<string>,
 		initialNow: number,
+		isQLd: boolean,
 		variants: mixed,
 		entryPath: string,
 		media: MatchMedia,

--- a/flow-typed/platform.js
+++ b/flow-typed/platform.js
@@ -17,7 +17,7 @@ declare type MWPState = {
 		requestLanguage: string,
 		supportedLangs: Array<string>,
 		initialNow: number,
-		isQLd: boolean,
+		isQL: boolean,
 		variants: mixed,
 		entryPath: string,
 		media: MatchMedia,

--- a/packages/mwp-core/src/renderers/server-render.jsx
+++ b/packages/mwp-core/src/renderers/server-render.jsx
@@ -12,6 +12,7 @@ import { getFindMatches, resolveAllRoutes } from 'mwp-router/lib/util';
 import { getServerCreateStore } from 'mwp-store/lib/server';
 import Dom from 'mwp-app-render/lib/components/Dom';
 import ServerApp from 'mwp-app-render/lib/components/ServerApp';
+import { parseMemberCookie } from 'mwp-core/lib/util/cookieUtils';
 
 import { getVariants } from '../util/cookieUtils';
 
@@ -247,6 +248,7 @@ const makeRenderer = (
 					requestLanguage,
 					supportedLangs,
 					initialNow: new Date().getTime(),
+					isQLd: parseMemberCookie(state)['ql'] === 'true',
 					variants: getVariants(state),
 					entryPath: url.pathname, // the path that the user entered the app on
 					media: getMedia(userAgent, userAgentDevice),

--- a/packages/mwp-core/src/renderers/server-render.jsx
+++ b/packages/mwp-core/src/renderers/server-render.jsx
@@ -248,7 +248,7 @@ const makeRenderer = (
 					requestLanguage,
 					supportedLangs,
 					initialNow: new Date().getTime(),
-					isQLd: parseMemberCookie(state)['ql'] === 'true',
+					isQL: parseMemberCookie(state).ql === 'true',
 					variants: getVariants(state),
 					entryPath: url.pathname, // the path that the user entered the app on
 					media: getMedia(userAgent, userAgentDevice),


### PR DESCRIPTION
Adds `isQLd` to config object in state, used to help with an indicator on client UI to donote that the user is QL'd  as another member 

See: https://github.com/meetup/mup-web/pull/3296
for usage