### PR TITLE
feat: add mupweb packages path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [22.3]
+
+-   **New feature** `mwp-config` now exports a `packages.mupwebPackages` path Regex pointing
+    to the `/packages/<package-name>/lib` directory in monorepo consumers (e.g. mup-web)
+
 ## [22.2]
 
 -   **New feature** The Google Tag Manager util now targets specific GTM Environments

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CI_BUILD_NUMBER ?= $(USER)-snapshot
-VERSION ?= 22.2.$(CI_BUILD_NUMBER)
+VERSION ?= 22.3.$(CI_BUILD_NUMBER)
 
 version:
 	@echo $(VERSION)

--- a/packages/mwp-config/paths.js
+++ b/packages/mwp-config/paths.js
@@ -30,6 +30,9 @@ const packages = {
 		src: /node_modules\/meetup-web-components\/src/,
 		icons: /node_modules\/meetup-web-components\/icons/,
 	},
+	mupwebPackages: {
+		lib: /packages\/mupweb-.+\/lib/,
+	},
 };
 
 module.exports = {


### PR DESCRIPTION
Add only `lib` folder from each mupweb-package to babel-loader include config instead of whole `/packages/` folder