### PR TITLE
OS-480 Update Toast mwp component to support multiple system message keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [21.0]
+- **BREAKING CHANGE** - `mwp-toaster`: `<ToastContainer>` now takes an object with system messages mappings instead
+ of a message key and an array of messages.
+
 ## [20.1]
 
 - **New Feature** activity tracking support for `standardized_url` and

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CI_BUILD_NUMBER ?= $(USER)-snapshot
-VERSION ?= 20.1.$(CI_BUILD_NUMBER)
+VERSION ?= 21.0.$(CI_BUILD_NUMBER)
 
 version:
 	@echo $(VERSION)

--- a/packages/mwp-toaster/src/ToastContainer.jsx
+++ b/packages/mwp-toaster/src/ToastContainer.jsx
@@ -40,18 +40,18 @@ export class ToastContainer extends React.Component {
 	 * renders linked from chapstick
 	 */
 	componentDidMount() {
-		const {
-			showToasts,
-			location: { search },
-			sysmsgsKey,
-			sysmsgs,
-		} = this.props;
+		const { showToasts, location: { search }, sysmsgs } = this.props;
 		showToasts(); // dispatch action to tell app that toasts are shown
 		if (search) {
 			const searchParams = new URLSearchParams(search);
-			const sysmsgToast = sysmsgs[searchParams.get(sysmsgsKey)];
-			if (sysmsgToast) {
-				this.props.makeToast(sysmsgToast);
+			const sysmsgsKey = Object.keys(sysmsgs).find(sysmsgKey =>
+				searchParams.has(sysmsgKey)
+			);
+			if (sysmsgsKey) {
+				const sysmsgToast = sysmsgs[sysmsgsKey][searchParams.get(sysmsgsKey)];
+				if (sysmsgToast) {
+					this.props.makeToast(sysmsgToast);
+				}
 			}
 		}
 	}
@@ -60,7 +60,6 @@ export class ToastContainer extends React.Component {
 			makeToast, // eslint-disable-line no-unused-vars
 			readyToasts,
 			sysmsgs, // eslint-disable-line no-unused-vars
-			sysmsgsKey, // eslint-disable-line no-unused-vars
 			showToasts, // eslint-disable-line no-unused-vars
 			location, // eslint-disable-line no-unused-vars
 			match, // eslint-disable-line no-unused-vars
@@ -80,8 +79,7 @@ export class ToastContainer extends React.Component {
 ToastContainer.propTyes = {
 	makeToast: PropTypes.func.isRequired, // provided by `mapDispatchToProps`
 	readyToasts: PropTypes.arrayOf(PropTypes.object).isRequired, // array of Toast props from `mapStateToProps`
-	sysmsgs: PropTypes.object.isRequired, // map of sysmsg to <Toast> props
-	sysmsgsKey: PropTypes.string.isRequired, // querystring param key
+	sysmsgs: PropTypes.objectOf(PropTypes.string, PropTypes.object).isRequired, // map of sysmsg keys to <Toast> props for each sysmsg value
 	showToasts: PropTypes.func.isRequired, // provided by `mapDispatchToProps`
 	location: PropTypes.object.isRequired, // provided by `withRouter`
 	history: PropTypes.object.isRequired, // provided by `withRouter`
@@ -90,8 +88,9 @@ ToastContainer.propTyes = {
 };
 ToastContainer.defaultProps = {
 	readyToasts: [],
-	sysmsgsKey: 'sysmsg', // e.g. ?sysmsg=account_suspended
-	sysmsgs: {},
+	sysmsgs: {
+		sysmsg: {}, // e.g. ?sysmsg=account_suspended
+	},
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(

--- a/packages/mwp-toaster/src/toastContainer.test.jsx
+++ b/packages/mwp-toaster/src/toastContainer.test.jsx
@@ -4,25 +4,35 @@ import Toaster from 'meetup-web-components/lib/interactive/Toaster';
 import { ToastContainer } from './ToastContainer';
 
 describe('ToastContainer', () => {
-	const toastProps = {};
+	const toastPropsFoo = { message: 'foo' };
+	const toastPropsBar = { message: 'bar' };
+	const toastPropsBaz = { message: 'baz' };
 	const sysmsgs = {
-		foo: toastProps,
-		bar: toastProps,
+		key1: {
+			foo: toastPropsFoo,
+			bar: toastPropsBar,
+		},
+		key2: {
+			baz: toastPropsBaz,
+		},
 	};
 	const props = {
-		readyToasts: [toastProps],
+		readyToasts: [],
 		sysmsgs,
-		sysmsgsKey: 'key',
 		makeToast: jest.fn(),
 		showToasts: jest.fn(),
 		location: {},
 	};
 	it('renders a Toaster with toast props', () => {
-		const wrapper = shallow(<ToastContainer {...props} />);
+		const readyToastsProps = {
+			...props,
+			readyToasts: [toastPropsFoo],
+		};
+		const wrapper = shallow(<ToastContainer {...readyToastsProps} />);
 		const toasterWrapper = wrapper.find(Toaster);
 		expect(toasterWrapper.exists()).toBe(true);
 		expect(toasterWrapper.prop('toasts')).toHaveLength(
-			props.readyToasts.length
+			readyToastsProps.readyToasts.length
 		);
 	});
 	it('calls makeToast in componentDidMount when querystring param matches a sysmsg', () => {
@@ -31,23 +41,57 @@ describe('ToastContainer', () => {
 			...props,
 			location: {
 				...props.location,
-				search: '?key=foo',
+				search: '?key1=foo',
 			},
 		};
 		const wrapper = shallow(<ToastContainer {...sysmsgProps} />);
 		wrapper.instance().componentDidMount();
-		expect(props.makeToast).toHaveBeenCalled();
+		expect(props.makeToast).toHaveBeenCalledWith(toastPropsFoo);
 	});
-	it('does not call makeToast when querystring param does not match a sysmsg', () => {
+
+	it('calls makeToast in componentDidMount with the querystring param that matches the first sysmsg key', () => {
+		jest.clearAllMocks();
+		const sysmsgProps = {
+			...props,
+			location: {
+				...props.location,
+				search: '?key2=foo&key1=bar',
+			},
+		};
+		const wrapper = shallow(<ToastContainer {...sysmsgProps} />);
+		wrapper.instance().componentDidMount();
+		expect(props.makeToast).toHaveBeenCalledWith(toastPropsBar);
+	});
+
+	it('does not call makeToast when querystring param is empty', () => {
 		jest.clearAllMocks();
 		const wrapper = shallow(<ToastContainer {...props} />);
 		wrapper.instance().componentDidMount();
 		expect(props.makeToast).not.toHaveBeenCalled();
 	});
 
-	it('calls showToasts when component renders (didmount, didupdate)', () => {
+	it('does not call makeToast when querystring param does not match a sysmsg', () => {
 		jest.clearAllMocks();
-		const wrapper = shallow(<ToastContainer {...props} />);
+		const sysmsgProps = {
+			...props,
+			location: {
+				...props.location,
+				search: '?key3=foo&key4=bar&key5=baz',
+			},
+		};
+		const wrapper = shallow(<ToastContainer {...sysmsgProps} />);
+		wrapper.instance().componentDidMount();
+		expect(props.makeToast).not.toHaveBeenCalled();
+	});
+
+	it('calls showToasts when component renders (didmount, didupdate)', () => {
+		const readyToastsProps = {
+			...props,
+			readyToasts: [toastPropsFoo],
+		};
+
+		jest.clearAllMocks();
+		const wrapper = shallow(<ToastContainer {...readyToastsProps} />);
 		wrapper.instance().componentDidMount();
 		expect(props.showToasts).toHaveBeenCalled();
 
@@ -57,12 +101,19 @@ describe('ToastContainer', () => {
 	});
 
 	it('only updates when `readyToasts` contains new toasts (shouldComponentUpdate)', () => {
-		const newReady = { ...props, readyToasts: [...props.readyToasts] };
-		const noReady = { ...props, readyToasts: [] };
-		const wrapper = shallow(<ToastContainer {...props} />);
+		const readyToastsProps = {
+			...props,
+			readyToasts: [toastPropsFoo],
+		};
+		const newReady = {
+			...readyToastsProps,
+			readyToasts: [readyToastsProps.readyToasts],
+		};
+		const noReady = { ...readyToastsProps, readyToasts: [] };
+		const wrapper = shallow(<ToastContainer {...readyToastsProps} />);
 		const instance = wrapper.instance();
 		// test 'no change' props
-		expect(instance.shouldComponentUpdate(props)).toBe(false);
+		expect(instance.shouldComponentUpdate(readyToastsProps)).toBe(false);
 		// test 'new `readyToasts` prop'
 		expect(instance.shouldComponentUpdate(newReady)).toBe(true);
 		// test 'no `readyToasts` prop`


### PR DESCRIPTION
Fixes https://meetup.atlassian.net/browse/OS-480

Updates `<ToastContainer>` to support multiple system message keys (passed via URL query params) by replacing `sysmsgsKey` and `sysmsgs` properties with a single `sysmsgs` object property. The object keys are possible sysmsg keys. Values are mappings of a sysmsg key value to Toast config object. 

Example:
```javascript
const sysmsgs = {
    "success": {
        // ?success=dues_renew
        "dues_renew": {
             message: "Dues renewed!",
             autodismiss: true,
        },
    },
    "error": {
       // ?error=wepay.timeout_paydues
       "wepay.timeout_paydues": {
             message: "#blamewepay",
             autodismiss: true,
             error: true,
       },
    },
}
```

This is a *breaking change*, but the component is used only in mup-web in two places, so it going to be easy to update the clients. There is already a task for that: https://meetup.atlassian.net/browse/OS-449.