### PR TITLE
Make sort callback optional for List state

### DIFF
--- a/flow-typed/platform.js
+++ b/flow-typed/platform.js
@@ -56,7 +56,7 @@ declare type QueryListParam = {|
 	dynamicRef: string, // dynamic ref that will be kept forever
 	merge?: {
 		idTest: (Object, Object) => boolean, // test for same object identity
-		sort: (Object, Object) => number, // test for order
+		sort?: (Object, Object) => number, // test for order
 	},
 |};
 // API query structure

--- a/packages/mwp-api-state/src/reducer.js
+++ b/packages/mwp-api-state/src/reducer.js
@@ -63,12 +63,12 @@ export const getListState: ResponseStateSetter = (
 	const oldList = ((state[dynamicRef] || {}).value || [])
 		.filter(valOld => !newList.find(valNew => idTest(valOld, valNew)));
 
+	// combine the new list and the old list
 	const mergedList = [...oldList, ...newList];
-	// we can omit sort callback e.g. in members search default sort is `closest_match` which we decided not to implement on FE side
+	// sort is optional
 	if (sort) {
 		mergedList.sort(sort);
 	}
-	// combine the new list and the old list and sort the results
 	return { [dynamicRef]: { value: mergedList } };
 };
 

--- a/packages/mwp-api-state/src/reducer.js
+++ b/packages/mwp-api-state/src/reducer.js
@@ -63,8 +63,13 @@ export const getListState: ResponseStateSetter = (
 	const oldList = ((state[dynamicRef] || {}).value || [])
 		.filter(valOld => !newList.find(valNew => idTest(valOld, valNew)));
 
+	const mergedList = [...oldList, ...newList];
+	// we can omit sort callback e.g. in members search default sort is `closest_match` which we decided not to implement on FE side
+	if (sort) {
+		mergedList.sort(sort);
+	}
 	// combine the new list and the old list and sort the results
-	return { [dynamicRef]: { value: [...oldList, ...newList].sort(sort) } };
+	return { [dynamicRef]: { value: mergedList } };
 };
 
 export const responseToState: ResponseStateSetter = (

--- a/packages/mwp-api-state/src/reducer.test.js
+++ b/packages/mwp-api-state/src/reducer.test.js
@@ -33,6 +33,18 @@ describe('getListState', () => {
 			},
 		},
 	};
+	const respWithoutSort = {
+		response: { value: ['foo'] },
+		query: {
+			ref: 'bar',
+			list: {
+				dynamicRef: 'baz',
+				merge: {
+					idTest: () => false,
+				},
+			},
+		},
+	};
 	it('ignores no-response responses', () => {
 		expect(
 			getListState(state, {
@@ -63,6 +75,16 @@ describe('getListState', () => {
 				value: [...value, ...resp.response.value].sort(
 					resp.query.list.merge.sort
 				),
+			},
+		});
+	});
+	it('merges new response with existing dynamicRef, not sorted if sort callback undefined', () => {
+		const value = ['qux'];
+		expect(
+			getListState({ [resp.query.list.dynamicRef]: { value } }, respWithoutSort)
+		).toEqual({
+			[resp.query.list.dynamicRef]: {
+				value: [...value, ...resp.response.value],
 			},
 		});
 	});


### PR DESCRIPTION
Make sort callback optional as e.g. in members search default sort is `closest_match` which we decided not to implement on FE side