### PR TITLE
WP-744 Add API host variable in config

### DIFF
--- a/packages/mwp-core/src/renderers/server-render.jsx
+++ b/packages/mwp-core/src/renderers/server-render.jsx
@@ -220,8 +220,7 @@ const makeRenderer = (
 
 		const { headers, info, url, server, state } = request;
 		const apiHost = server.settings;
-		console.log(server.settings);
-
+		console.log('API HOST', server.settings);
 		debugger;
 		const requestLanguage = request.getLanguage();
 		// basename is the 'base path' for the application - usually a localeCode

--- a/packages/mwp-core/src/renderers/server-render.jsx
+++ b/packages/mwp-core/src/renderers/server-render.jsx
@@ -237,13 +237,13 @@ const makeRenderer = (
 		const initializeStore = resolvedRoutes => {
 			const initialState = {
 				config: {
-					isProdApi: server.settings.app.api.isProd,
 					apiUrl: API_ROUTE_PATH,
 					baseUrl: host,
 					enableServiceWorker,
 					requestLanguage,
 					supportedLangs: server.settings.app.supportedLangs,
 					initialNow: new Date().getTime(),
+					isProdApi: server.settings.app.api.isProd,
 					isQL: parseMemberCookie(state).ql === 'true',
 					variants: getVariants(state),
 					entryPath: url.pathname, // the path that the user entered the app on

--- a/packages/mwp-core/src/renderers/server-render.jsx
+++ b/packages/mwp-core/src/renderers/server-render.jsx
@@ -219,8 +219,6 @@ const makeRenderer = (
 		}
 
 		const { headers, info, url, server, state } = request;
-		const isProdApi = server.settings;
-		console.log('SETTINGS.APP.API >>>>>>>>', server.settings.app.api);
 		const requestLanguage = request.getLanguage();
 		// basename is the 'base path' for the application - usually a localeCode
 		const basename = requestLanguage === 'en-US' ? '' : `/${requestLanguage}`;
@@ -239,7 +237,7 @@ const makeRenderer = (
 		const initializeStore = resolvedRoutes => {
 			const initialState = {
 				config: {
-					isProdApi,
+					isProdApi: server.settings.app.api.isProd,
 					apiUrl: API_ROUTE_PATH,
 					baseUrl: host,
 					enableServiceWorker,

--- a/packages/mwp-core/src/renderers/server-render.jsx
+++ b/packages/mwp-core/src/renderers/server-render.jsx
@@ -219,9 +219,8 @@ const makeRenderer = (
 		}
 
 		const { headers, info, url, server, state } = request;
-		const apiHost = server.settings;
-		console.log('API HOST', server.settings);
-		debugger;
+		const isProdApi = server.settings.api.isProd;
+		console.log('IS_PROD_API', isProdApi);
 		const requestLanguage = request.getLanguage();
 		// basename is the 'base path' for the application - usually a localeCode
 		const basename = requestLanguage === 'en-US' ? '' : `/${requestLanguage}`;
@@ -240,7 +239,7 @@ const makeRenderer = (
 		const initializeStore = resolvedRoutes => {
 			const initialState = {
 				config: {
-					apiHost,
+					isProdApi,
 					apiUrl: API_ROUTE_PATH,
 					baseUrl: host,
 					enableServiceWorker,

--- a/packages/mwp-core/src/renderers/server-render.jsx
+++ b/packages/mwp-core/src/renderers/server-render.jsx
@@ -219,6 +219,8 @@ const makeRenderer = (
 		}
 
 		const { headers, info, url, server, state } = request;
+		const apiHost = server.settings.api.host;
+		console.log(apiHost);
 		const requestLanguage = request.getLanguage();
 		// basename is the 'base path' for the application - usually a localeCode
 		const basename = requestLanguage === 'en-US' ? '' : `/${requestLanguage}`;
@@ -237,6 +239,7 @@ const makeRenderer = (
 		const initializeStore = resolvedRoutes => {
 			const initialState = {
 				config: {
+					apiHost:,
 					apiUrl: API_ROUTE_PATH,
 					baseUrl: host,
 					enableServiceWorker,

--- a/packages/mwp-core/src/renderers/server-render.jsx
+++ b/packages/mwp-core/src/renderers/server-render.jsx
@@ -239,7 +239,7 @@ const makeRenderer = (
 		const initializeStore = resolvedRoutes => {
 			const initialState = {
 				config: {
-					apiHost:,
+					apiHost,
 					apiUrl: API_ROUTE_PATH,
 					baseUrl: host,
 					enableServiceWorker,

--- a/packages/mwp-core/src/renderers/server-render.jsx
+++ b/packages/mwp-core/src/renderers/server-render.jsx
@@ -219,8 +219,8 @@ const makeRenderer = (
 		}
 
 		const { headers, info, url, server, state } = request;
-		const isProdApi = server.settings.api.isProd;
-		console.log('IS_PROD_API', isProdApi);
+		const isProdApi = server.settings;
+		console.log('SETTINGS.API >>>>>>>>', server.settings.api);
 		const requestLanguage = request.getLanguage();
 		// basename is the 'base path' for the application - usually a localeCode
 		const basename = requestLanguage === 'en-US' ? '' : `/${requestLanguage}`;

--- a/packages/mwp-core/src/renderers/server-render.jsx
+++ b/packages/mwp-core/src/renderers/server-render.jsx
@@ -220,7 +220,7 @@ const makeRenderer = (
 
 		const { headers, info, url, server, state } = request;
 		const apiHost = server.settings.api.host;
-		console.log(apiHost);
+		console.log(server);
 		const requestLanguage = request.getLanguage();
 		// basename is the 'base path' for the application - usually a localeCode
 		const basename = requestLanguage === 'en-US' ? '' : `/${requestLanguage}`;

--- a/packages/mwp-core/src/renderers/server-render.jsx
+++ b/packages/mwp-core/src/renderers/server-render.jsx
@@ -221,6 +221,7 @@ const makeRenderer = (
 		const { headers, info, url, server, state } = request;
 		const apiHost = server.settings;
 		console.log(server);
+		debugger;
 		const requestLanguage = request.getLanguage();
 		// basename is the 'base path' for the application - usually a localeCode
 		const basename = requestLanguage === 'en-US' ? '' : `/${requestLanguage}`;

--- a/packages/mwp-core/src/renderers/server-render.jsx
+++ b/packages/mwp-core/src/renderers/server-render.jsx
@@ -219,7 +219,7 @@ const makeRenderer = (
 		}
 
 		const { headers, info, url, server, state } = request;
-		const apiHost = server.settings.api.host;
+		const apiHost = server.settings;
 		console.log(server);
 		const requestLanguage = request.getLanguage();
 		// basename is the 'base path' for the application - usually a localeCode

--- a/packages/mwp-core/src/renderers/server-render.jsx
+++ b/packages/mwp-core/src/renderers/server-render.jsx
@@ -220,7 +220,8 @@ const makeRenderer = (
 
 		const { headers, info, url, server, state } = request;
 		const apiHost = server.settings;
-		console.log(server);
+		console.log(server.settings);
+
 		debugger;
 		const requestLanguage = request.getLanguage();
 		// basename is the 'base path' for the application - usually a localeCode

--- a/packages/mwp-core/src/renderers/server-render.jsx
+++ b/packages/mwp-core/src/renderers/server-render.jsx
@@ -220,7 +220,7 @@ const makeRenderer = (
 
 		const { headers, info, url, server, state } = request;
 		const isProdApi = server.settings;
-		console.log('SETTINGS.API >>>>>>>>', server.settings.api);
+		console.log('SETTINGS.APP.API >>>>>>>>', server.settings.app.api);
 		const requestLanguage = request.getLanguage();
 		// basename is the 'base path' for the application - usually a localeCode
 		const basename = requestLanguage === 'en-US' ? '' : `/${requestLanguage}`;


### PR DESCRIPTION
Add a variable to redux state, indicating which API host is currently being used. This will be used to configure links helpers in web platform applications to generate appropriate links to dev or production in chapstick.

DoD:
- API host information is available in redux state