### PR TITLE
logging serialized to standard out in case we fail to write to kinesis

### DIFF
--- a/packages/mwp-tracking-plugin/src/util/avro.js
+++ b/packages/mwp-tracking-plugin/src/util/avro.js
@@ -81,8 +81,12 @@ const getLogAWSKinesis = (): (string => Promise<void>) => {
 		});
 
 		kinesis.putRecord(options, function(err, data) {
-			if (err) console.log(err, err.stack);
-			else console.log(data);
+			if (err) {
+				console.log("Error sending message to Kinesis: "+ serializedRecord);
+				console.log(err, err.stack);
+			} else {
+				console.log("Kinesis recieved message: " + serializedRecord);
+			}
 		});
 	};
 };


### PR DESCRIPTION
In cases when we can't log to kinesis, log message we wanted to send to standard out. This way, if kinesis becomes unavailable we can reprocess any tracking records we couldn't write to kinesis by reading them from cloudwatch logs.