### PR TITLE
[166870354] feat: Support different GTM Environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [22.2]
+
+-   **New feature** The Google Tag Manager util now targets specific GTM Environments
+    based on the running environment (eg: prod, dev). Environments can also be 
+    manually chosen by passing parameters to the GTM util.
+
 ## [22.1]
 
 -   **New feature** `mwp-config` now exports a `paths.localPackages` path pointing

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CI_BUILD_NUMBER ?= $(USER)-snapshot
-VERSION ?= 22.1.$(CI_BUILD_NUMBER)
+VERSION ?= 22.2.$(CI_BUILD_NUMBER)
 
 version:
 	@echo $(VERSION)

--- a/packages/mwp-app-render/src/util/__snapshots__/googleTagManager.test.js.snap
+++ b/packages/mwp-app-render/src/util/__snapshots__/googleTagManager.test.js.snap
@@ -5,11 +5,17 @@ exports[`getDataLayerInitSnippet() should match the snapshot with some \`data\` 
 exports[`getDataLayerInitSnippet() should match the snapshot without \`data\` passed 1`] = `"dataLayer=[]"`;
 
 exports[`getGoogleTagManagerSnippet() matches snap 1`] = `
-"(function(w,d,s,l,i){
-		w[l]=w[l]||[];
-		w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});
-		var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';
-		j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;
-		f.parentNode.insertBefore(j,f);
-	})(window,document,'script','dataLayer','GTM-W9W847');"
+"(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth=OtzciJkDXO73MJ5VH2mTsA&gtm_preview=env-265&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-T2LNGD');"
+`;
+
+exports[`getGoogleTagManagerSnippet() matches snap with parameters passed 1`] = `
+"(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth=qwertyuiopasdfghjklzxcvbnm&gtm_preview=env-42&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-CONTAINER-ID');"
 `;

--- a/packages/mwp-app-render/src/util/googleTagManager.js
+++ b/packages/mwp-app-render/src/util/googleTagManager.js
@@ -1,8 +1,16 @@
 // @flow
 
-// Production and dev keys
-const GTM_KEY =
-	process.env.NODE_ENV === 'production' ? 'GTM-T2LNGD' : 'GTM-W9W847';
+// GTM key for the default GTM container (www.meetup.com)
+const GTM_KEY = 'GTM-T2LNGD';
+
+// public auth key for GTM Environment (production/development)
+const GTM_PUBLIC_AUTH =
+	process.env.NODE_ENV === 'production'
+		? 'KofUFmSzY9oFkO_VAgxnWA'
+		: 'OtzciJkDXO73MJ5VH2mTsA';
+
+// preview ID for the GTM Environment (production/development)
+const GTM_PREVIEW_ID = process.env.NODE_ENV === 'production' ? 'env-1' : 'env-265';
 
 /**
  * @description Gets dataLayer initialization snippet with initial values provided
@@ -26,12 +34,14 @@ export const gtmPush = (data: { [string]: string }) => {
 /**
  * @description Gets google tag manager JS snippet
  * @see {@link https://developers.google.com/tag-manager/quickstart}
-*/
-export const getGoogleTagManagerSnippet = (): string =>
-	`(function(w,d,s,l,i){
-		w[l]=w[l]||[];
-		w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});
-		var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';
-		j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;
-		f.parentNode.insertBefore(j,f);
-	})(window,document,'script','dataLayer','${GTM_KEY}');`;
+ */
+export const getGoogleTagManagerSnippet = (
+	gtmKey: string = GTM_KEY,
+	gtmPublicAuth: string = GTM_PUBLIC_AUTH,
+	gtmPreviewId: string = GTM_PREVIEW_ID
+): string =>
+	`(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth=${gtmPublicAuth}&gtm_preview=${gtmPreviewId}&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','${gtmKey}');`;

--- a/packages/mwp-app-render/src/util/googleTagManager.test.js
+++ b/packages/mwp-app-render/src/util/googleTagManager.test.js
@@ -5,8 +5,21 @@ import {
 } from './googleTagManager';
 
 describe('getGoogleTagManagerSnippet()', () => {
+	const MOCK_GTM_KEY = 'GTM-CONTAINER-ID';
+	const MOCK_GTM_PUBLIC_AUTH = 'qwertyuiopasdfghjklzxcvbnm';
+	const MOCK_GTM_PREVIEW_ID = 'env-42';
+
 	it('matches snap', () => {
 		expect(getGoogleTagManagerSnippet()).toMatchSnapshot();
+	});
+	it('matches snap with parameters passed', () => {
+		expect(
+			getGoogleTagManagerSnippet(
+				MOCK_GTM_KEY,
+				MOCK_GTM_PUBLIC_AUTH,
+				MOCK_GTM_PREVIEW_ID
+			)
+		).toMatchSnapshot();
 	});
 });
 


### PR DESCRIPTION
Enhance the Google Tag Manager snippet that is loaded on every page load, adding the possibility to target specific GTM Environments based on the current environment (`production` / `development`).

In addition to that, it lets also pass parameters to the `getGoogleTagManagerSnippet`, so that other application (future or existent) can use this method to target different GTM Containers or GTM Environments (eg: `now-app`).