### PR TITLE
Add "data:" to CSP plugin font options

### DIFF
--- a/packages/mwp-app-server/src/util/getPlugins.js
+++ b/packages/mwp-app-server/src/util/getPlugins.js
@@ -159,6 +159,7 @@ export default function getPlugins({ languageRenderers }) {
 			].join(' '),
 			connectSrc: '*',
 			frameSrc: '*',
+			fontSrc: '* data:',
 			imgSrc: '* data: blob:',
 			styleSrc: ['*', CSP_KEYWORDS.unsafeInline].join(' '),
 			scriptSrc: ['*', CSP_KEYWORDS.unsafeEval, CSP_KEYWORDS.unsafeInline].join(


### PR DESCRIPTION
JIRA Ticket: https://meetup.atlassian.net/browse/MP-2146

The pro-web page relies on base64 encoded fonts which are failing to load at the moment. Adding `data:` to the `fontSrc` should resolve the issue.

Screenshot:
![screen shot 2018-09-18 at 6 36 13 pm](https://user-images.githubusercontent.com/5719269/45720337-f7ecf400-bb71-11e8-86e2-1e8770bf28d7.png)


Similar fix here: https://github.com/meetup/meetup-web-platform/pull/547