### PR TITLE
explicitly handle 4 types of activity-generating requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [17.4]
+
+- **Refactor** `mwp-tracking-plugin` now explicitly handles each type of request
+  that results in an activity record to ensure that the expected `url` and
+  `referrer` values are populated
+
 ## [17.3]
 
 - **New feature** added support for `put` request

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CI_BUILD_NUMBER ?= $(USER)-snapshot
-VERSION ?= 17.2.$(CI_BUILD_NUMBER)
+VERSION ?= 17.4.$(CI_BUILD_NUMBER)
 
 version:
 	@echo $(VERSION)

--- a/packages/mwp-tracking-plugin/src/_activityTrackers.test.js
+++ b/packages/mwp-tracking-plugin/src/_activityTrackers.test.js
@@ -1,0 +1,86 @@
+import url from 'url';
+import rison from 'rison';
+import { getTrackActivity } from './_activityTrackers';
+
+describe('getTrackActivity', () => {
+	const PROXY_URL = url.parse('http://www.example.com/mu_api');
+	const trackApiResponses = jest.fn();
+	const REQUEST_BASE = { trackApiResponses };
+	const trackActivity = getTrackActivity();
+	const fields = { foo: 'bar' }; // arbitrary additional params to merge with url+referrer
+	test('server render record', () => {
+		const request = {
+			...REQUEST_BASE,
+			url: url.parse('http://www.current.com/foo'),
+			method: 'get',
+			query: {},
+			info: { referrer: 'http://www.previous.com/bar' },
+		};
+		trackActivity(request)(fields);
+		expect(trackApiResponses.mock.calls[0][0]).toMatchInlineSnapshot(`
+Object {
+  "foo": "bar",
+  "referrer": "http://www.previous.com/bar",
+  "url": "/foo",
+}
+`);
+	});
+	test('SPA navigation (referrer override)', () => {
+		trackApiResponses.mockClear();
+		const request = {
+			...REQUEST_BASE,
+			url: PROXY_URL,
+			method: 'get',
+			query: {
+				metadata: rison.encode_object({
+					referrer: 'http://www.previous.com/foo',
+				}),
+			},
+			info: { referrer: 'http://www.current.com/bar' },
+		};
+		trackActivity(request)(fields);
+		expect(trackApiResponses.mock.calls[0][0]).toMatchInlineSnapshot(`
+Object {
+  "foo": "bar",
+  "referrer": "http://www.previous.com/foo",
+  "url": "http://www.current.com/bar",
+}
+`);
+	});
+	test('lazy-loaded data', () => {
+		trackApiResponses.mockClear();
+		const request = {
+			...REQUEST_BASE,
+			url: PROXY_URL,
+			method: 'get',
+			query: {},
+			info: { referrer: 'http://www.current.com/foo' },
+		};
+		trackActivity(request)(fields);
+		expect(trackApiResponses.mock.calls[0][0]).toMatchInlineSnapshot(`
+Object {
+  "foo": "bar",
+  "referrer": "http://www.current.com/foo",
+  "url": "/mu_api",
+}
+`);
+	});
+	test('lazy-track', () => {
+		trackApiResponses.mockClear();
+		const request = {
+			...REQUEST_BASE,
+			url: PROXY_URL,
+			method: 'get',
+			query: {},
+			info: { referrer: 'http://www.current.com/foo' },
+		};
+		trackActivity(request)(fields);
+		expect(trackApiResponses.mock.calls[0][0]).toMatchInlineSnapshot(`
+Object {
+  "foo": "bar",
+  "referrer": "http://www.current.com/foo",
+  "url": "/mu_api",
+}
+`);
+	});
+});


### PR DESCRIPTION
The `url` and `referrer` fields are not being consistently populated as expected in consumer apps - after discussions on Slack with the data team, this PR explicitly defines the 'referrer override' case for SPA navigation, and sets up unit tests to validate the records for other types of requests that generate activity tracking records.