### PR TITLE
Launch Darkly flag support for conditional CSS

### DIFF
--- a/packages/mwp-core/src/renderers/server-render.jsx
+++ b/packages/mwp-core/src/renderers/server-render.jsx
@@ -338,31 +338,6 @@ const makeRenderer = (
 
 		return routesPromise.then(resolvedRoutes =>
 			initializeStore(resolvedRoutes).then(store => {
-				if ('skeleton' in request.query) {
-					// TODO: what is the skeleton? Do we need to also check the ld flags for css styles here too?
-					// Check launch darkly flags to determine if we should
-					// be rendering the new swarm global styles as well.
-					// The new global styles must be loaded after the old css styles
-					const initialState = store.getState();
-					const ldStyleFlag = initialState.flags['new-swarm-assets'];
-					if (ldStyleFlag) {
-						cssLinks = [...cssLinks, ...newCSSLinks];
-					}
-
-					// render skeleton if requested - the store is ready
-					return {
-						result: getHtml(
-							<Dom
-								basename={basename}
-								head={Helmet.rewind()}
-								initialState={store.getState()}
-								scripts={scripts}
-								cssLinks={cssLinks}
-							/>
-						),
-						statusCode: 200,
-					};
-				}
 				// the initial addFlags call will only be key'd by member ID
 				return addFlags(store, { id: parseMemberCookie(state).id })
 					.then(() => populateStore(store))

--- a/packages/mwp-core/src/renderers/server-render.jsx
+++ b/packages/mwp-core/src/renderers/server-render.jsx
@@ -192,7 +192,7 @@ const makeRenderer$ = (renderConfig: {
 	middleware: Array<Function>,
 	scripts: Array<string>,
 	enableServiceWorker: boolean,
-	cssLinks: ?(Array<string> | Function),
+	cssLinks: ?(Array<string> | (MWPState => Array<string>)),
 }) =>
 	makeRenderer(
 		renderConfig.routes,
@@ -216,7 +216,7 @@ const makeRenderer = (
 	middleware: Array<Function> = [],
 	scripts: Array<string> = [],
 	enableServiceWorker: boolean,
-	cssLinks: ?(Array<string> | Function)
+	cssLinks: ?(Array<string> | (MWPState => Array<string>))
 ) => {
 	// set up a Promise that emits the resolved routes - this single Promise will
 	// be reused for all subsequent requests, so we're not resolving the routes repeatedly


### PR DESCRIPTION
As part of the Swarm updates, `@meetup/swarm-styles` will be publishing a new `globals.css` file that will be imported by `mup-web` and passed to the server render utilities in mwp-core. 

Server Render has access to the launch darkly flag values in initial state and will use that to determine whether or not render the "newCSSStyles".

In the case that the launch darkly flag value is true, we want to render BOTH the old CSS and the new CSS.