### PR TITLE
Allow withIntl-wrapped components to render non-pure

### DIFF
--- a/packages/mwp-i18n/src/withIntl.jsx
+++ b/packages/mwp-i18n/src/withIntl.jsx
@@ -13,6 +13,7 @@ type Props = { requestLanguage: string, __locale?: string, [string]: any };
 const mapStateToProps = (state: MWPState) => ({
 	requestLanguage: state.config.requestLanguage,
 });
+const mapDispatchToProps = () => ({}); // swallow the injected 'dispatch' props
 
 /*
  * A HOC function that applies the necessary context to the component that is
@@ -34,12 +35,7 @@ export default (
 	}
 
 	const WithIntl = (props: Props) => {
-		const {
-			__locale,
-			requestLanguage,
-			dispatch, // eslint-disable-line no-unused-vars
-			...wrappedProps
-		} = props;
+		const { __locale, requestLanguage, ...wrappedProps } = props;
 
 		const providerProps: typeof IntlProvider.propTypes = {
 			defaultLocale: DEFAULT_LOCALE,
@@ -60,7 +56,9 @@ export default (
 	const ConnectedWithIntl =
 		process.env.NODE_ENV === 'test' // avoid Redux context dependency in tests
 			? WithIntl
-			: connect(mapStateToProps)(WithIntl);
+			: connect(mapStateToProps, mapDispatchToProps, null, { pure: false })(
+					WithIntl
+				);
 
 	// modify display name to hide internal 'connect' implementation
 	const wrappedComponentName =


### PR DESCRIPTION
`withIntl` wraps its children with Redux `connect`, which automatically makes the component 'pure', only responding to prop and state changes, not context changes, which can make for unexpected failure to render in context-dependent Formik form fields.

While we don't encourage non-pure children to be wrapped with `withIntl`, there is no need to silently force that rendering behavior, so we pass in `{ pure: false }` as a config option to the `connect` call as recommended by https://github.com/reduxjs/react-redux/blob/master/docs/troubleshooting.md#my-views-arent-updating-when-something-changes-outside-of-redux