### PR TITLE
169984752: do not set headers for OPTIONS

### DIFF
--- a/packages/mwp-app-server/src/util/index.js
+++ b/packages/mwp-app-server/src/util/index.js
@@ -28,11 +28,9 @@ export function onRequestExtension(request, h) {
 }
 
 export function onPreResponseExtension(request, h) {
+	// happens with OPTIONS request
 	if (typeof request.response.header !== 'function') {
-		request.server.app.logger.error({
-			err: 'onPreResponseExtension: request.response.header is not a function',
-			context: request.response,
-		});
+		return h.continue;
 	}
 
 	// set a response header with the value of the version tag env variable

--- a/packages/mwp-csp-plugin/src/index.js
+++ b/packages/mwp-csp-plugin/src/index.js
@@ -12,11 +12,9 @@ export function register(
 			return h.continue;
 		}
 
+		// happens with OPTIONS request
 		if (typeof request.response.header !== 'function') {
-			server.app.logger.error({
-				err: 'register: request.response.header is not a function',
-				context: request.response,
-			});
+			return h.continue;
 		}
 
 		// Tells browser that it should only be accessed using HTTPS & how long to remember that


### PR DESCRIPTION
For OPTIONS request `request.response.headers` is not a function
https://www.pivotaltracker.com/story/show/169984752