### PR TITLE
Fix language path redirects

### DIFF
--- a/packages/mwp-app-route-plugin/src/handler.js
+++ b/packages/mwp-app-route-plugin/src/handler.js
@@ -1,5 +1,4 @@
 // @flow
-import url from 'url';
 
 /*
  * This is the Hapi route handler that will be applied to the React application
@@ -21,7 +20,8 @@ export default (languageRenderers: { [string]: LanguageRenderer }): HapiHandler 
 ) => {
 	const pathname = request.getLangPrefixPath();
 	if (pathname !== request.url.pathname) {
-		return h.redirect(url.format({ ...request.url, pathname }));
+		// redirect to a host relative path, keeping query params intact
+		return h.redirect(`${pathname}${request.url.search}`);
 	}
 	const requestLanguage = request.getLanguage();
 	const renderRequest = languageRenderers[requestLanguage];

--- a/packages/mwp-app-route-plugin/src/handler.js
+++ b/packages/mwp-app-route-plugin/src/handler.js
@@ -1,4 +1,5 @@
 // @flow
+import url from 'url';
 
 /*
  * This is the Hapi route handler that will be applied to the React application
@@ -20,7 +21,7 @@ export default (languageRenderers: { [string]: LanguageRenderer }): HapiHandler 
 ) => {
 	const pathname = request.getLangPrefixPath();
 	if (pathname !== request.url.pathname) {
-		return h.redirect({ ...request.url, pathname }.toString());
+		return h.redirect(url.format({ ...request.url, pathname }));
 	}
 	const requestLanguage = request.getLanguage();
 	const renderRequest = languageRenderers[requestLanguage];

--- a/packages/mwp-app-route-plugin/src/handler.test.js
+++ b/packages/mwp-app-route-plugin/src/handler.test.js
@@ -1,0 +1,19 @@
+import handler from './handler';
+
+const MOCK_HAPI_REQUEST = {
+	url: new URL('https://example.com/bar?a=b'),
+	getLangPrefixPath: () => '/foo',
+};
+
+const MOCK_HAPI_TOOLKIT = {
+	redirect: jest.fn(),
+};
+
+describe('Language Prefix Redirect', () => {
+	it('redirects to correct language path with original query string', () => {
+		handler({})(MOCK_HAPI_REQUEST, MOCK_HAPI_TOOLKIT);
+		expect(MOCK_HAPI_TOOLKIT.redirect.mock.calls[0][0]).toMatchInlineSnapshot(
+			`"/foo?a=b"`
+		);
+	});
+});


### PR DESCRIPTION
In the original migration, I wrongly translated this. My expectation was that I was calling `.toString()` on a URL object, but obviously it's not an instance of a URL object so calling .toString() on `Object` returns [object%20Object]