### PR TITLE
tests for getRedirect and URL string formatting fix

### DIFF
--- a/packages/mwp-core/src/renderers/server-render.jsx
+++ b/packages/mwp-core/src/renderers/server-render.jsx
@@ -30,13 +30,15 @@ function getHtml(el) {
 	return `${DOCTYPE}${htmlMarkup}`;
 }
 
-function getRedirect(context) {
+export function getRedirect(context) {
 	if (!context || !context.url) {
 		return;
 	}
+	// use `URL` to ensure valid character encoding (e.g. escaped emoji)
+	const url = new URL(context.url).toString();
 	return {
 		redirect: {
-			url: encodeURI(decodeURI(context.url)), // ensure that the url is encoded for the redirect header
+			url,
 			permanent: context.permanent,
 		},
 	};

--- a/packages/mwp-core/src/renderers/server-render.test.jsx
+++ b/packages/mwp-core/src/renderers/server-render.test.jsx
@@ -1,0 +1,23 @@
+import { getRedirect } from './server-render';
+
+describe('getRedirect', () => {
+	test('escapes UTF-8', () => {
+		const context = { url: 'http://www.meetup.com/驚くばかり' };
+		expect(getRedirect(context).redirect.url).toMatchInlineSnapshot(
+			`"http://www.meetup.com/%E9%A9%9A%E3%81%8F%E3%81%B0%E3%81%8B%E3%82%8A"`
+		);
+	});
+	test('does not modify escaped emoji', () => {
+		const context = {
+			url:
+				'http://www.meetup.com/%E9%A9%9A%E3%81%8F%E3%81%B0%E3%81%8B%E3%82%8A',
+		};
+		expect(getRedirect(context).redirect.url).toBe(context.url);
+	});
+	test('does not modify escaped ampersands', () => {
+		const context = {
+			url: 'http://www.meetup.com/?foo=bar%26baz',
+		};
+		expect(getRedirect(context).redirect.url).toBe(context.url);
+	});
+});


### PR DESCRIPTION
`encodeURI(decodeURI(...))` is double-escaping ampersands. This PR uses a different `URL.prototype.toString()` approach to correctly escape utf-8 characters without affecting already-valid escaped characters.