### PR TITLE
Enforce node and yarn versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - "8.9"
+  - "8.11"
 cache:
   directories:
     - node_modules
@@ -36,7 +36,7 @@ before_install:
   - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > packages/mwp-test-utils/.npmrc
   - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > packages/mwp-toaster/.npmrc
   - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > packages/mwp-tracking-plugin/.npmrc
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.9.2
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.9.4
   - export PATH=$HOME/.yarn/bin:$PATH
   - yarn --version
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A collection of Node web application utilities for the Meetup web platform",
   "engineStrict": true,
   "engines": {
-    "node": ">=8.9.0"
+    "node": "^8.11.4",
+    "yarn": "1.9.4"
   },
   "main": "./lib/index.js",
   "config": {

--- a/packages/mwp-api-proxy-plugin/package.json
+++ b/packages/mwp-api-proxy-plugin/package.json
@@ -4,7 +4,8 @@
   "description": "Hapi plugin to activate the REST API proxy behavior + route",
   "engineStrict": true,
   "engines": {
-    "node": ">=8.1.0"
+    "node": "^8.11.4",
+    "yarn": "1.9.4"
   },
   "main": "./lib/index.js",
   "scripts": {

--- a/packages/mwp-api-state/package.json
+++ b/packages/mwp-api-state/package.json
@@ -4,7 +4,8 @@
   "description": "Redux helpers to manage API data in a MWP app",
   "engineStrict": true,
   "engines": {
-    "node": ">=8.1.0"
+    "node": "^8.11.4",
+    "yarn": "1.9.4"
   },
   "main": "./lib/index.js",
   "scripts": {

--- a/packages/mwp-app-render/package.json
+++ b/packages/mwp-app-render/package.json
@@ -4,7 +4,8 @@
   "description": "MWP application rendering tools",
   "engineStrict": true,
   "engines": {
-    "node": ">=8.1.0"
+    "node": "^8.11.4",
+    "yarn": "1.9.4"
   },
   "main": "./lib/index.js",
   "scripts": {

--- a/packages/mwp-app-route-plugin/package.json
+++ b/packages/mwp-app-route-plugin/package.json
@@ -4,7 +4,8 @@
   "description": "Hapi plugin to activate the wildcard application route",
   "engineStrict": true,
   "engines": {
-    "node": ">=8.1.0"
+    "node": "^8.11.4",
+    "yarn": "1.9.4"
   },
   "main": "./lib/index.js",
   "scripts": {

--- a/packages/mwp-app-server/package.json
+++ b/packages/mwp-app-server/package.json
@@ -4,7 +4,8 @@
   "description": "Hapi server startup module for MWP applications",
   "engineStrict": true,
   "engines": {
-    "node": ">=8.1.0"
+    "node": "^8.11.4",
+    "yarn": "1.9.4"
   },
   "main": "./lib/index.js",
   "scripts": {

--- a/packages/mwp-auth-plugin/package.json
+++ b/packages/mwp-auth-plugin/package.json
@@ -4,7 +4,8 @@
   "description": "Hapi plugin providing user authentication for MWP apps",
   "engineStrict": true,
   "engines": {
-    "node": ">=8.1.0"
+    "node": "^8.11.4",
+    "yarn": "1.9.4"
   },
   "main": "./lib/index.js",
   "scripts": {

--- a/packages/mwp-consumer/package.json
+++ b/packages/mwp-consumer/package.json
@@ -4,7 +4,8 @@
 	"description": "A minimal MWP consumer application that can be used for performance testing",
 	"engineStrict": true,
 	"engines": {
-		"node": ">=8.9.0"
+		"node": "^8.11.4",
+		"yarn": "1.9.4"
 	},
 	"config": {},
 	"main": "./lib/index.js",

--- a/packages/mwp-core/package.json
+++ b/packages/mwp-core/package.json
@@ -4,7 +4,8 @@
   "description": "Core utilities for MWP apps",
   "engineStrict": true,
   "engines": {
-    "node": ">=8.1.0"
+    "node": "^8.11.4",
+    "yarn": "1.9.4"
   },
   "main": "./lib/index.js",
   "scripts": {

--- a/packages/mwp-csp-plugin/package.json
+++ b/packages/mwp-csp-plugin/package.json
@@ -4,7 +4,8 @@
   "description": "Sets content security policy headers",
   "engineStrict": true,
   "engines": {
-    "node": ">=8.1.0"
+    "node": "^8.11.4",
+    "yarn": "1.9.4"
   },
   "main": "./lib/index.js",
   "scripts": {

--- a/packages/mwp-i18n/package.json
+++ b/packages/mwp-i18n/package.json
@@ -4,7 +4,8 @@
   "description": "Internationalization helpers for MWP apps",
   "engineStrict": true,
   "engines": {
-    "node": ">=8.1.0"
+    "node": "^8.11.4",
+    "yarn": "1.9.4"
   },
   "main": "./lib/index.js",
   "scripts": {

--- a/packages/mwp-language-plugin/package.json
+++ b/packages/mwp-language-plugin/package.json
@@ -4,7 +4,8 @@
   "description": "Hapi plugin for determining the requested language for MWP apps",
   "engineStrict": true,
   "engines": {
-    "node": ">=8.1.0"
+    "node": "^8.11.4",
+    "yarn": "1.9.4"
   },
   "main": "./lib/index.js",
   "scripts": {

--- a/packages/mwp-logger-plugin/package.json
+++ b/packages/mwp-logger-plugin/package.json
@@ -4,7 +4,8 @@
   "description": "Hapi logging plugin for MWP apps",
   "engineStrict": true,
   "engines": {
-    "node": ">=8.1.0"
+    "node": "^8.11.4",
+    "yarn": "1.9.4"
   },
   "main": "./lib/index.js",
   "scripts": {

--- a/packages/mwp-router/package.json
+++ b/packages/mwp-router/package.json
@@ -4,7 +4,8 @@
   "description": "React routing tools for MWP apps",
   "engineStrict": true,
   "engines": {
-    "node": ">=8.1.0"
+    "node": "^8.11.4",
+    "yarn": "1.9.4"
   },
   "main": "./lib/index.js",
   "scripts": {

--- a/packages/mwp-store/package.json
+++ b/packages/mwp-store/package.json
@@ -4,7 +4,8 @@
   "description": "Redux store management for MWP apps",
   "engineStrict": true,
   "engines": {
-    "node": ">=8.1.0"
+    "node": "^8.11.4",
+    "yarn": "1.9.4"
   },
   "main": "./lib/index.js",
   "scripts": {

--- a/packages/mwp-sw-plugin/package.json
+++ b/packages/mwp-sw-plugin/package.json
@@ -4,7 +4,8 @@
   "description": "Hapi plugin for serving a service worker script",
   "engineStrict": true,
   "engines": {
-    "node": ">=8.1.0"
+    "node": "^8.11.4",
+    "yarn": "1.9.4"
   },
   "main": "./lib/index.js",
   "scripts": {

--- a/packages/mwp-test-utils/package.json
+++ b/packages/mwp-test-utils/package.json
@@ -4,7 +4,8 @@
   "description": "Helpers for running unit tests in MWP apps",
   "engineStrict": true,
   "engines": {
-    "node": ">=8.1.0"
+    "node": "^8.11.4",
+    "yarn": "1.9.4"
   },
   "main": "./lib/index.js",
   "scripts": {

--- a/packages/mwp-toaster/package.json
+++ b/packages/mwp-toaster/package.json
@@ -4,7 +4,8 @@
   "description": "Toast UI controller for MWP apps",
   "engineStrict": true,
   "engines": {
-    "node": ">=8.1.0"
+    "node": "^8.11.4",
+    "yarn": "1.9.4"
   },
   "main": "./lib/index.js",
   "scripts": {

--- a/packages/mwp-tracking-plugin/package.json
+++ b/packages/mwp-tracking-plugin/package.json
@@ -4,7 +4,8 @@
   "description": "Data collection for MWP apps, including activity and click tracking",
   "engineStrict": true,
   "engines": {
-    "node": ">=8.1.0"
+    "node": "^8.11.4",
+    "yarn": "1.9.4"
   },
   "main": "./lib/index.js",
   "scripts": {


### PR DESCRIPTION
If you're on the wrong version of node, you'll get:

```bash
sadaf: ~/git_repo/meetup-web-platform [WP-781_engine_versions] [!] $ yarn
yarn install v1.9.4
[1/5] 🔍  Validating package.json...
error meetup-web-platform@0.0.1: The engine "node" is incompatible with this module. Expected version "^8.11.4".
error Found incompatible module
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

If you're on the wrong version of yarn, you'll get:

```bash
sadaf: ~/git_repo/meetup-web-platform [WP-781_engine_versions] $ yarn
yarn install v1.8.0
[1/5] 🔍  Validating package.json...
error meetup-web-platform@0.0.1: The engine "yarn" is incompatible with this module. Expected version "1.9.4".
error Found incompatible module
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```