### PR TITLE
Configure stylelint to autofix rule and declaration ordering errors

### DIFF
--- a/packages/mwp-config/package.json
+++ b/packages/mwp-config/package.json
@@ -25,6 +25,7 @@
         "babel-preset-stage-2": "6.24.1",
         "convict": "4.0.1",
         "stylelint": "9.2.1",
+        "stylelint-order": "0.8.1",
         "stylelint-scss": "3.1.0"
     },
     "devDependencies": {}

--- a/packages/mwp-config/stylelint/stylelint-config-base.js
+++ b/packages/mwp-config/stylelint/stylelint-config-base.js
@@ -1,5 +1,5 @@
 module.exports = {
-	extends: './stylelint-config-scss',
+	extends: ['./stylelint-config-scss', './stylelint-config-order'],
 	rules: {
 		'at-rule-empty-line-before': 'always',
 		'at-rule-name-case': 'lower',

--- a/packages/mwp-config/stylelint/stylelint-config-order.js
+++ b/packages/mwp-config/stylelint/stylelint-config-order.js
@@ -1,0 +1,36 @@
+module.exports = {
+	plugins: ['stylelint-order'],
+	rules: {
+		'order/order': [
+			'dollar-variables',
+			'custom-properties',
+			{
+				type: 'at-rule',
+				name: 'extend',
+			},
+			{
+				type: 'at-rule',
+				name: 'include',
+				hasBlock: false,
+			},
+			'declarations',
+			{
+				type: 'at-rule',
+				hasBlock: true,
+			},
+			{
+				type: 'at-rule',
+				name: 'include',
+				parameter: 'atMediaUp',
+				hasBlock: true,
+			},
+			{
+				type: 'at-rule',
+				name: 'include',
+				parameter: 'browser-ie11',
+				hasBlock: true,
+			},
+		],
+		'order/properties-alphabetical-order': true,
+	},
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -6164,6 +6164,13 @@ postcss-selector-parser@^4.0.0:
     indexes-of "^1.0.1"
     uniq "^1.0.1"
 
+postcss-sorting@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/postcss-sorting/-/postcss-sorting-3.1.0.tgz#af7c90ee73ad12569a57664eaf06735c2e25bec0"
+  dependencies:
+    lodash "^4.17.4"
+    postcss "^6.0.13"
+
 postcss-syntax@^0.9.0:
   version "0.9.1"
   resolved "https://registry.yarnpkg.com/postcss-syntax/-/postcss-syntax-0.9.1.tgz#5dbd90af1631ab8805b8f594bef2c2e8002d3758"
@@ -6172,7 +6179,7 @@ postcss-value-parser@^3.2.3, postcss-value-parser@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz#87f38f9f18f774a4ab4c8a232f5c5ce8872a9d15"
 
-postcss@6.0.22, postcss@^6.0.14, postcss@^6.0.16, postcss@^6.0.17, postcss@^6.0.21, postcss@^6.0.22, postcss@^6.0.6, postcss@^6.0.8:
+postcss@6.0.22, postcss@^6.0.13, postcss@^6.0.14, postcss@^6.0.16, postcss@^6.0.17, postcss@^6.0.21, postcss@^6.0.22, postcss@^6.0.6, postcss@^6.0.8:
   version "6.0.22"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.22.tgz#e23b78314905c3b90cbd61702121e7a78848f2a3"
   dependencies:
@@ -7676,6 +7683,14 @@ stubs@^3.0.0:
 style-search@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
+
+stylelint-order@0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/stylelint-order/-/stylelint-order-0.8.1.tgz#35f71af3a15954154e0e99e5646ba3d6fbe34f8d"
+  dependencies:
+    lodash "^4.17.4"
+    postcss "^6.0.14"
+    postcss-sorting "^3.1.0"
 
 stylelint-scss@3.1.0:
   version "3.1.0"


### PR DESCRIPTION
Using [stylelint-order](https://github.com/hudochenkov/stylelint-order) to enable us to automatically alphabetize declarations and order other rules.