### PR TITLE
Add blob to CSP plugin options

### DIFF
--- a/packages/mwp-app-server/src/util/getPlugins.js
+++ b/packages/mwp-app-server/src/util/getPlugins.js
@@ -159,7 +159,7 @@ export default function getPlugins({ languageRenderers }) {
 			].join(' '),
 			connectSrc: '*',
 			frameSrc: '*',
-			imgSrc: '* data:',
+			imgSrc: '* data: blob:',
 			styleSrc: ['*', CSP_KEYWORDS.unsafeInline].join(' '),
 			scriptSrc: ['*', CSP_KEYWORDS.unsafeEval, CSP_KEYWORDS.unsafeInline].join(
 				' '


### PR DESCRIPTION
The `pro` BCAN service has a file upload option that is currently failing because of a `Content Security Policy` error stating that `blob` is not an accepted file source type. 

![screen shot 2018-09-10 at 2 49 21 pm](https://user-images.githubusercontent.com/5719269/45318417-e6b93d00-b50a-11e8-99ac-0e10f679bade.png)

Adding `blob:` resolves this issue.