### PR TITLE
fix: 171722586 pass empty config object to UXCapture.create

### DIFF
--- a/packages/mwp-app-render/src/components/uxcapture/UXCaptureCreate.jsx
+++ b/packages/mwp-app-render/src/components/uxcapture/UXCaptureCreate.jsx
@@ -1,13 +1,11 @@
 // @flow
 import React from 'react';
 
-type callbackType = (label: string) => void;
-
 export default () => {
 	const uxCaptureConfigJS = `
 		<script>
 			if(window.UXCapture) {
-				window.UXCapture.create();
+				window.UXCapture.create({});
 			}
 		</script>
 	`;

--- a/packages/mwp-app-render/src/components/uxcapture/__snapshots__/uxCaptureCreate.test.jsx.snap
+++ b/packages/mwp-app-render/src/components/uxcapture/__snapshots__/uxCaptureCreate.test.jsx.snap
@@ -7,7 +7,7 @@ exports[`UXCaptureCreate renders the correct markup when no props are provided 1
       "__html": "
 		<script>
 			if(window.UXCapture) {
-				window.UXCapture.create();
+				window.UXCapture.create({});
 			}
 		</script>
 	",


### PR DESCRIPTION
Fixing: https://www.pivotaltracker.com/story/show/171722586

UXCapture.create waits for config object param