### PR TITLE
167407231 suppress click header

### DIFF
--- a/packages/mwp-api-proxy-plugin/src/util/send.js
+++ b/packages/mwp-api-proxy-plugin/src/util/send.js
@@ -9,6 +9,7 @@ import config from 'mwp-config';
 
 export const API_META_HEADER = 'X-Meta-Request-Headers';
 const FULL_URL_PATTERN = /^https?:\/\//;
+export const COOKIE_BLACKLIST = ['click-track'];
 
 // create a promisified version of `externalRequest` - can't use `util.promisify`
 // because the callback gets 2 additional arguments, and promisify only supports 1.
@@ -200,6 +201,7 @@ export function getAuthHeaders(request) {
 
 	// rebuild a cookie header string from the parsed `cookies` object
 	const cookie = Object.keys(cookies)
+		.filter(name => !COOKIE_BLACKLIST.includes(name))
 		.map(name => `${name}=${cookies[name]}`)
 		.join('; ');
 

--- a/packages/mwp-api-proxy-plugin/src/util/send.js
+++ b/packages/mwp-api-proxy-plugin/src/util/send.js
@@ -9,7 +9,11 @@ import config from 'mwp-config';
 
 export const API_META_HEADER = 'X-Meta-Request-Headers';
 const FULL_URL_PATTERN = /^https?:\/\//;
-export const COOKIE_BLACKLIST = ['click-track'];
+
+// some cookies are only consumed by the API proxy server and should not be forwarded
+export const COOKIE_BLACKLIST = [
+	'click-track', // click-track is a potentially large cookie that gets consumed by the mwp-tracking-plugin clickReader module
+];
 
 // create a promisified version of `externalRequest` - can't use `util.promisify`
 // because the callback gets 2 additional arguments, and promisify only supports 1.


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/2409221/stories/167407231

requests to the variants service sometimes have extra-large headers that result in a 500 error. This PR eliminates the largest cookie that is currently being forwarded - `click-track` from _all_ proxied API requests, because the click tracking data is consumed by the `mwp-tracking-plugin` and is not needed for any other request handling.

There are two things that we should watch after launching this in mup-web:

1. dramatic reduction in click tracking data appearing in our analytics as the result of no longer sending the click-track cookie to API endpoints. My understanding is that the API endpoints are not doing anything with the click tracking cookie, and so it is safe to remove it, but I will double check with the data team..

2. Sending much less data per request should reduce our 'outgoing data' payload from the API proxy, which could reduce costs and improve response times.