### PR TITLE
separate api.isProd/isProdApi value from env.isProd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [16.1]
+
+- **NEW FEATURE** the prod REST API can now be used directly in the dev environment.
+  To enable, simply add `{ "api": { "host": "api.meetup.com" } }` to a
+  `config.development.json` file in the root of your application. _Note_: there
+  is no visible difference between using the prod REST API and the dev REST API.
+  Try not to chnage any data that doesn't belong to you.
+
 ## [16.0]
 - **BREAKING CHANGE** webpack build configurations have been moved to
    mwp-cli and are no longer a part of `mwp-config`. Make sure to upgrade

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CI_BUILD_NUMBER ?= $(USER)-snapshot
-VERSION ?= 16.0.$(CI_BUILD_NUMBER)
+VERSION ?= 16.1.$(CI_BUILD_NUMBER)
 
 version:
 	@echo $(VERSION)

--- a/flow-typed/platform.js
+++ b/flow-typed/platform.js
@@ -36,6 +36,7 @@ declare type HapiServer = {
 	expose: (key: string, value: any) => void,
 	settings: {
 		app: { isProd: boolean, supportedLangs: Array<string>, [string]: any },
+		api: { host: string, isProd: boolean },
 	},
 	plugins: {
 		[string]: any,

--- a/packages/mwp-api-proxy-plugin/src/util/__snapshots__/send.test.js.snap
+++ b/packages/mwp-api-proxy-plugin/src/util/__snapshots__/send.test.js.snap
@@ -11,7 +11,7 @@ Object {
   },
   "headers": Object {
     "accept-language": "en-US",
-    "cookie": "MEETUP_CSRF_DEV=bar token; MEETUP_MEMBER_DEV=foo member",
+    "cookie": "MEETUP_MEMBER_DEV=foo member; MEETUP_CSRF_DEV=bar token",
     "csrf-token": "bar token",
     "x-meetup-agent": "TEST_AGENT ",
     "x-meetup-parent-request-id": "mock-uuid-1234",
@@ -31,7 +31,7 @@ Object {
   "baseUrl": "https://api.dev.meetup.com",
   "headers": Object {
     "accept-language": "en-US",
-    "cookie": "MEETUP_CSRF_DEV=bar token; MEETUP_MEMBER_DEV=foo member",
+    "cookie": "MEETUP_MEMBER_DEV=foo member; MEETUP_CSRF_DEV=bar token",
     "csrf-token": "bar token",
     "x-meetup-agent": "TEST_AGENT ",
     "x-meetup-parent-request-id": "mock-uuid-1234",

--- a/packages/mwp-api-proxy-plugin/src/util/send.test.js
+++ b/packages/mwp-api-proxy-plugin/src/util/send.test.js
@@ -50,6 +50,7 @@ const MOCK_HAPI_REQUEST = {
 describe('getAuthHeaders', () => {
 	it('sets MEETUP_CSRF', () => {
 		const authHeaders = getAuthHeaders({
+			server: { settings: { app: { api: {} } } },
 			auth: {
 				credentials: {
 					memberCookie: 'foo member',

--- a/packages/mwp-app-server/src/util/getPlugins.js
+++ b/packages/mwp-app-server/src/util/getPlugins.js
@@ -97,12 +97,12 @@ export function getLogger(
 	};
 }
 
-export function getActivityTrackingPlugin({ agent, isProd }) {
+export function getActivityTrackingPlugin({ agent, isProdApi }) {
 	return {
 		register: activityPlugin,
 		options: {
 			agent,
-			isProd,
+			isProdApi,
 		},
 	};
 }
@@ -132,7 +132,7 @@ function getLanguagePlugin() {
 }
 
 export default function getPlugins({ languageRenderers }) {
-	const { package: { agent }, env: { properties: { isProd } } } = config;
+	const { package: { agent }, getServer } = config;
 	return [
 		getAppRoutePlugin({ languageRenderers }),
 		getApiProxyPlugin(),
@@ -140,7 +140,10 @@ export default function getPlugins({ languageRenderers }) {
 		getLogger(),
 		getCsrfPlugin(),
 		getRequestAuthPlugin(),
-		getActivityTrackingPlugin({ agent, isProd }),
+		getActivityTrackingPlugin({
+			agent,
+			isProdApi: getServer().properties.api.isProd,
+		}),
 		getClickTrackingPlugin(),
 		getServiceWorkerPlugin(),
 		Inert,

--- a/packages/mwp-auth-plugin/src/index.js
+++ b/packages/mwp-auth-plugin/src/index.js
@@ -1,10 +1,5 @@
 import uuid from 'uuid';
 
-const MEMBER_COOKIE_NAME =
-	process.env.NODE_ENV === 'production' ? 'MEETUP_MEMBER' : 'MEETUP_MEMBER_DEV';
-const CSRF_COOKIE_NAME =
-	process.env.NODE_ENV === 'production' ? 'MEETUP_CSRF' : 'MEETUP_CSRF_DEV';
-
 // hardcoded logged-out cookies with valid signatures that can be used for any logged-out API request
 const mockCookies = {
 	MEETUP_MEMBER:
@@ -24,6 +19,13 @@ const mockCookies = {
  *   auth stategy instance
  */
 export const mwpScheme = server => {
+	const MEMBER_COOKIE_NAME = server.settings.app.api.isProd
+		? 'MEETUP_MEMBER'
+		: 'MEETUP_MEMBER_DEV';
+	const CSRF_COOKIE_NAME = server.settings.app.api.isProd
+		? 'MEETUP_CSRF'
+		: 'MEETUP_CSRF_DEV';
+
 	// authenticate function takes (request, reply) and eventually calls
 	// `reply.continue({ credentials })`, where credentials === { memberCookie, csrfToken }
 	// 1. check for meetup_member(_dev) cookie

--- a/packages/mwp-auth-plugin/src/index.test.js
+++ b/packages/mwp-auth-plugin/src/index.test.js
@@ -17,6 +17,7 @@ const MOCK_SERVER = {
 	plugins: {
 		requestAuth: {},
 	},
+	settings: { app: { api: {} } },
 };
 
 const MOCK_REQUEST = {
@@ -32,11 +33,13 @@ const MOCK_REQUEST = {
 
 describe('mwpScheme', () => {
 	test('returns an object with an "authenticate" function', () => {
-		expect(mwpScheme()).toMatchObject({ authenticate: expect.any(Function) });
+		expect(mwpScheme(MOCK_SERVER)).toMatchObject({
+			authenticate: expect.any(Function),
+		});
 	});
 	test('authenticate function calls reply.continue with an object with a "credentials" value', () => {
 		MOCK_REPLY_FN.continue.mockClear();
-		mwpScheme().authenticate(MOCK_REQUEST, MOCK_REPLY_FN);
+		mwpScheme(MOCK_SERVER).authenticate(MOCK_REQUEST, MOCK_REPLY_FN);
 		expect(MOCK_REPLY_FN.continue).toHaveBeenCalledWith({
 			credentials: {
 				memberCookie: expect.any(String),
@@ -56,7 +59,7 @@ describe('mwpScheme', () => {
 				[CSRF_TOKEN_COOKIE]: csrfToken,
 			},
 		};
-		mwpScheme().authenticate(MOCK_REQUEST_AUTH, MOCK_REPLY_FN);
+		mwpScheme(MOCK_SERVER).authenticate(MOCK_REQUEST_AUTH, MOCK_REPLY_FN);
 		expect(MOCK_REPLY_FN.continue).toHaveBeenCalledWith({
 			credentials: {
 				memberCookie,

--- a/packages/mwp-config/server/index.js
+++ b/packages/mwp-config/server/index.js
@@ -13,7 +13,6 @@ const {
 	validateCsrfSecret,
 	validatePhotoScalerSalt,
 	validateProtocol,
-	validateServerHost,
 } = require('./util');
 
 /**
@@ -73,7 +72,7 @@ const schema = Object.assign({}, envSchema, {
 			env: 'API_PROTOCOL',
 		},
 		host: {
-			format: validateServerHost,
+			format: String,
 			default: 'api.dev.meetup.com',
 			env: 'API_HOST',
 		},

--- a/packages/mwp-config/server/index.test.js
+++ b/packages/mwp-config/server/index.test.js
@@ -8,7 +8,6 @@ const {
 	validateCsrfSecret,
 	validatePhotoScalerSalt,
 	validateProtocol,
-	validateServerHost,
 } = require('./util');
 
 const string1 = '1';
@@ -24,30 +23,6 @@ describe('validateProtocol', () => {
 
 	it('throws error when the protocol is not `http` or `https`', () => {
 		expect(() => validateProtocol('ftp')).toThrowError(PROTOCOL_ERROR);
-	});
-});
-
-describe('validateServerHost', () => {
-	it('throws an error for non-string values', () => {
-		expect(() => validateServerHost(null)).toThrow();
-		expect(() => validateServerHost(1234)).toThrow();
-		expect(() => validateServerHost({ foo: 'bar' })).toThrow();
-		expect(() => validateServerHost(['foo'])).toThrow();
-		expect(() => validateServerHost('foo.dev.')).not.toThrow();
-	});
-	it('throws error for dev in prod', () => {
-		const _env = process.env.NODE_ENV; // cache the 'real' value to restore later
-		process.env.NODE_ENV = 'production';
-		expect(() => validateServerHost('foo.dev.bar.com')).toThrow();
-		expect(() => validateServerHost('foo.bar.com')).not.toThrow();
-		process.env.NODE_ENV = _env; // restore original env value
-	});
-	it('throws error for dev in prod', () => {
-		const _env = process.env.NODE_ENV; // cache the 'real' value to restore later
-		process.env.NODE_ENV = 'development';
-		expect(() => validateServerHost('foo.dev.bar.com')).not.toThrow();
-		expect(() => validateServerHost('foo.bar.com')).toThrow();
-		process.env.NODE_ENV = _env; // restore original env value
 	});
 });
 

--- a/packages/mwp-core/src/util/cookieUtils.js
+++ b/packages/mwp-core/src/util/cookieUtils.js
@@ -3,7 +3,9 @@ import config from 'mwp-config';
 import { logger } from 'mwp-logger-plugin';
 const appConfig = config.getServer().properties;
 
-export const MEMBER_COOKIE = appConfig.isProd ? 'MEETUP_MEMBER' : 'MEETUP_MEMBER_DEV';
+export const MEMBER_COOKIE = appConfig.api.isProd
+	? 'MEETUP_MEMBER'
+	: 'MEETUP_MEMBER_DEV';
 
 export const parseMemberCookie = state => {
 	if (!state[MEMBER_COOKIE]) {
@@ -22,7 +24,7 @@ export const parseMemberCookie = state => {
  */
 export const getVariants = state =>
 	Object.keys(state).reduce((variants, cookieName) => {
-		const isEnvCookie = !(appConfig.isProd ^ !cookieName.endsWith('_DEV')); // XNOR - both conditions or neither condition
+		const isEnvCookie = !(appConfig.api.isProd ^ !cookieName.endsWith('_DEV')); // XNOR - both conditions or neither condition
 		if (cookieName.startsWith('MEETUP_VARIANT_') && isEnvCookie) {
 			variants[cookieName.replace(/^MEETUP_VARIANT_|_DEV$/g, '')] =
 				state[cookieName];

--- a/packages/mwp-core/src/util/cookieUtils.test.js
+++ b/packages/mwp-core/src/util/cookieUtils.test.js
@@ -46,10 +46,6 @@ describe('getVariants', () => {
 			expect.any(Object)
 		);
 	});
-	it('extracts prefix-free key from MEETUP_VARIANT_XXX', () => {
-		const val = 'bar';
-		expect(getVariants({ MEETUP_VARIANT_FOO_DEV: val }).FOO).toEqual(val);
-	});
 	it('extracts suffix-free key from MEETUP_VARIANT_XXX_DEV', () => {
 		const val = 'bar';
 		expect(getVariants({ MEETUP_VARIANT_FOO_DEV: val }).FOO).toEqual(val);

--- a/packages/mwp-language-plugin/src/util/getLanguage.js
+++ b/packages/mwp-language-plugin/src/util/getLanguage.js
@@ -11,7 +11,7 @@ const getServerSettings = (request: HapiRequest) => request.server.settings.app;
  * Get cookie-specified language using MEETUP_LANGUAGE cookie value
  */
 export const getCookieLang: ParseRequestLang = (request: HapiRequest) => {
-	const { isProd, supportedLangs } = getServerSettings(request);
+	const { api: { isProd }, supportedLangs } = getServerSettings(request);
 	const LANGUAGE_COOKIE = isProd ? 'MEETUP_LANGUAGE' : 'MEETUP_LANGUAGE_DEV';
 
 	const cookie = request.state[LANGUAGE_COOKIE];

--- a/packages/mwp-language-plugin/src/util/getLanguage.test.js
+++ b/packages/mwp-language-plugin/src/util/getLanguage.test.js
@@ -14,7 +14,13 @@ const altLang = 'fr-FR';
 const altLang2 = 'de-DE';
 const altLang3 = 'es-ES';
 const unsupportedLang = 'xx-XX';
-const supportedLangs = [defaultLang, similarToDefault, altLang, altLang2, altLang3];
+const supportedLangs = [
+	defaultLang,
+	similarToDefault,
+	altLang,
+	altLang2,
+	altLang3,
+];
 const MOCK_HAPI_REQUEST = {
 	log() {},
 	url: url.parse(rootUrl),
@@ -22,7 +28,7 @@ const MOCK_HAPI_REQUEST = {
 		'accept-language': unsupportedLang, // must test unsupported lang by default
 	},
 	state: {},
-	server: { settings: { app: { supportedLangs } } },
+	server: { settings: { app: { supportedLangs, api: {} } } },
 };
 describe('getCookieLang', () => {
 	it('returns undefined when no cookie in state', () => {

--- a/packages/mwp-store/src/server/fetchQueries.js
+++ b/packages/mwp-store/src/server/fetchQueries.js
@@ -4,12 +4,15 @@ import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/toPromise';
 import { parseQueryResponse, getAuthedQueryFilter } from '../util/fetchUtils';
 
-const isProd = process.env.NODE_ENV === 'production';
 const getCookieMember = memberCookie => {
 	const memberObj = querystring.parse(memberCookie);
 	memberObj.id = memberObj.id ? parseInt(memberObj.id, 10) : 0;
 	return memberObj;
 };
+
+// prod API only needs to be set once, but is only accessible from the request object
+let isProdApi;
+
 /**
  * on the server, we can proxy the API requests directly without making a
  * request to the server's own API proxy endpoint
@@ -17,8 +20,11 @@ const getCookieMember = memberCookie => {
 export default (request: HapiRequest) => () => (
 	queries: Array<Query>
 ): Promise<ParsedQueryResponses> => {
+	if (isProdApi === undefined) {
+		isProdApi = request.server.settings.app.api.isProd;
+	}
 	const member = getCookieMember(
-		request.state[isProd ? 'MEETUP_MEMBER' : 'MEETUP_MEMBER_DEV']
+		request.state[isProdApi ? 'MEETUP_MEMBER' : 'MEETUP_MEMBER_DEV']
 	);
 	const authedQueries = getAuthedQueryFilter(member);
 	const validQueries = queries.filter(authedQueries);

--- a/packages/mwp-store/src/server/fetchQueries.test.js
+++ b/packages/mwp-store/src/server/fetchQueries.test.js
@@ -14,6 +14,7 @@ describe('serverFetchQueries', () => {
 			}),
 			trackActivity: jest.fn(),
 			state: {},
+			server: { settings: { app: { api: {} } } },
 		};
 		const queries = [];
 		const expectedParsedResponse = 'foo';

--- a/packages/mwp-tracking-plugin/src/activity.js
+++ b/packages/mwp-tracking-plugin/src/activity.js
@@ -44,7 +44,9 @@ export const fakeUTCinTimezone = (timezone: string) => {
  * - `trackActivity`
  */
 
-export const getLogger: string => (Object, Object) => mixed = (agent: string) => {
+export const getLogger: string => (Object, Object) => mixed = (
+	agent: string
+) => {
 	// activity record wants an ISO 8601 timestamp in the New York timezone,
 	// so we have to fake a UTC date object shifted into NYC's timezone before
 	// calling `toISOString()`
@@ -147,16 +149,20 @@ const getOnPreResponse = cookieConfig => (request, reply) => {
  */
 export default function register(
 	server: Object,
-	options: { agent: string, isProd: boolean },
+	options: { agent: string, isProdApi: boolean },
 	next: () => void
 ) {
-	const { agent, isProd } = options;
+	const { agent, isProdApi } = options;
 
-	const trackIdCookieName: string = isProd ? 'MEETUP_TRACK' : 'MEETUP_TRACK_DEV';
-	const browserIdCookieName: string = isProd
+	const trackIdCookieName: string = isProdApi
+		? 'MEETUP_TRACK'
+		: 'MEETUP_TRACK_DEV';
+	const browserIdCookieName: string = isProdApi
 		? 'MEETUP_BROWSER_ID'
 		: 'MEETUP_BROWSER_ID_DEV';
-	const memberCookieName: string = isProd ? 'MEETUP_MEMBER' : 'MEETUP_MEMBER_DEV';
+	const memberCookieName: string = isProdApi
+		? 'MEETUP_MEMBER'
+		: 'MEETUP_MEMBER_DEV';
 
 	const trackers: { [string]: Tracker } = getTrackers({
 		agent,

--- a/packages/mwp-tracking-plugin/src/util/avro.test.js
+++ b/packages/mwp-tracking-plugin/src/util/avro.test.js
@@ -69,6 +69,7 @@ describe('Activity tracking', () => {
 		id: 'foo',
 		headers: {},
 		log() {},
+		server: { settings: { app: { api: {} } } },
 	};
 	const trackInfo = getLogger('WEB')(request, {
 		memberId: 1234,
@@ -99,6 +100,7 @@ describe('Click tracking', () => {
 	const request = {
 		id: 'foo',
 		state: {},
+		server: { settings: { app: { api: {} } } },
 	};
 	const click = {
 		timestamp: new Date(0).toISOString(),

--- a/packages/mwp-tracking-plugin/src/util/clickReader.js
+++ b/packages/mwp-tracking-plugin/src/util/clickReader.js
@@ -8,7 +8,6 @@ import { COOKIE_NAME } from './clickState';
  */
 
 const isProd = process.env.NODE_ENV === 'production';
-const memberCookieName = isProd ? 'MEETUP_MEMBER' : 'MEETUP_MEMBER_DEV';
 export const clickCookieOptions = {
 	isSecure: isProd,
 	isHttpOnly: false,
@@ -16,6 +15,9 @@ export const clickCookieOptions = {
 };
 
 export const clickToClickRecord = request => click => {
+	const memberCookieName = request.server.settings.app.api.isProd
+		? 'MEETUP_MEMBER'
+		: 'MEETUP_MEMBER_DEV';
 	return {
 		timestamp: click.timestamp || new Date().toISOString(),
 		requestId: request.id,

--- a/packages/mwp-tracking-plugin/src/util/clickReader.test.js
+++ b/packages/mwp-tracking-plugin/src/util/clickReader.test.js
@@ -14,6 +14,7 @@ describe('processClickTracking', () => {
 		},
 		log: jest.fn(),
 		id: '1234',
+		server: { settings: { app: { api: {} } } },
 	};
 	const reply = {
 		unstate: jest.fn(),
@@ -23,7 +24,9 @@ describe('processClickTracking', () => {
 	it('calls process.stdout.write for each click record', () => {
 		process.stdout.write.mockClear();
 		processClickTracking(request, reply);
-		expect(process.stdout.write).toHaveBeenCalledTimes(clickData.history.length);
+		expect(process.stdout.write).toHaveBeenCalledTimes(
+			clickData.history.length
+		);
 	});
 	it('calls reply.unstate for click-track cookie', () => {
 		reply.unstate.mockClear();


### PR DESCRIPTION
This update allows consumer apps to specify `api.meetup.com` as the REST API hostname and use the prod API in dev.

This is a particular blocker for Pro, which has a number of microservice API endpoints that are only available through the prod API host.

**Summary of changes**

- the `api` config now has its own `isProd` property that is independent of `env.isProd`
- this value can be consumed in a couple different ways:
   1. (Preferred) from `server.settings.app.api.isProd` in contexts that have access to `server` (or `request.server`)
   2. from `require('mwp-config').getServer().properties.api.isProd` in contexts that _don't_ have access to the `server` instance.
