### PR TITLE
❗️MONOREPO CONFIGS ❗️

### DIFF
--- a/packages/mwp-config/index.js
+++ b/packages/mwp-config/index.js
@@ -4,5 +4,6 @@ module.exports = {
 	localesSecondary: require('./localesSecondary'),
 	package: require('./package'),
 	paths: require('./paths'),
+	monorepoPaths: require('./monorepo/paths'),
 	getServer: () => require('./server'), // this is a getter because it validates environment config at runtime
 };

--- a/packages/mwp-config/monorepo/paths.js
+++ b/packages/mwp-config/monorepo/paths.js
@@ -1,0 +1,46 @@
+const path = require('path');
+
+const repoRoot = process.cwd(); // expect CLI to be run from consumer repo root
+const srcPath = path.resolve(repoRoot, 'src');
+const localPackages = path.resolve(repoRoot, 'packages');
+const buildPath = path.resolve(repoRoot, 'build');
+
+const output = {
+	browser: path.resolve(buildPath, 'browser-app'),
+	server: path.resolve(buildPath, 'server-app'),
+	serverMap: path.resolve(buildPath, 'server-app', 'serverAppMap.js'), // map server app builds to a single module
+	vendor: path.resolve(buildPath, 'vendor'),
+};
+
+const src = {
+	asset: path.resolve(srcPath, 'assets'), // pre-made static assets
+	trns: path.resolve(srcPath, 'trns'),
+	browser: {
+		app: srcPath,
+		entry: path.resolve(srcPath, 'browser-app-entry.js'),
+	},
+	server: {
+		app: srcPath,
+		entry: path.resolve(srcPath, 'server-app-entry.js'),
+	},
+};
+
+const packages = {
+	webComponents: {
+		src: /node_modules\/meetup-web-components\/src/,
+		icons: /node_modules\/meetup-web-components\/icons/,
+	},
+	mupwebPackages: {
+		lib: /packages\/mupweb-.+\/lib/,
+	},
+};
+
+module.exports = {
+	repoRoot,
+	srcPath,
+	buildPath,
+	output,
+	src,
+	localPackages,
+	packages,
+};


### PR DESCRIPTION
This is an in-progress PR meant to support the `mupweb-app` package monorepo work in `mup-web`.

The intent of this PR is to introduce NO BREAKING CHANGES so that `pro-web` will continue to work without any required upgrades. If/when `pro-web` is ready to migrate, the branched/duplicate logic in this PR can be cleaned up.

Reference `mwp-cli` branch: https://github.com/meetup/mwp-cli/pull/115 