### PR TITLE
TAX-358 Update mwp-core to add a request geo location to LaunchDarkly user data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,7 @@ config.*.json
 # visual studio code settings
 .vscode
 
+# IntelliJ IDEA settings
+.idea
+
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [18.2]
+
+-   **Refactor** `mwp-app-route-plugin` defines a `LaunchDarklyUser` type for a LaunchDarkly user object
+    based on the official [documentation](https://docs.launchdarkly.com/docs/node-sdk-reference#section-users)
+-   **Refactor** `mwp-core` uses a `LaunchDarklyUser` object to call `getFlags` method of `mwp-app-route-plugin`.
+-   **New Feature** `mwp-core` adds a request country and region provided by Fastly to LaunchDarkly user
+    custom attributes.
+
 ## [18.1]
 
 -   Adds new rasp plugin which monitors and prevents traffic from bad actors.

--- a/flow-typed/platform.js
+++ b/flow-typed/platform.js
@@ -143,3 +143,23 @@ declare type CookieOpts = {
 	isSecure?: boolean,
 	encoding?: string,
 };
+
+// See https://docs.launchdarkly.com/docs/node-sdk-reference#section-users
+declare type LaunchDarklyUser$CustomAttributes = {
+	RequestCountry?: string,
+	RequestRegion?: string,
+	[string]: string | boolean | number | Array<string> | Array<boolean> | Array<number>
+};
+
+declare type LaunchDarklyUser = {|
+	key: string,
+	ip?: string,
+	firstName?: string,
+	lastName?: string,
+	country?: string,
+	email?: string,
+	avatar?: string,
+	name?: string,
+	anonymous?: boolean,
+	custom?: LaunchDarklyUser$CustomAttributes
+|};

--- a/packages/mwp-app-route-plugin/src/index.js
+++ b/packages/mwp-app-route-plugin/src/index.js
@@ -20,14 +20,13 @@ export function register(
 	const ldClient = LaunchDarkly.init(options.ldkey || LAUNCH_DARKLY_SDK_KEY, {
 		offline: process.env.NODE_ENV === 'test',
 	});
-	server.expose('getFlags', memberObj => {
-		const key = (memberObj && memberObj.id) || 0;
-		return ldClient.allFlags({ ...memberObj, key, anonymous: key === 0 }).then(
+	server.expose('getFlags', (user: LaunchDarklyUser) => {
+		return ldClient.allFlags(user).then(
 			flags => flags,
 			err => {
 				server.app.logger.error({
 					err,
-					member: memberObj,
+					launchDarklyUser: user,
 				});
 				return {}; // return empty flags on error
 			}

--- a/packages/mwp-core/src/util/launchDarkly.js
+++ b/packages/mwp-core/src/util/launchDarkly.js
@@ -1,0 +1,76 @@
+// @flow
+
+const HEADER_FASTLY_CLIENT_IP = 'fastly-client-ip';
+const HEADER_FASTLY_X_REGION = 'x-region';
+
+/**
+ * Populates a LaunchDarklyUser object with member and request properties.
+ *
+ * @param member  a member state object
+ * @param request a request object
+ */
+export const getLaunchDarklyUser = (
+	member: Object,
+	request: HapiRequest
+): LaunchDarklyUser => {
+	const { id, name, email, country } = member;
+
+	const ip = getRemoteIp(request);
+	const key = (id && id.toString()) || '0';
+	const anonymous = key === '0';
+	const custom = getCustomAttributes(request);
+
+	const user: LaunchDarklyUser = {
+		key,
+		anonymous,
+		custom,
+	};
+
+	if (ip) {
+		user.ip = ip;
+	}
+	if (name) {
+		user.name = name;
+	}
+	if (email) {
+		user.email = email;
+	}
+	if (country) {
+		user.country = country;
+	}
+
+	return user;
+};
+
+const getRemoteIp = (request: HapiRequest): ?string => {
+	const { headers, info, query } = request;
+	const fromQuery = query && query.__set_geoip && query.__set_geoip.toString();
+	const fromHeaders = headers && headers[HEADER_FASTLY_CLIENT_IP];
+	const fromInfo =
+		info && typeof info.remoteAddress === 'string'
+			? info.remoteAddress
+			: undefined;
+	return fromQuery || fromHeaders || fromInfo;
+};
+
+const getCustomAttributes = (
+	request: HapiRequest
+): LaunchDarklyUser$CustomAttributes => {
+	const { headers } = request;
+
+	const location = (headers && headers[HEADER_FASTLY_X_REGION]) || '';
+	const [country, region] = location
+		.split('/')
+		.map(value => (value ? value.toUpperCase() : value));
+
+	const custom: LaunchDarklyUser$CustomAttributes = {};
+
+	if (country) {
+		custom.RequestCountry = country;
+	}
+	if (region) {
+		custom.RequestRegion = region;
+	}
+
+	return custom;
+};

--- a/packages/mwp-core/src/util/launchDarkly.test.js
+++ b/packages/mwp-core/src/util/launchDarkly.test.js
@@ -1,0 +1,205 @@
+import { getLaunchDarklyUser } from './launchDarkly';
+
+describe('getLaunchDarklyUser', () => {
+	const REQUEST_MOCK = {
+		info: {},
+		headers: {},
+		query: {},
+	};
+
+	it('creates an anonymous user for an empty member object', () => {
+		const user = getLaunchDarklyUser({}, REQUEST_MOCK);
+
+		expect(user).toEqual({
+			key: '0',
+			anonymous: true,
+			custom: {},
+		});
+	});
+
+	it('creates an anonymous user for an anonymous member', () => {
+		const member = {
+			id: 0,
+		};
+
+		const user = getLaunchDarklyUser(member, REQUEST_MOCK);
+
+		expect(user).toEqual({
+			key: '0',
+			anonymous: true,
+			custom: {},
+		});
+	});
+
+	it('populates a user with member details', () => {
+		const member = {
+			id: 12345,
+			name: 'Test User',
+			email: 'test@test.test',
+			country: 'US',
+		};
+
+		const user = getLaunchDarklyUser(member, REQUEST_MOCK);
+
+		expect(user).toEqual({
+			key: '12345',
+			name: 'Test User',
+			email: 'test@test.test',
+			country: 'US',
+			anonymous: false,
+			custom: {},
+		});
+	});
+
+	describe('user IP address', () => {
+		const member = {
+			id: 12345,
+			name: 'Test User',
+			email: 'test@test.test',
+			country: 'US',
+		};
+
+		it('sets a user IP address from a query string parameter', () => {
+			const request = {
+				...REQUEST_MOCK,
+				info: {
+					remoteAddress: '127.0.0.1',
+				},
+				headers: {
+					'fastly-client-ip': '192.168.0.1',
+				},
+				query: {
+					__set_geoip: '89.22.50.79',
+				},
+			};
+
+			const user = getLaunchDarklyUser(member, request);
+
+			expect(user.ip).toEqual('89.22.50.79');
+		});
+
+		it('sets a user IP address from Fastly header', () => {
+			const request = {
+				...REQUEST_MOCK,
+				info: {
+					remoteAddress: '127.0.0.1',
+				},
+				headers: {
+					'fastly-client-ip': '192.168.0.1',
+				},
+				query: {},
+			};
+
+			const user = getLaunchDarklyUser(member, request);
+
+			expect(user.ip).toEqual('192.168.0.1');
+		});
+
+		it('sets a user IP address from a request remote address', () => {
+			const request = {
+				...REQUEST_MOCK,
+				info: {
+					remoteAddress: '127.0.0.1',
+				},
+				headers: {},
+				query: {},
+			};
+
+			const user = getLaunchDarklyUser(member, request);
+
+			expect(user.ip).toEqual('127.0.0.1');
+		});
+
+		it('does not set a user IP address if none of the methods above yielded a result', () => {
+			const request = {
+				...REQUEST_MOCK,
+				info: {},
+				headers: {},
+				query: {},
+			};
+
+			const user = getLaunchDarklyUser(member, request);
+
+			expect(user.ip).toBeUndefined();
+		});
+	});
+
+	describe('custom attributes', () => {
+		const member = {
+			id: 12345,
+			name: 'Test User',
+			email: 'test@test.test',
+			country: 'US',
+		};
+
+		it('sets empty custom attributes if a request has no X-Region header', () => {
+			const request = {
+				...REQUEST_MOCK,
+				headers: {},
+			};
+
+			const user = getLaunchDarklyUser(member, request);
+
+			expect(user.custom).toEqual({});
+		});
+
+		it('sets empty custom attributes if X-Region header has empty country and region', () => {
+			const request = {
+				...REQUEST_MOCK,
+				headers: {
+					'x-region': '/',
+				},
+			};
+
+			const user = getLaunchDarklyUser(member, request);
+
+			expect(user.custom).toEqual({});
+		});
+
+		it('sets only an uppercased country to custom attributes if X-Region header contains a non-empty country and an empty region', () => {
+			const request = {
+				...REQUEST_MOCK,
+				headers: {
+					'x-region': 'ru/',
+				},
+			};
+
+			const user = getLaunchDarklyUser(member, request);
+
+			expect(user.custom).toEqual({
+				RequestCountry: 'RU',
+			});
+		});
+
+		it('sets only an uppercased region to custom attributes if X-Region header contains an empty country and a non-empty region', () => {
+			const request = {
+				...REQUEST_MOCK,
+				headers: {
+					'x-region': '/ny',
+				},
+			};
+
+			const user = getLaunchDarklyUser(member, request);
+
+			expect(user.custom).toEqual({
+				RequestRegion: 'NY',
+			});
+		});
+
+		it('sets both uppercased country and region custom attributes if X-Region header contains non-empty country and region', () => {
+			const request = {
+				...REQUEST_MOCK,
+				headers: {
+					'x-region': 'us/ny',
+				},
+			};
+
+			const user = getLaunchDarklyUser(member, request);
+
+			expect(user.custom).toEqual({
+				RequestCountry: 'US',
+				RequestRegion: 'NY',
+			});
+		});
+	});
+});


### PR DESCRIPTION
*Description*
Tax Collection project is going to be launched initally in just two jurisdictions: Australia and Utah, US. The feature availability is managed by several LaunchDarkly flags which currently have access only to Meetup member information. In order to enable separation by geo location required for beta launch, we need to add a country code and a region code resolved from a client request to a payload sent to LaunchDarkly. 

*What does this PR do?*
1. Introduced Flow type for LaunchDarkly user (request payload) based on the official documentation for Node SDK: https://docs.launchdarkly.com/docs/node-sdk-reference#section-users
2. Updated `mwp-app-router-plugin` to send an instance of LaunchDarklyUser instead of member state object to LaunchDarkly when fetching feature flags for a member.
3. Updated `mwp-core` to create a LaunchDarklyUser from a member state object and a request object.
4. Added unit tests for the mapping method

*How did I test this PR?*
With unit tests and on local pro-web setup. 
In order to test the changes in the components locally, I've put the modified components to `node_modules` of `pro-web` and started the app. I was simulating possible values of `X-Region` request header, normally set by Fastly, with Modify Headers Chrome plugin. By playing with various combinations of `X-Region` header value and a `pro-tax-checkout-form` feature flag configuration I was able to confirm that targeting works as expected.