### PR TITLE
Separate DIY edge from Shared edge request builders

### DIFF
--- a/packages/mwp-api-proxy-plugin/src/util/__snapshots__/send.test.js.snap
+++ b/packages/mwp-api-proxy-plugin/src/util/__snapshots__/send.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`getExternalRequestOpts returns the expected object from a multipart request 1`] = `
+exports[`getRequestOpts returns the expected object from a multipart request 1`] = `
 Object {
   "agentOptions": Object {
     "rejectUnauthorized": false,
@@ -23,7 +23,7 @@ Object {
 }
 `;
 
-exports[`getExternalRequestOpts returns the expected object from a vanilla request 1`] = `
+exports[`getRequestOpts returns the expected object from a vanilla request 1`] = `
 Object {
   "agentOptions": Object {
     "rejectUnauthorized": false,

--- a/packages/mwp-api-proxy-plugin/src/util/receive.test.js
+++ b/packages/mwp-api-proxy-plugin/src/util/receive.test.js
@@ -1,14 +1,10 @@
-import externalRequest from 'request';
-
 import { MOCK_API_PROBLEM } from 'meetup-web-mocks/lib/app';
 import { MOCK_GROUP } from 'meetup-web-mocks/lib/api';
 
 import { getServer, MOCK_LOGGER } from 'mwp-test-utils';
 
-import { API_PROXY_PLUGIN_NAME } from '../config';
 import {
 	makeApiResponseToQueryResponse,
-	makeInjectResponseCookies,
 	makeLogResponse,
 	makeParseApiResponse,
 	parseApiValue,
@@ -20,54 +16,6 @@ jest.mock('mwp-logger-plugin', () => {
 	return {
 		logger: require('mwp-test-utils').MOCK_LOGGER,
 	};
-});
-
-describe('makeInjectResponseCookies', async () => {
-	const server = await getServer();
-	const request = {
-		plugins: {
-			[API_PROXY_PLUGIN_NAME]: {
-				setState() {},
-			},
-		},
-		server,
-	};
-	const responseObj = {
-		request: {
-			uri: {
-				href: 'http://example.com',
-			},
-		},
-	};
-	const response = {
-		toJSON() {
-			return responseObj;
-		},
-	};
-
-	it('does nothing without a cookie jar', () => {
-		spyOn(response, 'toJSON');
-		makeInjectResponseCookies(request)([response, null, null]);
-		expect(response.toJSON).not.toHaveBeenCalled();
-	});
-	it('sets the provided cookies on the response state', () => {
-		const mockJar = externalRequest.jar();
-		spyOn(request.plugins[API_PROXY_PLUGIN_NAME], 'setState');
-
-		// set up mock cookie jar with a dummy cookie for the response.request.uri
-		const key = 'foo';
-		const value = 'bar';
-		mockJar.setCookie(`${key}=${value}`, responseObj.request.uri.href);
-
-		makeInjectResponseCookies(request)([response, null, mockJar]);
-		expect(
-			request.plugins[API_PROXY_PLUGIN_NAME].setState
-		).toHaveBeenCalledWith(
-			key,
-			value,
-			jasmine.any(Object) // don't actually care about the cookie options
-		);
-	});
 });
 
 describe('parseApiValue', () => {

--- a/packages/mwp-api-proxy-plugin/src/util/send.js
+++ b/packages/mwp-api-proxy-plugin/src/util/send.js
@@ -88,13 +88,13 @@ function makeMockResponse(requestOpts, response = MOCK_RESPONSE_OK) {
  * Currently, cookies cannot be set by DIY edge endpoints. (e.g. using the
  * `jar` interface in `request`)
  */
-const buildGenericRequestArgs = requestOpts => {
+export const buildGenericRequestArgs = requestOpts => {
 	// make a copy of the 'global' headers set for all queries.
 	const headers = { ...requestOpts.headers };
 	// all DIY edges support JSON bodies for all methods
 	headers['content-type'] = 'application/json';
 	// strip clicktracking cookie 'click-track'
-	headers.cookie = headers.cookie.replace(/\s+?click-track=[^;]+/, '');
+	headers.cookie = headers.cookie.replace(/\s*click-track=[^;]+/, '');
 
 	return query => {
 		let body;
@@ -146,7 +146,7 @@ const buildGenericRequestArgs = requestOpts => {
  *
  * - 'set cookie' for login requests to /sessions (not used)
  */
-const buildSharedEdgeRequestArgs = requestOpts => query => {
+export const buildSharedEdgeRequestArgs = requestOpts => query => {
 	const { endpoint, params, flags, meta = {} } = query;
 	const dataParams = querystring.stringify(params);
 	const headers = { ...requestOpts.headers };

--- a/packages/mwp-api-proxy-plugin/src/util/send.test.js
+++ b/packages/mwp-api-proxy-plugin/src/util/send.test.js
@@ -7,7 +7,6 @@ import {
 } from 'meetup-web-mocks/lib/app';
 
 import {
-	createCookieJar,
 	makeExternalApiRequest,
 	buildRequestArgs,
 	getAuthHeaders,
@@ -170,6 +169,7 @@ describe('buildRequestArgs', () => {
 		url,
 		headers: {
 			authorization: 'Bearer testtoken',
+			cookie: '',
 		},
 		mode: 'no-cors',
 	};
@@ -301,17 +301,6 @@ describe('getExternalRequestOpts', () => {
 	});
 });
 
-describe('createCookieJar', () => {
-	it('returns a cookie jar for /sessions endpoint', () => {
-		const jar = createCookieJar('/sessions?asdfasd');
-		expect(jar).not.toBeNull();
-	});
-	it('returns null for non-sessions endpoint', () => {
-		const jar = createCookieJar('/not-sessions?asdfasd');
-		expect(jar).toBeNull();
-	});
-});
-
 describe('makeExternalApiRequest', () => {
 	it('calls externalRequest with requestOpts', async () => {
 		const server = await getServer();
@@ -347,23 +336,6 @@ describe('makeExternalApiRequest', () => {
 		})(requestOpts).then(([resp, body]) =>
 			expect(JSON.parse(body).errors[0].code).toBe('ETIMEDOUT')
 		);
-	});
-	it('returns the requestOpts jar at array index 2', async () => {
-		const server = await getServer();
-
-		const mockRequest = {
-			...MOCK_HAPI_REQUEST,
-			server,
-		};
-
-		const requestOpts = {
-			foo: 'bar',
-			url: 'http://example.com',
-			jar: 'fooJar',
-		};
-		return makeExternalApiRequest(mockRequest)(
-			requestOpts
-		).then(([response, body, jar]) => expect(jar).toBe(requestOpts.jar));
 	});
 });
 

--- a/packages/mwp-api-proxy-plugin/src/util/send.test.js
+++ b/packages/mwp-api-proxy-plugin/src/util/send.test.js
@@ -7,15 +7,15 @@ import {
 } from 'meetup-web-mocks/lib/app';
 
 import {
-	makeExternalApiRequest,
+	makeDoApiRequest,
 	buildRequestArgs,
 	getAuthHeaders,
-	getExternalRequestOpts,
 	getLanguageHeader,
 	getClientIpHeader,
 	getTrackingHeaders,
 	parseMultipart,
 	API_META_HEADER,
+	getRequestOpts,
 } from './send';
 
 import { API_PROXY_PLUGIN_NAME } from '../config';
@@ -277,14 +277,14 @@ describe('buildRequestArgs', () => {
 	});
 });
 
-describe('getExternalRequestOpts', () => {
+describe('getRequestOpts', () => {
 	it('returns the expected object from a vanilla request', async () => {
 		const server = await getServer();
 		const mockRequest = {
 			...MOCK_HAPI_REQUEST,
 			server,
 		};
-		expect(getExternalRequestOpts(mockRequest)).toMatchSnapshot();
+		expect(getRequestOpts(mockRequest)).toMatchSnapshot();
 	});
 	it('returns the expected object from a multipart request', async () => {
 		const server = await getServer();
@@ -297,11 +297,11 @@ describe('getExternalRequestOpts', () => {
 			payload: { foo: 'bar' },
 		};
 
-		expect(getExternalRequestOpts(mockRequest)).toMatchSnapshot();
+		expect(getRequestOpts(mockRequest)).toMatchSnapshot();
 	});
 });
 
-describe('makeExternalApiRequest', () => {
+describe('makeDoApiRequest', () => {
 	it('calls externalRequest with requestOpts', async () => {
 		const server = await getServer();
 		const mockRequest = {
@@ -314,7 +314,7 @@ describe('makeExternalApiRequest', () => {
 			url: 'http://example.com',
 		};
 
-		return makeExternalApiRequest(mockRequest)(requestOpts)
+		return makeDoApiRequest(mockRequest)(requestOpts)
 			.then(() => require('request').mock.calls.pop()[0])
 			.then(arg => expect(arg).toBe(requestOpts));
 	});
@@ -327,7 +327,7 @@ describe('makeExternalApiRequest', () => {
 			err,
 		};
 
-		return makeExternalApiRequest({
+		return makeDoApiRequest({
 			server: {
 				app: { logger: { error: () => {} } },
 				settings: { app: { api: { timeout: 100 } } },


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/167407231

This PR separates the 'request arg builder' functions for DIY edge (non-api.meetup.com) and Shared edge (api.meetup.com) requests, since the shared edge needs to support features that are not supported by the shared API/chapstick.

In particular, this separation includes a feature that strips the 'click-track' cookie from the request so that the request payload can be significantly smaller - this will avoid errors in variants service requests.

Also, remove unused `jar` code for allowing API to set cookies on the client - that was originally set up for the `/sessions` endpoint for login, but that feature was never replatformed and we don't need to carry the tech debt.