### PR TITLE
WP 696 fix the delayed cache

### DIFF
--- a/packages/mwp-api-state/src/cache/index.js
+++ b/packages/mwp-api-state/src/cache/index.js
@@ -4,7 +4,6 @@
  *
  * @module CacheMiddleware
  */
-import { combineEpics } from '../redux-promise-epic';
 import { API_REQ, API_RESP_SUCCESS } from '../sync/apiActionCreators';
 import { CACHE_CLEAR, CACHE_SET, cacheSuccess } from './cacheActionCreators';
 
@@ -71,13 +70,7 @@ export const cacheQueryEpic = cache => (action, store) => {
 		.then(hits => hits.map(cacheSuccess)); // map the hits onto cacheSuccess actions
 };
 
-const getCacheEpic = (cache = makeCache()) =>
+export default (cache = makeCache()) =>
 	checkEnable()
-		? combineEpics(
-				cacheClearEpic(cache),
-				cacheSetEpic(cache),
-				cacheQueryEpic(cache)
-		  )
-		: action => Promise.resolve([]);
-
-export default getCacheEpic;
+		? [cacheClearEpic(cache), cacheSetEpic(cache), cacheQueryEpic(cache)]
+		: [action => Promise.resolve([])];

--- a/packages/mwp-api-state/src/cache/index.test.js
+++ b/packages/mwp-api-state/src/cache/index.test.js
@@ -8,7 +8,7 @@ import * as api from '../sync/apiActionCreators';
 
 import { makeCache } from './util';
 import { CACHE_CLEAR, CACHE_SUCCESS } from './cacheActionCreators';
-import getCacheEpic from './';
+import getCacheEpics from './';
 
 const MOCK_QUERY = mockQuery(MOCK_RENDERPROPS);
 const MOCK_SUCCESS_ACTION = api.success({
@@ -25,8 +25,11 @@ const fakeStore = {
 	subscribe() {},
 };
 
+const flattenArray = arrays => [].concat.apply([], arrays);
 function makeCacheEpic() {
-	return Promise.resolve(getCacheEpic(makeCache()));
+	const cacheEpics = getCacheEpics(makeCache());
+	return (action, store) =>
+		Promise.all(cacheEpics.map(e => e(action, store))).then(flattenArray);
 }
 function populateCacheEpic(CacheEpic) {
 	// set the cache with API_SUCCESS
@@ -46,22 +49,19 @@ const testForPopulatedCache = (action = apiRequestAction) => CacheEpic =>
 		expect(actions.map(({ type }) => type)).toContain(CACHE_SUCCESS)
 	);
 
-describe('getCacheEpic', () => {
+describe('getCacheEpics', () => {
 	it('does not pass through arbitrary actions', () =>
-		getCacheEpic()({ type: 'asdf' }).then(actions =>
-			expect(actions).toHaveLength(0)
-		));
+		Promise.all(getCacheEpics().map(e => e({ type: 'asdf' })))
+			.then(flattenArray)
+			.then(actions => expect(actions).toHaveLength(0)));
 	it('does not emit CACHE_SUCCESS when no cache hit from API_REQ', () =>
-		makeCacheEpic().then(testForEmptyCache()));
+		testForEmptyCache()(makeCacheEpic()));
 
 	it('emits CACHE_SUCCESS when there is a cache hit for API_REQ', () =>
-		makeCacheEpic()
-			.then(populateCacheEpic) // also indirectly testing for successful cache set on API_SUCCESS
-			.then(testForPopulatedCache()));
+		populateCacheEpic(makeCacheEpic()).then(testForPopulatedCache()));
 
 	it('does not emit CACHE_SUCCESS after CACHE_CLEAR is dispatched', () =>
-		makeCacheEpic()
-			.then(populateCacheEpic)
+		populateCacheEpic(makeCacheEpic())
 			.then(clearCacheEpic)
 			.then(testForEmptyCache()));
 });

--- a/packages/mwp-api-state/src/index.js
+++ b/packages/mwp-api-state/src/index.js
@@ -1,4 +1,4 @@
-import { createEpicMiddleware, combineEpics } from './redux-promise-epic';
+import { createMiddleware } from './redux-promise-epic';
 
 import getSyncEpic from './sync';
 import getCacheEpic from './cache';
@@ -29,11 +29,9 @@ export { api, app, DEFAULT_API_STATE } from './reducer';
  * middleware that doesn't include the other epics if performance is an issue
  */
 export const getApiMiddleware = (findMatches, fetchQueriesFn) =>
-	createEpicMiddleware(
-		combineEpics(
-			getCacheEpic(),
-			getSyncEpic(findMatches, fetchQueriesFn),
-			postEpic, // DEPRECATED
-			deleteEpic // DEPRECATED
-		)
+	createMiddleware(
+		getCacheEpic(),
+		getSyncEpic(findMatches, fetchQueriesFn),
+		postEpic, // DEPRECATED
+		deleteEpic // DEPRECATED
 	);

--- a/packages/mwp-api-state/src/index.js
+++ b/packages/mwp-api-state/src/index.js
@@ -1,7 +1,7 @@
 import { createMiddleware } from './redux-promise-epic';
 
-import getSyncEpic from './sync';
-import getCacheEpic from './cache';
+import getSyncEpics from './sync';
+import getCacheEpics from './cache';
 import { postEpic, deleteEpic } from './mutate'; // DEPRECATED
 
 // export specific values of internal modules
@@ -30,8 +30,8 @@ export { api, app, DEFAULT_API_STATE } from './reducer';
  */
 export const getApiMiddleware = (findMatches, fetchQueriesFn) =>
 	createMiddleware(
-		getCacheEpic(),
-		getSyncEpic(findMatches, fetchQueriesFn),
+		...getCacheEpics(),
+		...getSyncEpics(findMatches, fetchQueriesFn),
 		postEpic, // DEPRECATED
 		deleteEpic // DEPRECATED
 	);

--- a/packages/mwp-api-state/src/redux-promise-epic/__snapshots__/index.test.js.snap
+++ b/packages/mwp-api-state/src/redux-promise-epic/__snapshots__/index.test.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`makeCallEpics every epic calls store.dipatch 1`] = `
+Array [
+  Array [
+    "action1",
+  ],
+  Array [
+    "action2",
+  ],
+  Array [
+    "action3",
+  ],
+]
+`;

--- a/packages/mwp-api-state/src/redux-promise-epic/index.test.js
+++ b/packages/mwp-api-state/src/redux-promise-epic/index.test.js
@@ -1,0 +1,34 @@
+import { makeCallEpics } from './index';
+
+describe('makeCallEpics', () => {
+	test('every epic calls store.dipatch', () => {
+		const store = { dispatch: jest.fn() };
+		const epics = [
+			() => Promise.resolve(['action1']),
+			() => Promise.resolve(['action2']),
+			() => Promise.resolve(['action3']),
+		];
+
+		const callEpics = makeCallEpics(...epics);
+		return Promise.all(callEpics('foo', store)).then(() => {
+			expect(store.dispatch.mock.calls).toMatchSnapshot();
+		});
+	});
+	test('delayed actions arrive later', () => {
+		const store = { dispatch: jest.fn() };
+		const delayedAction = 'action0';
+		const delayedEpic = () =>
+			new Promise(resolve => setTimeout(() => resolve([delayedAction]), 5));
+		const epics = [
+			delayedEpic,
+			() => Promise.resolve(['action1']),
+			() => Promise.resolve(['action2']),
+			() => Promise.resolve(['action3']),
+		];
+
+		const callEpics = makeCallEpics(...epics);
+		return Promise.all(callEpics('foo', store)).then(() => {
+			expect(store.dispatch).toHaveBeenLastCalledWith(delayedAction);
+		});
+	});
+});

--- a/packages/mwp-api-state/src/sync/index.js
+++ b/packages/mwp-api-state/src/sync/index.js
@@ -1,5 +1,3 @@
-import { combineEpics } from '../redux-promise-epic';
-
 import { LOCATION_CHANGE, SERVER_RENDER } from 'mwp-router';
 import { getMatchedQueries } from 'mwp-router/lib/util';
 import { actions as clickActions } from 'mwp-tracking-plugin/lib/util/clickState';
@@ -205,10 +203,9 @@ export const getFetchQueriesEpic = (findMatches, fetchQueriesFn) => {
 	};
 };
 
-export default (findMatches, fetchQueriesFn) =>
-	combineEpics(
-		getNavEpic(findMatches),
-		getFetchQueriesEpic(findMatches, fetchQueriesFn),
-		apiRequestToApiReq,
-		clickEpic
-	);
+export default (findMatches, fetchQueriesFn) => [
+	getNavEpic(findMatches),
+	getFetchQueriesEpic(findMatches, fetchQueriesFn),
+	apiRequestToApiReq,
+	clickEpic,
+];


### PR DESCRIPTION
The in-browser cache has been effectively broken for a few months - this fixes it.

Cause: the CACHE_SUCCESS action was only being dispatched after _all_ responses to the `API_REQ` action returned, including the API_RESP_XXX actions, so the cache would only update state at the same time that the API response was updating state. Fail

This should have a big impact on perceived TTI