### PR TITLE
Restore cache change

### DIFF
--- a/packages/mwp-api-state/src/cache/index.js
+++ b/packages/mwp-api-state/src/cache/index.js
@@ -4,7 +4,6 @@
  *
  * @module CacheMiddleware
  */
-import { combineEpics } from '../redux-promise-epic';
 import { API_REQ, API_RESP_SUCCESS } from '../sync/apiActionCreators';
 import { CACHE_CLEAR, CACHE_SET, cacheSuccess } from './cacheActionCreators';
 
@@ -70,13 +69,7 @@ export const cacheQueryEpic = cache => (action, store) => {
 		.then(hits => hits.map(cacheSuccess)); // map the hits onto cacheSuccess actions
 };
 
-const getCacheEpic = (cache = makeCache()) =>
+export default (cache = makeCache()) =>
 	checkEnable()
-		? combineEpics(
-				cacheClearEpic(cache),
-				cacheSetEpic(cache),
-				cacheQueryEpic(cache)
-			)
-		: action => Promise.resolve([]);
-
-export default getCacheEpic;
+		? [cacheClearEpic(cache), cacheSetEpic(cache), cacheQueryEpic(cache)]
+		: [action => Promise.resolve([])];

--- a/packages/mwp-api-state/src/cache/index.test.js
+++ b/packages/mwp-api-state/src/cache/index.test.js
@@ -8,7 +8,7 @@ import * as api from '../sync/apiActionCreators';
 
 import { makeCache } from './util';
 import { CACHE_CLEAR, CACHE_SUCCESS } from './cacheActionCreators';
-import getCacheEpic from './';
+import getCacheEpics from './';
 
 const MOCK_QUERY = mockQuery(MOCK_RENDERPROPS);
 const MOCK_SUCCESS_ACTION = api.success({
@@ -25,8 +25,11 @@ const fakeStore = {
 	subscribe() {},
 };
 
+const flattenArray = arrays => [].concat.apply([], arrays);
 function makeCacheEpic() {
-	return Promise.resolve(getCacheEpic(makeCache()));
+	const cacheEpics = getCacheEpics(makeCache());
+	return (action, store) =>
+		Promise.all(cacheEpics.map(e => e(action, store))).then(flattenArray);
 }
 function populateCacheEpic(CacheEpic) {
 	// set the cache with API_SUCCESS
@@ -46,22 +49,19 @@ const testForPopulatedCache = (action = apiRequestAction) => CacheEpic =>
 		expect(actions.map(({ type }) => type)).toContain(CACHE_SUCCESS)
 	);
 
-describe('getCacheEpic', () => {
+describe('getCacheEpics', () => {
 	it('does not pass through arbitrary actions', () =>
-		getCacheEpic()({ type: 'asdf' }).then(actions =>
-			expect(actions).toHaveLength(0)
-		));
+		Promise.all(getCacheEpics().map(e => e({ type: 'asdf' })))
+			.then(flattenArray)
+			.then(actions => expect(actions).toHaveLength(0)));
 	it('does not emit CACHE_SUCCESS when no cache hit from API_REQ', () =>
-		makeCacheEpic().then(testForEmptyCache()));
+		testForEmptyCache()(makeCacheEpic()));
 
 	it('emits CACHE_SUCCESS when there is a cache hit for API_REQ', () =>
-		makeCacheEpic()
-			.then(populateCacheEpic) // also indirectly testing for successful cache set on API_SUCCESS
-			.then(testForPopulatedCache()));
+		populateCacheEpic(makeCacheEpic()).then(testForPopulatedCache()));
 
 	it('does not emit CACHE_SUCCESS after CACHE_CLEAR is dispatched', () =>
-		makeCacheEpic()
-			.then(populateCacheEpic)
+		populateCacheEpic(makeCacheEpic())
 			.then(clearCacheEpic)
 			.then(testForEmptyCache()));
 });

--- a/packages/mwp-api-state/src/index.js
+++ b/packages/mwp-api-state/src/index.js
@@ -1,7 +1,7 @@
-import { createEpicMiddleware, combineEpics } from './redux-promise-epic';
+import { createMiddleware } from './redux-promise-epic';
 
-import getSyncEpic from './sync';
-import getCacheEpic from './cache';
+import getSyncEpics from './sync';
+import getCacheEpics from './cache';
 import { postEpic, deleteEpic } from './mutate'; // DEPRECATED
 
 // export specific values of internal modules
@@ -29,11 +29,9 @@ export { api, app, DEFAULT_API_STATE } from './reducer';
  * middleware that doesn't include the other epics if performance is an issue
  */
 export const getApiMiddleware = (findMatches, fetchQueriesFn) =>
-	createEpicMiddleware(
-		combineEpics(
-			getCacheEpic(),
-			getSyncEpic(findMatches, fetchQueriesFn),
-			postEpic, // DEPRECATED
-			deleteEpic // DEPRECATED
-		)
+	createMiddleware(
+		...getCacheEpics(),
+		...getSyncEpics(findMatches, fetchQueriesFn),
+		postEpic, // DEPRECATED
+		deleteEpic // DEPRECATED
 	);

--- a/packages/mwp-api-state/src/redux-promise-epic/__snapshots__/index.test.js.snap
+++ b/packages/mwp-api-state/src/redux-promise-epic/__snapshots__/index.test.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`makeCallEpics every epic calls store.dipatch 1`] = `
+Array [
+  Array [
+    "action1",
+  ],
+  Array [
+    "action2",
+  ],
+  Array [
+    "action3",
+  ],
+]
+`;

--- a/packages/mwp-api-state/src/redux-promise-epic/index.test.js
+++ b/packages/mwp-api-state/src/redux-promise-epic/index.test.js
@@ -1,0 +1,34 @@
+import { makeCallEpics } from './index';
+
+describe('makeCallEpics', () => {
+	test('every epic calls store.dipatch', () => {
+		const store = { dispatch: jest.fn() };
+		const epics = [
+			() => Promise.resolve(['action1']),
+			() => Promise.resolve(['action2']),
+			() => Promise.resolve(['action3']),
+		];
+
+		const callEpics = makeCallEpics(...epics);
+		return Promise.all(callEpics('foo', store)).then(() => {
+			expect(store.dispatch.mock.calls).toMatchSnapshot();
+		});
+	});
+	test('delayed actions arrive later', () => {
+		const store = { dispatch: jest.fn() };
+		const delayedAction = 'action0';
+		const delayedEpic = () =>
+			new Promise(resolve => setTimeout(() => resolve([delayedAction]), 5));
+		const epics = [
+			delayedEpic,
+			() => Promise.resolve(['action1']),
+			() => Promise.resolve(['action2']),
+			() => Promise.resolve(['action3']),
+		];
+
+		const callEpics = makeCallEpics(...epics);
+		return Promise.all(callEpics('foo', store)).then(() => {
+			expect(store.dispatch).toHaveBeenLastCalledWith(delayedAction);
+		});
+	});
+});

--- a/packages/mwp-api-state/src/sync/index.js
+++ b/packages/mwp-api-state/src/sync/index.js
@@ -1,5 +1,3 @@
-import { combineEpics } from '../redux-promise-epic';
-
 import { LOCATION_CHANGE, SERVER_RENDER } from 'mwp-router';
 import { getMatchedQueries } from 'mwp-router/lib/util';
 import { actions as clickActions } from 'mwp-tracking-plugin/lib/util/clickState';
@@ -205,10 +203,9 @@ export const getFetchQueriesEpic = (findMatches, fetchQueriesFn) => {
 	};
 };
 
-export default (findMatches, fetchQueriesFn) =>
-	combineEpics(
-		getNavEpic(findMatches),
-		getFetchQueriesEpic(findMatches, fetchQueriesFn),
-		apiRequestToApiReq,
-		clickEpic
-	);
+export default (findMatches, fetchQueriesFn) => [
+	getNavEpic(findMatches),
+	getFetchQueriesEpic(findMatches, fetchQueriesFn),
+	apiRequestToApiReq,
+	clickEpic,
+];

--- a/packages/mwp-router/src/AsyncRoute.jsx
+++ b/packages/mwp-router/src/AsyncRoute.jsx
@@ -12,20 +12,21 @@ type Props = {
 };
 type ComponentState = {
 	component: React$ComponentType<*>,
-	_componentCache: { [string]: React$ComponentType<*> },
 };
 type State = ComponentState;
 
-// simple pass through component to use while real component is loading
-const PassThrough = (children: React$Node) => <div />;
+// 'global' cache of resolved components to skip async fetching on repeat renders
+const _componentCache = {};
 
-// Helper to set rendering component once resolved, as well as update cache
-const getComponentStateSetter = (key: string) => (
-	component: React$ComponentType<*>
-) => (state: State): ComponentState => ({
-	component,
-	_componentCache: { ...state._componentCache, [key]: component },
-});
+// simple pass through component to use while real component is loading
+const Placeholder = (children: React$Node) => <div />;
+
+const keyFromRoute = (route: PlatformRoute): string =>
+	(route.getComponent || '').toString();
+const componentFromRoute = (route: PlatformRoute): React$ComponentType<*> =>
+	route.component || // statically defined component
+	_componentCache[keyFromRoute(route)] || // cached getComponent
+	Placeholder; // fallback placeholder while getComponent is resolved
 
 /**
  * Route rendering component that uses internal state to keep a reference to the
@@ -34,54 +35,50 @@ const getComponentStateSetter = (key: string) => (
  * component 'getter' and the the result will be rendered (and cached).
  */
 class AsyncRoute extends React.Component<Props, State> {
-	constructor(props: Props) {
-		super(props);
-		const route = props.route;
-
-		this.state = {
-			component: route.component || PassThrough,
-			_componentCache: {},
-		};
-		if (route.getComponent) {
-			this.resolveComponent(route.getComponent);
+	stopLoading: boolean = false;
+	state = {
+		component: componentFromRoute(this.props.route),
+	};
+	static getDerivedStateFromProps(props: Props, state: State) {
+		const component = componentFromRoute(props.route);
+		if (state.component === component) {
+			return null;
 		}
+		return { component };
 	}
-	/*
-	 * Given a component-resolving function, update this.state.component with
-	 * the resolved value - set/get cached reference as necessary
-	 */
-	resolveComponent(resolver: () => Promise<React$ComponentType<*>>) {
-		const key = resolver.toString();
-		const cached = this.state._componentCache[key];
+	componentDidMount() {
+		this.resolveComponent();
+	}
+	componentDidUpdate() {
+		this.resolveComponent();
+	}
+	componentWillUnmount() {
+		this.stopLoading = true;
+	}
+
+	resolveComponent() {
+		const { route } = this.props;
+		if (this.state.component !== Placeholder || !route.getComponent) {
+			// already resolved
+			return;
+		}
+		const key = keyFromRoute(route);
+		const cached = _componentCache[key];
 		if (cached) {
 			this.setState({ component: cached });
 			return;
 		}
-		resolver()
-			.then(getComponentStateSetter(key))
-			.then(setter => this.setState(setter));
+		// not cached yet - go get it
+		route.getComponent().then(component => {
+			// now cache it
+			_componentCache[key] = component;
+			if (this.stopLoading) {
+				return;
+			}
+			// and set it to render if this route is still mounted
+			this.setState({ component });
+		});
 	}
-
-	/*
-	 * New props may correspond to a route change. If so, this function sets the
-	 * component to render
-	 */
-	componentWillReceiveProps(nextProps: Props) {
-		const { match, route } = nextProps;
-		if (route === this.props.route && match === this.props.match) {
-			return; // no new route, just re-render normally
-		}
-
-		if (route.component) {
-			this.setState(state => ({ component: route.component }));
-			return;
-		}
-
-		this.setState(state => ({ component: PassThrough }));
-		// Component needs to be resolved - just render children for now
-		this.resolveComponent(route.getComponent);
-	}
-
 	render() {
 		const { match, route, ...props } = this.props;
 


### PR DESCRIPTION
This restores the caching changes introduced in #533 that resulted in broken e2e tests in mup-web.

This branch will be used to test failure modes in mup-web independent of the router changes introduced in #539 , 

https://meetup-auth.appspot.com/mup-web-canary/mupweb-canary-18539-2018-08-28-22-35-56/report/CHROME/report.html