### PR TITLE
Support 'tag' in Click tracking records

### DIFF
--- a/packages/mwp-tracking-plugin/src/util/clickParser.js
+++ b/packages/mwp-tracking-plugin/src/util/clickParser.js
@@ -60,13 +60,8 @@ function _getData(e) {
 		e.type === 'change' && target.tagName.toLowerCase() === 'select';
 	const el = useChildData ? target.children[target.selectedIndex] : target;
 
-	try {
-		const data = (el.dataset || {})[DATA_ATTR] || '{}';
-		return JSON.parse(data);
-	} catch (err) {
-		// data is not JSON-formatted
-		return {};
-	}
+	// pass along _any_ string value in data-clicktrack attribute
+	return (el.dataset || {})[DATA_ATTR] || '';
 }
 
 // recursive function to build an array of 'element shorthand' strings for the
@@ -127,7 +122,7 @@ function getTrackClick() {
 				lineage: clickLineage.join('<'),
 				linkText: linkText,
 				coords: [x, y],
-				data: data,
+				tag: data,
 			};
 		} catch (err) {
 			console.error(err);

--- a/packages/mwp-tracking-plugin/src/util/clickReader.js
+++ b/packages/mwp-tracking-plugin/src/util/clickReader.js
@@ -27,6 +27,7 @@ export const clickToClickRecord = request => click => {
 		linkText: click.linkText || '',
 		coordX: click.coords[0] || 0,
 		coordY: click.coords[1] || 0,
+		tag: click.tag,
 	};
 };
 


### PR DESCRIPTION
The `click.data` property was being ignored when creating Click records.

This update renames `click.data` to `click.tag`, and removes the enforcement of having a JSON-formatted `data-clicktracking` attribute value - any string value in `data-clicktracking` will be used as-is in the `tag` field of the Click record