### PR TITLE
Return null value in StateBroadcast component

### DIFF
--- a/packages/mwp-app-render/src/components/StateBroadcast.jsx
+++ b/packages/mwp-app-render/src/components/StateBroadcast.jsx
@@ -14,6 +14,7 @@ export class StateBroadcastComponent extends React.PureComponent<Props> {
 	render() {
 		// don't actually need to render - this.props.state will always contain
 		// latest Redux state
+		return null;
 	}
 }
 

--- a/packages/mwp-app-render/src/components/stateBroadcast.test.jsx
+++ b/packages/mwp-app-render/src/components/stateBroadcast.test.jsx
@@ -6,6 +6,9 @@ test('Does not render', () => {
 	global.window = {};
 	expect(shallow(<StateBroadcastComponent state={{}} />)).toMatchSnapshot();
 });
+test('returns null', () => {
+	expect(shallow(<StateBroadcastComponent state={{}} />).type()).toEqual(null);
+});
 test('adds a getAppState function to window', () => {
 	global.window = {};
 	const mockState = { foo: 'bar' };


### PR DESCRIPTION
Building off of this PR:
https://github.com/meetup/meetup-web-platform/pull/504

We were getting an error because the component wasn't actually returning anything within the `render` method.

Screenshot:
![screen shot 2018-09-05 at 2 58 55 pm](https://user-images.githubusercontent.com/5719269/45118175-b5fd9000-b125-11e8-8d8e-167d754f93b8.png)
