### PR TITLE
use isBot to suppress bot-sourced API request errors

### DIFF
--- a/packages/mwp-api-proxy-plugin/package.json
+++ b/packages/mwp-api-proxy-plugin/package.json
@@ -32,10 +32,11 @@
   },
   "dependencies": {
     "ajv": "5.5.2",
+    "isbot": "2.2.0",
     "joi": "13.4.0",
     "mwp-auth-plugin": ">=0.0.1",
-    "mwp-logger-plugin": ">=0.0.1",
     "mwp-config": ">=0.0.1",
+    "mwp-logger-plugin": ">=0.0.1",
     "qs": "6.5.0",
     "request": "2.88.0",
     "rison": "0.1.1"

--- a/packages/mwp-api-proxy-plugin/src/util/receive.js
+++ b/packages/mwp-api-proxy-plugin/src/util/receive.js
@@ -1,3 +1,4 @@
+import isBot from 'isbot';
 import querystring from 'qs';
 import { logger } from 'mwp-logger-plugin';
 
@@ -198,6 +199,10 @@ export const makeLogResponse = request => ([response, body]) => {
 		statusCode >= 500 || // REST API had an internal error
 		(method.toLowerCase() === 'get' && statusCode >= 400) // something fishy with a GET
 	) {
+		if (isBot(request.headers['user-agent'])) {
+			// don't log errors from bots - e.g. for deleted groups/events/whatever
+			return;
+		}
 		const logError = (statusCode < 500 ? logger.warn : logger.error).bind(
 			logger
 		);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4129,6 +4129,10 @@ isarray@1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
+isbot@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/isbot/-/isbot-2.2.0.tgz#89b4d84a8d709496371b4ea0a55f242bee7612fd"
+
 isemail@3.x.x:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/isemail/-/isemail-3.1.3.tgz#64f37fc113579ea12523165c3ebe3a71a56ce571"


### PR DESCRIPTION
search bots indexing old pages is causing a lot of error log noise

This PR prevents the error logs from being written if the request comes from a bot

Paired with @sadafie 

https://console.cloud.google.com/errors/COau2_iYrsbVLA?service=default&time=P1D&project=meetup-prod-east4