### PR TITLE
add back member id to initial state

### DIFF
--- a/packages/mwp-core/src/renderers/server-render.jsx
+++ b/packages/mwp-core/src/renderers/server-render.jsx
@@ -245,6 +245,7 @@ const makeRenderer = (
 					initialNow: new Date().getTime(),
 					isProdApi: server.settings.app.api.isProd,
 					isQL: parseMemberCookie(state).ql === 'true',
+					memberId: parseMemberCookie(state).id,
 					variants: getVariants(state),
 					entryPath: url.pathname, // the path that the user entered the app on
 					media: getMedia(userAgent, userAgentDevice),


### PR DESCRIPTION
Accidentally removed this line, which is needed to get the member id since we don't have access to the cookie in mup-web.