### PR TITLE
WP 871 native app platformAgent

### DIFF
--- a/packages/mwp-tracking-plugin/src/activity.js
+++ b/packages/mwp-tracking-plugin/src/activity.js
@@ -61,7 +61,7 @@ export const getLogger: string => (Object, Object) => mixed = (
 			ip: requestHeaders['remote-addr'] || '',
 			agent: requestHeaders['user-agent'] || '',
 			platform: 'WEB',
-			platformAgent: agent,
+			platformAgent: request.state.isNativeApp ? 'NATIVE_APP_WEB_VIEW' : agent,
 			mobileWeb: false,
 			referer: '', // misspelled to align with schema
 			trax: {},

--- a/packages/mwp-tracking-plugin/src/activity.js
+++ b/packages/mwp-tracking-plugin/src/activity.js
@@ -50,13 +50,13 @@ const ANDROID_APP_ID = 'com.meetup';
 export const getRequestPlatform = (request: HapiRequest): ActivityPlatform => {
 	const { headers, state, query = {} } = request;
 	const isNativeApp = state.isNativeApp || query.isNativeApp;
-	if (!isNativeApp) {
-		return 'WEB';
+	if (isNativeApp) {
+		// recommended test for Android WebView - not perfect but should be adequate
+		// https://stackoverflow.com/questions/24291315/android-webview-detection-in-php
+		const isAndroid = headers.http_x_requested_with === ANDROID_APP_ID;
+		return isAndroid ? 'ANDROID' : 'IOS';
 	}
-	// recommended test for Android WebView - not perfect but should be adequate
-	// https://stackoverflow.com/questions/24291315/android-webview-detection-in-php
-	const isAndroid = headers.http_x_requested_with === ANDROID_APP_ID;
-	return isAndroid ? 'ANDROID' : 'IOS';
+	return 'WEB';
 };
 export const getLogger: string => (Object, Object) => mixed = (
 	agent: string

--- a/packages/mwp-tracking-plugin/src/activity.js
+++ b/packages/mwp-tracking-plugin/src/activity.js
@@ -48,7 +48,7 @@ type ActivityPlatform = 'WEB' | 'IOS' | 'ANDROID';
 const ANDROID_APP_ID = 'com.meetup';
 
 export const getRequestPlatform = (request: HapiRequest): ActivityPlatform => {
-	const { headers, query = {}, state } = request;
+	const { headers, state, query = {} } = request;
 	const isNativeApp = state.isNativeApp || query.isNativeApp;
 	if (!isNativeApp) {
 		return 'WEB';

--- a/packages/mwp-tracking-plugin/src/activity.js
+++ b/packages/mwp-tracking-plugin/src/activity.js
@@ -44,6 +44,20 @@ export const fakeUTCinTimezone = (timezone: string) => {
  * - `trackActivity`
  */
 
+type ActivityPlatform = 'WEB' | 'IOS' | 'ANDROID';
+const ANDROID_APP_ID = 'com.meetup';
+
+export const getRequestPlatform = (request: HapiRequest): ActivityPlatform => {
+	const { headers, query = {}, state } = request;
+	const isNativeApp = state.isNativeApp || query.isNativeApp;
+	if (!isNativeApp) {
+		return 'WEB';
+	}
+	// recommended test for Android WebView - not perfect but should be adequate
+	// https://stackoverflow.com/questions/24291315/android-webview-detection-in-php
+	const isAndroid = headers.http_x_requested_with === ANDROID_APP_ID;
+	return isAndroid ? 'ANDROID' : 'IOS';
+};
 export const getLogger: string => (Object, Object) => mixed = (
 	agent: string
 ) => {
@@ -53,15 +67,15 @@ export const getLogger: string => (Object, Object) => mixed = (
 	const getTime = fakeUTCinTimezone('America/New_York');
 
 	return (request: Object, trackInfo: Object) => {
-		const requestHeaders = request.headers;
+		const { headers } = request;
 
 		const record = {
 			timestamp: getTime().toISOString(),
 			requestId: request.id,
-			ip: requestHeaders['remote-addr'] || '',
-			agent: requestHeaders['user-agent'] || '',
-			platform: 'WEB',
-			platformAgent: request.state.isNativeApp ? 'NATIVE_APP_WEB_VIEW' : agent,
+			ip: headers['remote-addr'] || '',
+			agent: headers['user-agent'] || '',
+			platform: getRequestPlatform(request),
+			platformAgent: agent,
 			mobileWeb: false,
 			referer: '', // misspelled to align with schema
 			trax: {},

--- a/packages/mwp-tracking-plugin/src/activity.test.js
+++ b/packages/mwp-tracking-plugin/src/activity.test.js
@@ -79,6 +79,9 @@ describe('getLogger', () => {
 			state: {},
 			id: 1234,
 		};
+		jest
+			.spyOn(Date.prototype, 'toISOString')
+			.mockImplementation(() => 'mock ISO date');
 		const logger = getLogger('FOO');
 		expect(logger(MOCK_REQUEST, { foo: 'bar' })).toMatchInlineSnapshot(`
 Object {
@@ -91,9 +94,10 @@ Object {
   "platformAgent": "FOO",
   "referer": "",
   "requestId": 1234,
-  "timestamp": "2018-10-25T16:58:15.000Z",
+  "timestamp": "mock ISO date",
   "trax": Object {},
 }
 `);
+		jest.restoreAllMocks(); // restore toISOString behavior
 	});
 });

--- a/packages/mwp-tracking-plugin/src/activity.test.js
+++ b/packages/mwp-tracking-plugin/src/activity.test.js
@@ -82,7 +82,7 @@ describe('getLogger', () => {
 		jest
 			.spyOn(Date.prototype, 'toISOString')
 			.mockImplementation(() => 'mock ISO date');
-		const logger = getLogger('FOO');
+		const logger = getLogger('MOCK_PLATFORM_AGENT');
 		expect(logger(MOCK_REQUEST, { foo: 'bar' })).toMatchInlineSnapshot(`
 Object {
   "agent": "",
@@ -91,7 +91,7 @@ Object {
   "isUserActivity": true,
   "mobileWeb": false,
   "platform": "WEB",
-  "platformAgent": "FOO",
+  "platformAgent": "MOCK_PLATFORM_AGENT",
   "referer": "",
   "requestId": 1234,
   "timestamp": "mock ISO date",
@@ -100,31 +100,28 @@ Object {
 `);
 		jest.restoreAllMocks(); // restore toISOString behavior
 	});
-	it('sets platformAgent to NATIVE_APP_WEB_VIEW for isNativeApp cookie', () => {
+	it('sets `platform` to IOS for isNativeApp without Android header', () => {
 		const MOCK_REQUEST = {
 			headers: {},
 			state: { isNativeApp: 'true' },
 			id: 1234,
 		};
-		jest
-			.spyOn(Date.prototype, 'toISOString')
-			.mockImplementation(() => 'mock ISO date');
-		const logger = getLogger('FOO');
-		expect(logger(MOCK_REQUEST, { foo: 'bar' })).toMatchInlineSnapshot(`
-Object {
-  "agent": "",
-  "foo": "bar",
-  "ip": "",
-  "isUserActivity": true,
-  "mobileWeb": false,
-  "platform": "WEB",
-  "platformAgent": "NATIVE_APP_WEB_VIEW",
-  "referer": "",
-  "requestId": 1234,
-  "timestamp": "mock ISO date",
-  "trax": Object {},
-}
-`);
-		jest.restoreAllMocks(); // restore toISOString behavior
+		const platformAgent = 'MOCK_PLATFORM_AGENT';
+		const logger = getLogger(platformAgent);
+		const record = logger(MOCK_REQUEST, {});
+		expect(record.platform).toBe('IOS');
+		expect(record.platformAgent).toBe(platformAgent);
+	});
+	it('sets `platform` to ANDROID for isNativeApp with Android header', () => {
+		const MOCK_REQUEST = {
+			headers: {},
+			state: { isNativeApp: 'true' },
+			id: 1234,
+		};
+		const platformAgent = 'MOCK_PLATFORM_AGENT';
+		const logger = getLogger(platformAgent);
+		const record = logger(MOCK_REQUEST, {});
+		expect(record.platform).toBe('IOS');
+		expect(record.platformAgent).toBe(platformAgent);
 	});
 });

--- a/packages/mwp-tracking-plugin/src/activity.test.js
+++ b/packages/mwp-tracking-plugin/src/activity.test.js
@@ -1,5 +1,12 @@
-import { fakeUTCinTimezone } from './activity';
+import { fakeUTCinTimezone, getLogger } from './activity';
 import { updateId } from './util/idUtils';
+
+jest.mock('./util/avro', () => ({
+	loggers: {
+		activity: jest.fn(),
+	},
+}));
+
 // RegEx to verify UUID
 const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
@@ -60,6 +67,33 @@ describe('updateId', () => {
 		const updatedTrackId = updateId(trackIdCookieName)(request, doRefresh);
 		expect(updatedTrackId).not.toBe(trackId); // no change
 		expect(request.plugins.tracking[trackIdCookieName]).not.toBeUndefined();
-		expect(request.plugins.tracking[trackIdCookieName]).toContain(updatedTrackId);
+		expect(request.plugins.tracking[trackIdCookieName]).toContain(
+			updatedTrackId
+		);
+	});
+});
+describe('getLogger', () => {
+	it('returns expected record shape', () => {
+		const MOCK_REQUEST = {
+			headers: {},
+			state: {},
+			id: 1234,
+		};
+		const logger = getLogger('FOO');
+		expect(logger(MOCK_REQUEST, { foo: 'bar' })).toMatchInlineSnapshot(`
+Object {
+  "agent": "",
+  "foo": "bar",
+  "ip": "",
+  "isUserActivity": true,
+  "mobileWeb": false,
+  "platform": "WEB",
+  "platformAgent": "FOO",
+  "referer": "",
+  "requestId": 1234,
+  "timestamp": "2018-10-25T16:58:15.000Z",
+  "trax": Object {},
+}
+`);
 	});
 });

--- a/packages/mwp-tracking-plugin/src/activity.test.js
+++ b/packages/mwp-tracking-plugin/src/activity.test.js
@@ -100,4 +100,31 @@ Object {
 `);
 		jest.restoreAllMocks(); // restore toISOString behavior
 	});
+	it('sets platformAgent to NATIVE_APP_WEB_VIEW for isNativeApp cookie', () => {
+		const MOCK_REQUEST = {
+			headers: {},
+			state: { isNativeApp: 'true' },
+			id: 1234,
+		};
+		jest
+			.spyOn(Date.prototype, 'toISOString')
+			.mockImplementation(() => 'mock ISO date');
+		const logger = getLogger('FOO');
+		expect(logger(MOCK_REQUEST, { foo: 'bar' })).toMatchInlineSnapshot(`
+Object {
+  "agent": "",
+  "foo": "bar",
+  "ip": "",
+  "isUserActivity": true,
+  "mobileWeb": false,
+  "platform": "WEB",
+  "platformAgent": "NATIVE_APP_WEB_VIEW",
+  "referer": "",
+  "requestId": 1234,
+  "timestamp": "mock ISO date",
+  "trax": Object {},
+}
+`);
+		jest.restoreAllMocks(); // restore toISOString behavior
+	});
 });

--- a/packages/mwp-tracking-plugin/src/util/avro.js
+++ b/packages/mwp-tracking-plugin/src/util/avro.js
@@ -137,9 +137,9 @@ const logger = (serializer: Serializer, deserializer: Deserializer) => (
 	const serializedRecord = serializer(record);
 	const deserializedRecord = deserializer(serializedRecord);
 	analyticsLog(serializedRecord);
-	if (process.argv.includes('--debug')) {
-		debugLog(deserializedRecord);
-	}
+	// if (process.argv.includes('--debug')) {
+	debugLog(deserializedRecord);
+	// }
 };
 
 const schemas = {

--- a/packages/mwp-tracking-plugin/src/util/avro.js
+++ b/packages/mwp-tracking-plugin/src/util/avro.js
@@ -137,9 +137,9 @@ const logger = (serializer: Serializer, deserializer: Deserializer) => (
 	const serializedRecord = serializer(record);
 	const deserializedRecord = deserializer(serializedRecord);
 	analyticsLog(serializedRecord);
-	// if (process.argv.includes('--debug')) {
-	debugLog(deserializedRecord);
-	// }
+	if (process.argv.includes('--debug')) {
+		debugLog(deserializedRecord);
+	}
 };
 
 const schemas = {

--- a/packages/mwp-tracking-plugin/src/util/avro.test.js
+++ b/packages/mwp-tracking-plugin/src/util/avro.test.js
@@ -68,6 +68,7 @@ describe('Activity tracking', () => {
 	const request = {
 		id: 'foo',
 		headers: {},
+		state: {},
 		log() {},
 		server: { settings: { app: { api: {} } } },
 	};


### PR DESCRIPTION
Native app web views should report a different `platformAgent` in activity recrods than what is usually used for requests from the browser for each web application - `'NATIVE_APP_WEB_VIEW'`

Followup will be to update mup-web and pro-web with this release