### PR TITLE
Wp 1018 standardized_url support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [20.1]
+
+- **New Feature** activity tracking support for `standardized_url` and
+  `standardized_referer` (new fields in Activty v9).
+  - API proxy endpoint (`mwp-api-proxy-plugin`) reads from url-encoded `x-meetup-activity` header
+  - API proxy method (`mwp-api-proxy-plugin`) takes `activityInfo` argument to inject fields into
+    activity records
+  - `mwp-store` browser `fetchQueries` sends `x-meetup-activity` header
+  - `mwp-store` server `fetchQueries` sends passes `activityInfo to 
+  - `mwp-api-store` supplies `activityInfo` argument to `fetchQueries`
+
 ## [20.0]
 
 - **BREAKING CHANGE** - `makeRenderer$` interface into server renderer removed -

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CI_BUILD_NUMBER ?= $(USER)-snapshot
-VERSION ?= 20.0.$(CI_BUILD_NUMBER)
+VERSION ?= 20.1.$(CI_BUILD_NUMBER)
 
 version:
 	@echo $(VERSION)

--- a/flow-typed/platform.js
+++ b/flow-typed/platform.js
@@ -162,3 +162,10 @@ declare type LaunchDarklyUser = {|
 	anonymous?: boolean,
 	custom?: LaunchDarklyUser$CustomAttributes
 |};
+
+declare type ActivityInfo = {
+	viewName?: string,
+	subViewName?: string,
+	standardized_url?: string,
+	standardized_referer?: string,
+};

--- a/packages/mwp-api-proxy-plugin/README.md
+++ b/packages/mwp-api-proxy-plugin/README.md
@@ -4,9 +4,14 @@ The API proxy plugin provides methods for requesting data from the Meetup REST
 API using [Queries](../../../docs/Queries.md). It provides two major features
 to a server.
 
-1. a `request.proxyApi(queries)` method that will generate REST API requests
+1. a `request.proxyApi(queries, activityInfo)` method that will generate REST API requests
 for `queries` that are passed in as an argument
 2. a route for HTTP requests from the application, which default to `/mu_api`.
+
+# `request.proxyApi(queries, activityInfo)`
+
+- *`queries`: `Array<Query>`* - array of query objects to proxy
+- *`activityInfo`: `{ string: string }`* - map of Activity record data to record
 
 ### Debugging API requests/responses
 

--- a/packages/mwp-api-proxy-plugin/src/handler.js
+++ b/packages/mwp-api-proxy-plugin/src/handler.js
@@ -1,3 +1,4 @@
+import querystring from 'querystring';
 import Joi from 'joi';
 import rison from 'rison';
 import { querySchema } from './util/validation';
@@ -29,11 +30,10 @@ export function parseRequestQueries(request) {
  * and serializes the API responses
  */
 export default (request, h) => {
-	const handleResponses = responses =>
-		h.response({ responses }).type('application/json');
-
-	return request.proxyApi(parseRequestQueries(request)).then(
-		handleResponses,
+	const activityHeader = request.headers['x-meetup-activity'];
+	const activityInfo = activityHeader ? querystring.parse(activityHeader) : {};
+	return request.proxyApi(parseRequestQueries(request), activityInfo).then(
+		responses => h.response({ responses }).type('application/json'),
 		err => err // 500 error - will only be thrown on bad implementation
 	);
 };

--- a/packages/mwp-api-proxy-plugin/src/proxy.js
+++ b/packages/mwp-api-proxy-plugin/src/proxy.js
@@ -31,11 +31,9 @@ const apiProxy = (request: HapiRequest) => {
 			// special case handling of tracking call - must supply a response, but
 			// empty object is fine
 
-			const { viewName, subViewName } = query.params;
-			if (viewName) {
+			if (query.params !== undefined) {
+				const { viewName, subViewName } = query.params;
 				activityInfo.viewName = viewName;
-			}
-			if (subViewName) {
 				activityInfo.subViewName = subViewName;
 			}
 

--- a/packages/mwp-api-proxy-plugin/src/util/duotone.js
+++ b/packages/mwp-api-proxy-plugin/src/util/duotone.js
@@ -131,7 +131,10 @@ export const groupDuotoneSetter = duotoneUrls => group => {
 	const photo = group.key_photo || group.group_photo || {};
 	const duotoneKey =
 		group.photo_gradient &&
-		duotoneRef(group.photo_gradient.light_color, group.photo_gradient.dark_color);
+		duotoneRef(
+			group.photo_gradient.light_color,
+			group.photo_gradient.dark_color
+		);
 	const duotoneUrlRoot = duotoneKey && duotoneUrls[duotoneKey];
 	if (duotoneUrlRoot && photo.id) {
 		group.duotoneUrl = {
@@ -166,9 +169,8 @@ export const apiResponseDuotoneSetter = duotoneUrls => {
 				groups.forEach(setGroupDuotone);
 				break;
 			case 'home':
-				(value.most_popular || []).forEach(
-					event => (event.group = setGroupDuotone(event.group || {}))
-				);
+				(value.most_popular || [])
+					.forEach(event => (event.group = setGroupDuotone(event.group || {})));
 				break;
 		}
 		return queryResponse;

--- a/packages/mwp-api-proxy-plugin/src/util/duotone.test.js
+++ b/packages/mwp-api-proxy-plugin/src/util/duotone.test.js
@@ -1,6 +1,10 @@
 import { mockQuery } from 'meetup-web-mocks/lib/app';
 
-import { MOCK_DUOTONE_URLS, MOCK_GROUP, MOCK_MEMBER } from 'meetup-web-mocks/lib/api';
+import {
+	MOCK_DUOTONE_URLS,
+	MOCK_GROUP,
+	MOCK_MEMBER,
+} from 'meetup-web-mocks/lib/api';
 
 import {
 	apiResponseDuotoneSetter,

--- a/packages/mwp-api-state/src/sync/index.js
+++ b/packages/mwp-api-state/src/sync/index.js
@@ -152,7 +152,10 @@ export const getFetchQueriesEpic = (findMatches, fetchQueriesFn) => {
 		// construct the fetch call using match.path
 		const fetchUrl = `${config.apiUrl}${apiPath}`;
 		const fetchQueries = fetchQueriesFn(fetchUrl, (self || {}).value);
+
+		// supply additional request info, e.g. for tracking
 		const requestInfo = { standardized_url: apiPath };
+
 		return fetchQueries(queries, meta, requestInfo)
 			.then(({ successes = [], errors = [] }) => {
 				// meta contains a Promise that must be resolved

--- a/packages/mwp-api-state/src/sync/index.js
+++ b/packages/mwp-api-state/src/sync/index.js
@@ -126,9 +126,10 @@ export const getFetchQueriesEpic = (findMatches, fetchQueriesFn) => {
 	// keep track of location changes - will first be set by SERVER_RENDER
 	let locationIndex = 0;
 	const standardizeUrl = location => {
-		return findMatches(location).matched
-			.pop()
-			.match.path.replace(/[^a-zA-Z0-9/]/gi, '');
+		const matches = findMatches(location);
+		return matches && matches.matched
+			? matches.matched.pop().match.path.replace(/[^a-zA-Z0-9/]/gi, '')
+			: location;
 	};
 
 	// set up a closure that will compare the partially-applied location to the current value

--- a/packages/mwp-api-state/src/sync/index.js
+++ b/packages/mwp-api-state/src/sync/index.js
@@ -148,11 +148,12 @@ export const getFetchQueriesEpic = (findMatches, fetchQueriesFn) => {
 		// first get the current route 'match' data
 		const matched = findMatches(location);
 		// clean up path for use as endpoint URL
-		const apiPath = matched.pop().match.path.replace(/[^a-z0-9/]/gi, '');
+		const apiPath = matched.pop().match.path.replace(/[^a-zA-Z0-9/]/gi, '');
 		// construct the fetch call using match.path
 		const fetchUrl = `${config.apiUrl}${apiPath}`;
 		const fetchQueries = fetchQueriesFn(fetchUrl, (self || {}).value);
-		return fetchQueries(queries, meta)
+		const requestInfo = { standardized_url: apiPath };
+		return fetchQueries(queries, meta, requestInfo)
 			.then(({ successes = [], errors = [] }) => {
 				// meta contains a Promise that must be resolved
 				meta.resolve([...successes, ...errors]);

--- a/packages/mwp-store/src/browser/fetchQueries.js
+++ b/packages/mwp-store/src/browser/fetchQueries.js
@@ -57,7 +57,7 @@ const makeSerializable = queries => {
  *   click tracking data
  * @return {Object} { url, config } arguments for a fetch call
  */
-export const getFetchArgs = (apiUrl, queries, meta) => {
+export const getFetchArgs = (apiUrl, queries, meta, activityInfo) => {
 	const headers = {};
 	const method = ((queries[0].meta || {}).method || 'GET') // fallback to 'get'
 		.toUpperCase(); // must be upper case - requests can fail silently otherwise
@@ -117,13 +117,13 @@ export const getFetchArgs = (apiUrl, queries, meta) => {
 	};
 };
 
-const _fetchQueryResponse = (apiUrl, queries, meta) => {
+const _fetchQueryResponse = ({ apiUrl, queries, meta, activityInfo }) => {
 	if (queries.length === 0) {
 		// no queries => no responses (no need to fetch)
 		return Promise.resolve({ responses: [] });
 	}
 
-	const { url, config } = getFetchArgs(apiUrl, queries, meta);
+	const { url, config } = getFetchArgs(apiUrl, queries, meta, activityInfo);
 	return fetch(url, config)
 		.catch(err => {
 			console.error(err);
@@ -152,7 +152,7 @@ const _fetchQueryResponse = (apiUrl, queries, meta) => {
  *   click tracking data
  * @return {Promise} resolves with a `{queries, responses}` object
  */
-const fetchQueries = (apiUrl, member) => (queries, meta) => {
+const fetchQueries = (apiUrl, member) => (queries, meta, activityInfo) => {
 	if (
 		typeof window === 'undefined' &&
 		typeof test === 'undefined' // not in browser // not in testing env (global set by Jest)
@@ -162,11 +162,12 @@ const fetchQueries = (apiUrl, member) => (queries, meta) => {
 
 	const authedQueries = getAuthedQueryFilter(member);
 	const validQueries = queries.filter(authedQueries);
-	return _fetchQueryResponse(
+	return _fetchQueryResponse({
 		apiUrl,
-		validQueries,
-		meta
-	).then(queryResponse => ({
+		queries: validQueries,
+		meta,
+		activityInfo,
+	}).then(queryResponse => ({
 		...parseQueryResponse(validQueries)(queryResponse),
 	}));
 };

--- a/packages/mwp-store/src/browser/fetchQueries.js
+++ b/packages/mwp-store/src/browser/fetchQueries.js
@@ -46,6 +46,8 @@ const makeSerializable = queries => {
 	return queries;
 };
 
+const getHeaders = () => {};
+
 /**
  * Build the arguments for the `fetch` call to the app server that will
  * contain the batched queries

--- a/packages/mwp-store/src/browser/fetchQueries.js
+++ b/packages/mwp-store/src/browser/fetchQueries.js
@@ -46,8 +46,6 @@ const makeSerializable = queries => {
 	return queries;
 };
 
-const getHeaders = () => {};
-
 /**
  * Build the arguments for the `fetch` call to the app server that will
  * contain the batched queries
@@ -103,6 +101,10 @@ export const getFetchArgs = (apiUrl, queries, meta, activityInfo) => {
 		headers[CSRF_COOKIE_NAME] = JSCookie.get(CSRF_HEADER_COOKIE_NAME);
 	}
 
+	if (activityInfo) {
+		headers['x-meetup-activity'] = new URLSearchParams(activityInfo).toString();
+	}
+
 	const config = {
 		method,
 		headers,
@@ -152,6 +154,8 @@ const _fetchQueryResponse = ({ apiUrl, queries, meta, activityInfo }) => {
  * @param {Array} queries the queries to send - must all use the same `method`
  * @param {Object} meta additional characteristics of the request, e.g.
  *   click tracking data
+ * @param {Object} activityInfo optional map of additional activity record data
+ *   to pass along with fetch request
  * @return {Promise} resolves with a `{queries, responses}` object
  */
 const fetchQueries = (apiUrl, member) => (queries, meta, activityInfo) => {
@@ -169,9 +173,7 @@ const fetchQueries = (apiUrl, member) => (queries, meta, activityInfo) => {
 		queries: validQueries,
 		meta,
 		activityInfo,
-	}).then(queryResponse => ({
-		...parseQueryResponse(validQueries)(queryResponse),
-	}));
+	}).then(parseQueryResponse(validQueries));
 };
 
 export default fetchQueries;

--- a/packages/mwp-store/src/server/fetchQueries.js
+++ b/packages/mwp-store/src/server/fetchQueries.js
@@ -11,12 +11,18 @@ const getCookieMember = memberCookie => {
 // prod API only needs to be set once, but is only accessible from the request object
 let isProdApi;
 
+type ActivityInfo = {
+	standardized_url?: string,
+	standardized_referer?: string,
+};
 /**
  * on the server, we can proxy the API requests directly without making a
  * request to the server's own API proxy endpoint
  */
 export default (request: HapiRequest) => () => (
-	queries: Array<Query>
+	queries: Array<Query>,
+	_: void,
+	activityInfo: ActivityInfo
 ): Promise<ParsedQueryResponses> => {
 	if (isProdApi === undefined) {
 		isProdApi = request.server.settings.app.api.isProd;
@@ -27,7 +33,7 @@ export default (request: HapiRequest) => () => (
 	const authedQueries = getAuthedQueryFilter(member);
 	const validQueries = queries.filter(authedQueries);
 	return request
-		.proxyApi(validQueries)
+		.proxyApi(validQueries, activityInfo)
 		.then(responses => ({ responses })) // package the responses in object like the API proxy endpoint does
 		.then(parseQueryResponse(validQueries));
 };

--- a/packages/mwp-store/src/server/fetchQueries.js
+++ b/packages/mwp-store/src/server/fetchQueries.js
@@ -11,10 +11,6 @@ const getCookieMember = memberCookie => {
 // prod API only needs to be set once, but is only accessible from the request object
 let isProdApi;
 
-type ActivityInfo = {
-	standardized_url?: string,
-	standardized_referer?: string,
-};
 /**
  * on the server, we can proxy the API requests directly without making a
  * request to the server's own API proxy endpoint

--- a/packages/mwp-store/src/server/fetchQueries.js
+++ b/packages/mwp-store/src/server/fetchQueries.js
@@ -21,7 +21,7 @@ type ActivityInfo = {
  */
 export default (request: HapiRequest) => () => (
 	queries: Array<Query>,
-	_: void,
+	meta: { string: string },
 	activityInfo: ActivityInfo
 ): Promise<ParsedQueryResponses> => {
 	if (isProdApi === undefined) {

--- a/packages/mwp-store/src/server/fetchQueries.test.js
+++ b/packages/mwp-store/src/server/fetchQueries.test.js
@@ -20,7 +20,7 @@ describe('serverFetchQueries', () => {
 			expectedParsedResponse
 		);
 		return serverFetchQueries(request)()(queries).then(parsedResponse => {
-			expect(request.proxyApi).toHaveBeenCalledWith(queries);
+			expect(request.proxyApi).toHaveBeenCalledWith(queries, undefined);
 			expect(parsedResponse).toEqual(expectedParsedResponse);
 		});
 	});

--- a/packages/mwp-tracking-plugin/src/util/__snapshots__/avro.test.js.snap
+++ b/packages/mwp-tracking-plugin/src/util/__snapshots__/avro.test.js.snap
@@ -16,6 +16,8 @@ Activity {
   "platformAgent": "WEB",
   "referer": "",
   "requestId": "foo",
+  "standardized_referer": null,
+  "standardized_url": null,
   "subViewName": "foo subview",
   "trackId": "foo",
   "trax": Object {},

--- a/packages/mwp-tracking-plugin/src/util/avro.js
+++ b/packages/mwp-tracking-plugin/src/util/avro.js
@@ -64,19 +64,19 @@ const activity = {
 	namespace: 'com.meetup.base.avro',
 	type: 'record',
 	name: 'Activity',
-	doc: 'v8',
+	doc: 'v9',
 	fields: [
 		{ name: 'requestId', type: 'string' },
 		{ name: 'timestamp', type: 'string' },
 		{ name: 'url', type: 'string' },
-		{ name: 'aggregratedUrl', type: 'string', default: '' }, // it's misspelled in the original spec
+		{ name: 'aggregratedUrl', type: 'string', default: '' },
 		{ name: 'ip', type: 'string', default: '' },
 		{ name: 'agent', type: 'string', default: '' },
 		{ name: 'memberId', type: 'int' },
 		{ name: 'trackId', type: 'string' },
 		{ name: 'mobileWeb', type: 'boolean' },
 		{ name: 'platform', type: 'string' },
-		{ name: 'referer', type: 'string' }, // it's misspelled in the original spec
+		{ name: 'referer', type: 'string' },
 		{ name: 'trax', type: { type: 'map', values: 'string' } },
 		{
 			name: 'platformAgent',
@@ -102,6 +102,8 @@ const activity = {
 		{ name: 'apiVersion', type: ['null', 'string'], default: null },
 		{ name: 'viewName', type: ['null', 'string'], default: null },
 		{ name: 'subViewName', type: ['null', 'string'], default: null },
+		{ name: 'standardized_url', type: ['null', 'string'], default: null },
+		{ name: 'standardized_referer', type: ['null', 'string'], default: null },
 	],
 };
 


### PR DESCRIPTION
https://meetup.atlassian.net/browse/WP-1018

Adding the ability to supply activity tracking fields from mwp-api-state, read them in them in the API proxy plugin (both the proxy route and the server-render proxy), and finally consume them in the activity tracker.