### PR TITLE
fix: standardized_url and standardized_referrer not showing in activity logs

### DIFF
--- a/packages/mwp-api-proxy-plugin/src/index.js
+++ b/packages/mwp-api-proxy-plugin/src/index.js
@@ -4,7 +4,6 @@ import getApiProxyRoutes from './routes';
 import proxyApi from './proxy';
 
 import { API_ROUTE_PATH, API_PROXY_PLUGIN_NAME } from './config';
-export { API_ROUTE_PATH } from './config';
 
 export const setPluginState = (
 	request: HapiRequest,

--- a/packages/mwp-api-proxy-plugin/src/index.js
+++ b/packages/mwp-api-proxy-plugin/src/index.js
@@ -5,6 +5,9 @@ import proxyApi from './proxy';
 
 import { API_ROUTE_PATH, API_PROXY_PLUGIN_NAME } from './config';
 
+// immediately export the API_ROUTE_PATH
+export { API_ROUTE_PATH } from './config';
+
 export const setPluginState = (
 	request: HapiRequest,
 	h: HapiResponseToolkit

--- a/packages/mwp-api-proxy-plugin/src/routes.js
+++ b/packages/mwp-api-proxy-plugin/src/routes.js
@@ -53,7 +53,6 @@ const getApiProxyRoutes = path => {
 							};
 						}
 
-						console.log('here', url.path);
 						return {
 							...fields,
 							url: url.path,

--- a/packages/mwp-api-proxy-plugin/src/routes.js
+++ b/packages/mwp-api-proxy-plugin/src/routes.js
@@ -1,7 +1,9 @@
 import Joi from 'joi';
 import rison from 'rison';
 import { CLICK_PLUGIN_NAME } from 'mwp-tracking-plugin/lib/click';
+import { ACTIVITY_PLUGIN_NAME } from 'mwp-tracking-plugin/lib/config';
 
+import { API_ROUTE_PATH } from './config';
 import handler from './handler'; // import allows easier mocking in integration tests
 
 const validApiPayloadSchema = Joi.object({
@@ -30,6 +32,36 @@ const getApiProxyRoutes = path => {
 				},
 				'mwp-language-plugin': {
 					useReferrerUrlLangCode: true,
+				},
+				[ACTIVITY_PLUGIN_NAME]: {
+					getFields: (request, fields) => {
+						const { url, method, payload, query, info: { referrer } } = request;
+						const requestReferrer = referrer || '';
+						const reqData = method === 'post' ? payload : query;
+
+						// the request may specify a referrer that should be used instead of the `request.referrer`
+						// usually set for SPA navigation
+						const referrerOverride =
+							reqData.metadata &&
+							(rison.decode_object(reqData.metadata) || {}).referrer;
+
+						if (referrerOverride) {
+							return {
+								...fields, // pass along existing standardized_url, standardized_referer
+								url: requestReferrer, // navigation requests come from the 'target' url
+								referrer: referrerOverride, // navigation referrer is in override
+							};
+						}
+
+						console.log('here', url.path);
+						return {
+							...fields,
+							url: url.path,
+							referrer: requestReferrer,
+							standardized_url: API_ROUTE_PATH,
+							standardized_referer: fields.standardized_url, // the current location supplied by app
+						};
+					},
 				},
 				[CLICK_PLUGIN_NAME]: {
 					click: request => {

--- a/packages/mwp-api-state/src/sync/index.js
+++ b/packages/mwp-api-state/src/sync/index.js
@@ -127,8 +127,8 @@ export const getFetchQueriesEpic = (findMatches, fetchQueriesFn) => {
 	let locationIndex = 0;
 	const standardizeUrl = location => {
 		const matches = findMatches(location);
-		return matches && matches.matched
-			? matches.matched.pop().match.path.replace(/[^a-zA-Z0-9/]/gi, '')
+		return matches
+			? matches.pop().match.path.replace(/[^a-zA-Z0-9/]/gi, '')
 			: '';
 	};
 

--- a/packages/mwp-tracking-plugin/README.md
+++ b/packages/mwp-tracking-plugin/README.md
@@ -51,6 +51,38 @@ responsibilities:
 1. Manage tracking IDs that are passed into the request through cookies
 2. Log the formatted, encoded tracking ID state of the request to `stdout`
 
+### Route config
+
+If a particular route needs to handle activity tracking parameters in unique ways,
+it can supply a plugin config object containing a `getFields(request, fields)`
+property. This function will be called with the Hapi request object and any
+custom field values passed to `request.trackActivity`. It must return an object
+that, at a minimum, contains the a `url` parameter for the Activity record.
+
+Example that simply returns the `request.url.path` for the `url` param:
+
+```js
+import { ACTIVITY_PLUGIN_NAME } from 'mwp-tracking-plugin/lib/config';
+
+const route = {
+	path: '/foo',
+	handler: () => 'Hello world',
+	options: {
+		plugins: {
+			[ACTIVITY_PLUGIN_NAME]: {
+				getFields: (request, fields) => ({
+					url: request.url.path,
+				})
+			}
+		}
+	}
+}
+```
+
+		}
+
+
+}
 ## Click tracking
 
 Click tracking consists of 4 related modules:

--- a/packages/mwp-tracking-plugin/src/_activityTrackers.js
+++ b/packages/mwp-tracking-plugin/src/_activityTrackers.js
@@ -45,7 +45,7 @@ export const getTrackApiResponses: TrackGetter = trackOpts => request => (
  * 3. lazy-loaded data
  *    - url: proxy endpoint path (request.url.path)
  *    - referrer: current URL (request.referrer)
- * 4. tracking-only request:
+ * 4. tracking-only request
  *    - url: proxy endpoint path (request.url.path)
  *    - referrer: current URL (request.referrer)
  */
@@ -56,7 +56,7 @@ export const getTrackActivity: TrackGetter = () => (request: HapiRequest) => (
 	// proxy endpoint that should be tracked differently
 	const { getFields } =
 		request.route.settings.plugins[ACTIVITY_PLUGIN_NAME] || {};
-	console.log('request.route', request.route, getFields);
+	console.log('request.route', request.route.path, getFields);
 	const trackFields = getFields
 		? getFields(request, fields)
 		: {

--- a/packages/mwp-tracking-plugin/src/_activityTrackers.js
+++ b/packages/mwp-tracking-plugin/src/_activityTrackers.js
@@ -1,6 +1,6 @@
 // @flow
 import { parseIdCookie, updateId } from './util/trackingUtils';
-import { ACTIVITY_PLUGIN_NAME } from '../config';
+import { ACTIVITY_PLUGIN_NAME } from './config';
 
 /*
  * This module exports specific tracking functions that consume the `request`

--- a/packages/mwp-tracking-plugin/src/_activityTrackers.js
+++ b/packages/mwp-tracking-plugin/src/_activityTrackers.js
@@ -56,7 +56,6 @@ export const getTrackActivity: TrackGetter = () => (request: HapiRequest) => (
 	// proxy endpoint that should be tracked differently
 	const { getFields } =
 		request.route.settings.plugins[ACTIVITY_PLUGIN_NAME] || {};
-	console.log('request.route', request.route.path, getFields);
 	const trackFields = getFields
 		? getFields(request, fields)
 		: {
@@ -64,6 +63,5 @@ export const getTrackActivity: TrackGetter = () => (request: HapiRequest) => (
 				url: request.url.path,
 				referrer: request.info.referrer || '',
 			};
-	console.log(trackFields);
 	return request.trackApiResponses(trackFields);
 };

--- a/packages/mwp-tracking-plugin/src/_activityTrackers.js
+++ b/packages/mwp-tracking-plugin/src/_activityTrackers.js
@@ -1,6 +1,6 @@
 // @flow
 import { parseIdCookie, updateId } from './util/trackingUtils';
-import { ACTIVITY_PLUGIN_NAME } from '../lib/config';
+import { ACTIVITY_PLUGIN_NAME } from '../config';
 
 /*
  * This module exports specific tracking functions that consume the `request`

--- a/packages/mwp-tracking-plugin/src/_activityTrackers.js
+++ b/packages/mwp-tracking-plugin/src/_activityTrackers.js
@@ -18,7 +18,7 @@ type ActivityFields = {
 export const getTrackApiResponses: TrackGetter = trackOpts => request => (
 	fields: ActivityFields
 ) => {
-	const { url = '', referrer = '', viewName, subViewName } = fields;
+	const { url = '', referrer = '', ...fieldLiterals } = fields;
 	return trackOpts.log(request, {
 		description: 'nav',
 		memberId: parseIdCookie(request.state[trackOpts.memberCookieName], true), // read memberId
@@ -26,8 +26,7 @@ export const getTrackApiResponses: TrackGetter = trackOpts => request => (
 		trackId: updateId(trackOpts.trackIdCookieName)(request), // read/add trackId
 		referer: referrer,
 		url,
-		viewName,
-		subViewName,
+		...fieldLiterals,
 	});
 };
 

--- a/packages/mwp-tracking-plugin/src/_activityTrackers.test.js
+++ b/packages/mwp-tracking-plugin/src/_activityTrackers.test.js
@@ -1,6 +1,6 @@
 import url from 'url';
 import rison from 'rison';
-import { getTrackActivity } from './_activityTrackers';
+import { getTrackActivity, getTrackApiResponses } from './_activityTrackers';
 
 describe('getTrackActivity', () => {
 	const PROXY_URL = url.parse('http://www.example.com/mu_api');
@@ -80,6 +80,28 @@ Object {
   "foo": "bar",
   "referrer": "http://www.current.com/foo",
   "url": "/mu_api",
+}
+`);
+	});
+});
+
+describe('getTrackApiResponses', () => {
+	test('passes along arbitrary fields', () => {
+		const trackApiResponses = getTrackApiResponses({
+			log: (x, record) => record,
+		})({
+			state: {},
+			plugins: { tracking: {} },
+		});
+		expect(trackApiResponses({ foo: 'bar' })).toMatchInlineSnapshot(`
+Object {
+  "browserId": "91272839-f70e-48fd-909a-0401f85a8cb6",
+  "description": "nav",
+  "foo": "bar",
+  "memberId": 0,
+  "referer": "",
+  "trackId": "91272839-f70e-48fd-909a-0401f85a8cb6",
+  "url": "",
 }
 `);
 	});

--- a/packages/mwp-tracking-plugin/src/_activityTrackers.test.js
+++ b/packages/mwp-tracking-plugin/src/_activityTrackers.test.js
@@ -5,7 +5,10 @@ import { getTrackActivity, getTrackApiResponses } from './_activityTrackers';
 describe('getTrackActivity', () => {
 	const PROXY_URL = url.parse('http://www.example.com/mu_api');
 	const trackApiResponses = jest.fn();
-	const REQUEST_BASE = { trackApiResponses };
+	const REQUEST_BASE = {
+		trackApiResponses,
+		route: { settings: { plugins: {} } },
+	};
 	const trackActivity = getTrackActivity();
 	const fields = { foo: 'bar' }; // arbitrary additional params to merge with url+referrer
 	test('server render record', () => {
@@ -42,8 +45,8 @@ Object {
 		expect(trackApiResponses.mock.calls[0][0]).toMatchInlineSnapshot(`
 Object {
   "foo": "bar",
-  "referrer": "http://www.previous.com/foo",
-  "url": "http://www.current.com/bar",
+  "referrer": "http://www.current.com/bar",
+  "url": "/mu_api",
 }
 `);
 	});

--- a/packages/mwp-tracking-plugin/src/_activityTrackers.test.js
+++ b/packages/mwp-tracking-plugin/src/_activityTrackers.test.js
@@ -93,16 +93,6 @@ describe('getTrackApiResponses', () => {
 			state: {},
 			plugins: { tracking: {} },
 		});
-		expect(trackApiResponses({ foo: 'bar' })).toMatchInlineSnapshot(`
-Object {
-  "browserId": "91272839-f70e-48fd-909a-0401f85a8cb6",
-  "description": "nav",
-  "foo": "bar",
-  "memberId": 0,
-  "referer": "",
-  "trackId": "91272839-f70e-48fd-909a-0401f85a8cb6",
-  "url": "",
-}
-`);
+		expect(trackApiResponses({ foo: 'bar' }).foo).toBe('bar');
 	});
 });


### PR DESCRIPTION
https://meetup.atlassian.net/browse/WP-1096

two issues:

1. the `matches` value is just an array, not an object with a `matched` property
2. the `standardized_url` fields were not being passed to the serializer.

Also discovered that the standardized urls were not being set correct for lazy requests, so I made the 'activity field setter' a config option on the route, which means that the special case handling for the api proxy route can be defined by the route itself - better separation of concerns.