### PR TITLE
do not set headers if response is an error

### DIFF
--- a/packages/mwp-csp-plugin/src/index.js
+++ b/packages/mwp-csp-plugin/src/index.js
@@ -7,6 +7,10 @@ export function register(
 	options: ?{ [string]: string }
 ): Promise<any> {
 	server.ext('onPreResponse', (request, h) => {
+		if (request.response.isBoom) {
+			// don't set headers on error objects
+			return h.continue;
+		}
 		// Tells browser that it should only be accessed using HTTPS & how long to remember that
 		request.response.header('Strict-Transport-Security', 'max-age=7776000'); // 3 months
 


### PR DESCRIPTION
- Check isBoom before setting CSP headers. Fixes `TypeError: request.response.header is not a function` which was appearing when there is an error upstream

I tested this by deleting the `x-mwp-csrf_dev-header` and making a POST request, which creates a BAD_TOKEN error to combat cross-site attacks. It was throwing the TypeError, but after I made this change the appropriate BAD_TOKEN error is thrown
