### PR TITLE
pass along __set_geoip in browser fetchQueries

### DIFF
--- a/packages/mwp-api-proxy-plugin/src/routes.js
+++ b/packages/mwp-api-proxy-plugin/src/routes.js
@@ -6,6 +6,7 @@ const validApiPayloadSchema = Joi.object({
 	queries: Joi.string().required(), // should be rison.encode_array-encoded
 	metadata: Joi.string(),
 	logout: Joi.any(),
+	__set_geoip: Joi.string().ip(),
 });
 
 const getApiProxyRoutes = path => {

--- a/packages/mwp-api-proxy-plugin/src/util/send.js
+++ b/packages/mwp-api-proxy-plugin/src/util/send.js
@@ -112,15 +112,14 @@ export const buildRequestArgs = externalRequestOpts => ({
 	}
 
 	if (meta.variants) {
-		headers['X-Meetup-Variants'] = Object.keys(meta.variants).reduce(
-			(header, experiment) => {
-				const context = meta.variants[experiment];
-				const contexts = context instanceof Array ? context : [context];
-				header += contexts.map(c => `${experiment}=${c}`).join(' ');
-				return header;
-			},
-			''
-		);
+		headers['X-Meetup-Variants'] = Object.keys(
+			meta.variants
+		).reduce((header, experiment) => {
+			const context = meta.variants[experiment];
+			const contexts = context instanceof Array ? context : [context];
+			header += contexts.map(c => `${experiment}=${c}`).join(' ');
+			return header;
+		}, '');
 	}
 
 	switch (externalRequestOpts.method) {
@@ -190,7 +189,7 @@ export function getLanguageHeader(request) {
 
 export function getClientIpHeader(request) {
 	const clientIP =
-		request.query['_set_geoip'] || request.headers['fastly-client-ip'];
+		request.query._set_geoip || request.headers['fastly-client-ip'];
 	if (clientIP) {
 		return { 'X-Meetup-Client-Ip': clientIP };
 	}
@@ -288,7 +287,10 @@ export function getExternalRequestOpts(request) {
 /**
  * Fake an API request and directly return the stringified mockResponse
  */
-export const makeMockRequest = (mockResponseContent, responseMeta) => requestOpts =>
+export const makeMockRequest = (
+	mockResponseContent,
+	responseMeta
+) => requestOpts =>
 	Observable.of([
 		makeMockResponse(requestOpts, responseMeta),
 		JSON.stringify(mockResponseContent),

--- a/packages/mwp-store/src/browser/fetchQueries.js
+++ b/packages/mwp-store/src/browser/fetchQueries.js
@@ -66,8 +66,12 @@ export const getFetchArgs = (apiUrl, queries, meta) => {
 	const isFormData = queries[0].params instanceof FormData;
 	const isDelete = method === 'DELETE';
 
+	const pageSearchParams = new URLSearchParams(window.location.search);
 	const searchParams = new URLSearchParams();
 	searchParams.append('queries', rison.encode_array(makeSerializable(queries)));
+	if (pageSearchParams.has('__set_geoip')) {
+		searchParams.append('__set_geoip', pageSearchParams.get('__set_geoip'));
+	}
 
 	if (meta) {
 		const {
@@ -163,7 +167,11 @@ const fetchQueries = (apiUrl, member) => (queries, meta) => {
 
 	const authedQueries = getAuthedQueryFilter(member);
 	const validQueries = queries.filter(authedQueries);
-	return _fetchQueryResponse(apiUrl, validQueries, meta).then(queryResponse => ({
+	return _fetchQueryResponse(
+		apiUrl,
+		validQueries,
+		meta
+	).then(queryResponse => ({
 		...parseQueryResponse(validQueries)(queryResponse),
 	}));
 };


### PR DESCRIPTION
currently, lazy API requests ignore any `__set_geoip` querystring param that might be in the current browser URL. This PR changes the browser's `fetchQueries` function to inject `__set_geoip` into the lazy fetch, and updates the api proxy endpoint route to _allow_ that qs param