### PR TITLE
WP-760 handle list which is under `value` field in response

### DIFF
--- a/packages/mwp-api-state/src/reducer.js
+++ b/packages/mwp-api-state/src/reducer.js
@@ -45,7 +45,13 @@ export const getListState: ResponseStateSetter = (
 	}
 	const { dynamicRef, merge } = query.list;
 	// this query should be treated as a list-building query
-	const newList = response.value instanceof Array ? response.value : [];
+	// list can be either a root query result (response.value) or be under `value` field of the result (response.value.value)
+	let newList = [];
+	if (response.value instanceof Array) {
+		newList = response.value;
+	} else if (response.value && response.value.value instanceof Array) {
+		newList = response.value.value;
+	}
 	if (!merge) {
 		// no merge rules, so just make a new list
 		return { [dynamicRef]: { value: newList, query } };

--- a/packages/mwp-api-state/src/reducer.test.js
+++ b/packages/mwp-api-state/src/reducer.test.js
@@ -66,6 +66,23 @@ describe('getListState', () => {
 			},
 		});
 	});
+	it('merges new response with existing dynamicRef, sorted in case list is not top level value (is under `value` filed)', () => {
+		const list = ['qux'];
+		const value = { value: list };
+		const response = {
+			response: { value: { value: ['foo'] } },
+			query: resp.query,
+		};
+		expect(
+			getListState({ [resp.query.list.dynamicRef]: { value: list } }, response)
+		).toEqual({
+			[resp.query.list.dynamicRef]: {
+				value: [...value.value, ...response.response.value.value].sort(
+					resp.query.list.merge.sort
+				),
+			},
+		});
+	});
 });
 
 describe('app reducer', () => {


### PR DESCRIPTION
Adjust getListState in `mwp-api-atate` to correctly handle list which is under `value` field in response:
https://meetup.atlassian.net/wiki/spaces/CP/pages/679346519/RFC+Pageable+Resources