### PR TITLE
use fragment in StyleWith

### DIFF
--- a/packages/mwp-app-render/src/components/StyleWith.jsx
+++ b/packages/mwp-app-render/src/components/StyleWith.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
 
@@ -32,14 +32,14 @@ const StyleWith = props => {
 	});
 
 	return (
-		<div>
+		<Fragment>
 			<Helmet defer={false}>
 				<style type="text/css">
 					{moduleCSS.join('')}
 				</style>
 			</Helmet>
 			{children}
-		</div>
+		</Fragment>
 	);
 };
 StyleWith.propTypes = {

--- a/packages/mwp-app-render/src/components/__snapshots__/styleWith.test.jsx.snap
+++ b/packages/mwp-app-render/src/components/__snapshots__/styleWith.test.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`StyleWith renders with mock props 1`] = `
-<div>
+<React.Fragment>
   <HelmetWrapper
     defer={false}
     encodeSpecialCharacters={true}
@@ -12,5 +12,5 @@ exports[`StyleWith renders with mock props 1`] = `
       .testClass1 {color: inherit;}.testClass2 {page-break-after: avoid;}
     </style>
   </HelmetWrapper>
-</div>
+</React.Fragment>
 `;


### PR DESCRIPTION
Adding a block-level element (`div`) could force a component into an unintended layout model. This branch changes the wrapping `div` to a react fragment.