### PR TITLE
read clickTracking data in fetch epic, clear click data in clickEpic

### DIFF
--- a/packages/mwp-api-proxy-plugin/src/proxy.js
+++ b/packages/mwp-api-proxy-plugin/src/proxy.js
@@ -30,7 +30,7 @@ export default (request: HapiRequest) => {
 		// special case handling of tracking call - must supply a response, but
 		// empty object is fine
 		if (queries.length === 1 && query.endpoint === 'track') {
-			return Observable.of([{}]).do(responses =>
+			return Observable.of([{ ref: query.ref, value: {} }]).do(responses =>
 				request.trackActivity(query.params)
 			);
 		}

--- a/packages/mwp-api-state/src/sync/apiActionCreators.js
+++ b/packages/mwp-api-state/src/sync/apiActionCreators.js
@@ -82,8 +82,9 @@ export const get = _applyMethod('get');
 export const post = _applyMethod('post');
 export const patch = _applyMethod('patch');
 export const del = _applyMethod('delete');
-export const track = (query: Query, meta: ?Object) => {
+export const track = (query: Query, meta: ?Object = {}) => {
 	query.endpoint = 'track';
+	meta.clickTracking = true;
 	return post(query, meta);
 };
 

--- a/packages/mwp-api-state/src/sync/apiActionCreators.js
+++ b/packages/mwp-api-state/src/sync/apiActionCreators.js
@@ -82,7 +82,8 @@ export const get = _applyMethod('get');
 export const post = _applyMethod('post');
 export const patch = _applyMethod('patch');
 export const del = _applyMethod('delete');
-export const track = (query: Query, meta: ?Object = {}) => {
+export const track = (query: Query, meta: ?Object) => {
+	meta = meta || {};
 	query.endpoint = 'track';
 	meta.clickTracking = true;
 	return post(query, meta);

--- a/packages/mwp-api-state/src/sync/apiActionCreators.test.js
+++ b/packages/mwp-api-state/src/sync/apiActionCreators.test.js
@@ -20,4 +20,17 @@ describe('method-specific creators', () => {
 			expect(requestAction.meta.reject).toEqual(expect.any(Function));
 		});
 	});
+	it('track sets endpoint, meta.method, adds requestMeta.clickTracking.true', () => {
+		const query = {};
+		const trackAction = api.track(query);
+		expect(trackAction.type).toBe('API_REQ');
+		expect(trackAction.payload).toHaveLength(1);
+		expect(trackAction.payload[0]).toMatchObject({
+			endpoint: 'track',
+			meta: {
+				method: 'post',
+			},
+		});
+		expect(trackAction.meta.clickTracking).toBe(true);
+	});
 });

--- a/packages/mwp-api-state/src/sync/index.test.js
+++ b/packages/mwp-api-state/src/sync/index.test.js
@@ -19,6 +19,7 @@ import getSyncEpic, {
 	getFetchQueriesEpic,
 	getNavEpic,
 	apiRequestToApiReq,
+	clickEpic,
 } from './';
 import { API_RESP_COMPLETE } from '../../lib/sync/apiActionCreators';
 
@@ -40,7 +41,7 @@ describe('Sync epic', () => {
 			expect(actions).toHaveLength(0)
 		));
 	describe('getNavEpic', () => {
-		it('emits API_REQ and CLICK_TRACK_CLEAR for nav-related actions with matched query', function() {
+		it('emits API_REQ for nav-related actions with matched query', function() {
 			const locationChange = {
 				type: LOCATION_CHANGE,
 				payload: MOCK_RENDERPROPS.location,
@@ -59,11 +60,10 @@ describe('Sync epic', () => {
 				actionArrays.forEach(actions => {
 					const types = actions.map(a => a.type);
 					expect(types).toContain(api.API_REQ);
-					expect(types.includes(CLICK_TRACK_CLEAR_ACTION)).toBe(true);
 				});
 			});
 		});
-		it('emits API_REQ, CACHE_CLEAR, and CLICK_TRACK_CLEAR for nav-related actions with logout request', function() {
+		it('emits API_REQ, CACHE_CLEAR for nav-related actions with logout request', function() {
 			const logoutLocation = {
 				...MOCK_RENDERPROPS.location,
 				pathname: '/logout',
@@ -81,7 +81,6 @@ describe('Sync epic', () => {
 				const types = actions.map(a => a.type);
 				expect(types).toContain(api.API_REQ);
 				expect(types.includes(CACHE_CLEAR)).toBe(true);
-				expect(types.includes(CLICK_TRACK_CLEAR_ACTION)).toBe(true);
 			});
 		});
 		it('emits API_COMPLETE for nav-related actions without matched query', () => {
@@ -254,6 +253,23 @@ describe('Sync epic', () => {
 			).then(actions =>
 				expect(apiRequest.meta.reject).toHaveBeenCalledWith(expectedError)
 			);
+		});
+	});
+	describe('clickEpic', () => {
+		it('emits CLICK_CLEAR for API_REQ with meta.clickAction', function() {
+			const reqClicks = {
+				type: api.API_REQ,
+				payload: {},
+				meta: {
+					clickTracking: true,
+				},
+			};
+
+			const fakeStore = createFakeStore(MOCK_APP_STATE);
+			return clickEpic(reqClicks, fakeStore).then(actions => {
+				expect(actions).toHaveLength(1);
+				expect(actions[0].type).toBe(CLICK_TRACK_CLEAR_ACTION);
+			});
 		});
 	});
 });

--- a/packages/mwp-tracking-plugin/src/util/clickState.js
+++ b/packages/mwp-tracking-plugin/src/util/clickState.js
@@ -24,13 +24,15 @@ export const setClickCookie = clickTracking => {
 
 export const CLICK_TRACK_ACTION = 'CLICK_TRACK';
 export const CLICK_TRACK_CLEAR_ACTION = 'CLICK_TRACK_CLEAR';
+// constant 'clear' action object
+const _CLICK_TRACK_CLEAR = { type: CLICK_TRACK_CLEAR_ACTION };
 
 export const actions = {
 	click: clickData => ({
 		type: CLICK_TRACK_ACTION,
 		payload: clickData,
 	}),
-	clear: () => ({ type: CLICK_TRACK_CLEAR_ACTION }),
+	clear: () => _CLICK_TRACK_CLEAR,
 };
 
 export const DEFAULT_CLICK_TRACK = { history: [] };


### PR DESCRIPTION
**Current behavior**

No way for lazy `api.*` calls to send click data, only `LOCATION_CHANGE`

1. (navigate)
  => LOCATION_CHANGE
  => navEpic adds `clickTracking`
  =>  API_REQ
  => fetchQueriesEpic
2. (lazy api.track)
  => API_REQ => fetchQueriesEpic

**New behavior**

_Any_ API_REQ can request that click tracking data be sent

1. (navigate)
  => LOCATION_CHANGE
  => navEpic
  =>  API_REQ
  => fetchQueriesEpic adds `clickTracking`
2. (lazy api.track)
  => API_REQ
  => fetchQueriesEpic adds `clickTracking`
