### PR TITLE
Remove Pubsub

### DIFF
--- a/packages/mwp-tracking-plugin/package.json
+++ b/packages/mwp-tracking-plugin/package.json
@@ -27,7 +27,6 @@
     "js-joda-timezone": "^2.0.1"
   },
   "dependencies": {
-    "@google-cloud/pubsub": "0.18.0",
     "avsc": "5.1.1",
     "js-cookie": "2.2.0",
     "mwp-logger-plugin": ">=0.0.1",

--- a/packages/mwp-tracking-plugin/src/activity.js
+++ b/packages/mwp-tracking-plugin/src/activity.js
@@ -47,7 +47,6 @@ export const getLogger: string => (Object, Object) => mixed = (agent: string) =>
 			...trackInfo,
 		};
 
-		avro.loggers.activity(record);
 		avro.loggers.awsactivity(record);
 		return record;
 	};

--- a/packages/mwp-tracking-plugin/src/util/__snapshots__/avro.test.js.snap
+++ b/packages/mwp-tracking-plugin/src/util/__snapshots__/avro.test.js.snap
@@ -25,29 +25,3 @@ Activity {
   "viewName": "foo view",
 }
 `;
-
-exports[`Activity tracking encodes standard output from getLogger 1`] = `
-Activity {
-  "agent": "",
-  "aggregratedUrl": "",
-  "apiVersion": null,
-  "browserId": "",
-  "ip": "",
-  "isUserActivity": true,
-  "memberId": 1234,
-  "mobileWeb": false,
-  "oauthConsumerId": null,
-  "parentRequestId": null,
-  "platform": "WEB",
-  "platformAgent": "WEB",
-  "referer": "",
-  "requestId": "foo",
-  "standardized_referer": null,
-  "standardized_url": null,
-  "subViewName": "foo subview",
-  "trackId": "foo",
-  "trax": Object {},
-  "url": "asdf",
-  "viewName": "foo view",
-}
-`;

--- a/packages/mwp-tracking-plugin/src/util/avro.test.js
+++ b/packages/mwp-tracking-plugin/src/util/avro.test.js
@@ -155,18 +155,3 @@ describe('Click tracking', () => {
 		expect(recordedInfo).toEqual(expectedTrackedInfo);
 	});
 });
-
-describe('getPlatformAnalyticsLog', () => {
-	it('logs to stdout by default', () => {
-		spyOn(process.stdout, 'write').and.callThrough();
-		const analyticsLog = avro.getPlatformAnalyticsLog();
-		analyticsLog('foo');
-		expect(process.stdout.write).toHaveBeenCalled();
-	});
-	it('calls pub/sub topic.publish when isGAE', () => {
-		const isGAE = true;
-		const analyticsLog = avro.getPlatformAnalyticsLog(isGAE);
-		analyticsLog('foo');
-		expect(require('@google-cloud/pubsub').publish).toHaveBeenCalled();
-	});
-});

--- a/packages/mwp-tracking-plugin/src/util/avro.test.js
+++ b/packages/mwp-tracking-plugin/src/util/avro.test.js
@@ -81,19 +81,6 @@ describe('Activity tracking', () => {
 		subViewName: 'foo subview',
 	});
 
-	it('encodes standard output from getLogger', () => {
-		const serialized = avro.serializers.activity(trackInfo);
-
-		// parse stringified object
-		const valObj = JSON.parse(serialized);
-		// create a new buffer from that string
-		const avroBuffer = Buffer.from(valObj.record, 'base64');
-		// get the avro-encoded record
-		const recordedInfo = avsc.parse(avro.schemas.activity).fromBuffer(avroBuffer);
-		delete recordedInfo.timestamp;
-		expect(recordedInfo).toMatchSnapshot();
-	});
-
 	it('encodes chapinEnvelope output from getLogger', () => {
 		const serialized = avro.serializers.awsactivity(trackInfo);
 
@@ -120,23 +107,6 @@ describe('Click tracking', () => {
 		linkText: 'hello world',
 		coords: [23, 45],
 	};
-
-	it('encodes standard output from clickToClickRecord', () => {
-		const trackInfo = clickToClickRecord(request)(click);
-		const serialized = avro.serializers.click(trackInfo);
-
-		// parse stringified object
-		const valObj = JSON.parse(serialized);
-		// create a new buffer from that string
-		const avroBuffer = Buffer.from(valObj.record, 'base64');
-		// get the avro-encoded record
-		const recordedInfo = avsc.parse(avro.schemas.click).fromBuffer(avroBuffer);
-		const expectedTrackedInfo = {
-			...trackInfo,
-			tag: '', // not used in our click data - defaults to empty string
-		};
-		expect(recordedInfo).toEqual(expectedTrackedInfo);
-	});
 
 	it('encodes chapinEnvelope output from clickToClickRecord', () => {
 		const trackInfo = clickToClickRecord(request)(click);

--- a/packages/mwp-tracking-plugin/src/util/clickReader.js
+++ b/packages/mwp-tracking-plugin/src/util/clickReader.js
@@ -43,10 +43,6 @@ export default function processClickTracking(request, h) {
 
 	const cookieJSON = decodeURIComponent(cookieValue);
 	const { history } = JSON.parse(cookieJSON);
-	history
-		.filter(click => click)
-		.map(clickToClickRecord(request))
-		.forEach(avro.loggers.click);
 
 	history
 		.filter(click => click)

--- a/packages/mwp-tracking-plugin/src/util/clickReader.test.js
+++ b/packages/mwp-tracking-plugin/src/util/clickReader.test.js
@@ -21,11 +21,6 @@ describe('processClickTracking', () => {
 	};
 	process.stdout.write = jest.fn(process.stdout.write);
 
-	it('calls process.stdout.write for each click record', () => {
-		process.stdout.write.mockClear();
-		processClickTracking(request, h);
-		expect(process.stdout.write).toHaveBeenCalledTimes(clickData.history.length);
-	});
 	it('calls h.unstate for click-track cookie', () => {
 		h.unstate.mockClear();
 		processClickTracking(request, h);

--- a/tests/integration/server.int.js
+++ b/tests/integration/server.int.js
@@ -113,7 +113,7 @@ describe('Cookie setting', () => {
 		// spyOn(config, 'default').and.returnValue(Promise.resolve({}));
 		return start({}, { routes }, mockConfig).then(server => {
 			const avro = require('mwp-tracking-plugin/lib/util/avro');
-			avro.loggers.click.mockReturnValue('mocked clicktracking log');
+			avro.loggers.awsclick.mockReturnValue('mocked clicktracking log');
 			const request = {
 				method: 'get',
 				url: '/ny-tech',
@@ -124,7 +124,7 @@ describe('Cookie setting', () => {
 				.inject(request)
 				.then(response => {
 					const cookieUnsetString = 'click-track=;';
-					expect(avro.loggers.click).toHaveBeenCalledTimes(
+					expect(avro.loggers.awsclick).toHaveBeenCalledTimes(
 						clickData.history.length
 					);
 					expect(response.headers['set-cookie']).toContainEqual(


### PR DESCRIPTION
Data Platform is now ready to decommission PubSub and the Analytics Persister. 

I cherry-picked [this commit](https://github.com/meetup/meetup-web-platform/commit/f59d74c0a6c9a558aeb6ea2813e4d0fceb4124bf), which deleted all code related to sending analytics tracking to pubsub, which has been deprecated. That commit was [reverted](https://github.com/meetup/meetup-web-platform/pull/667), presumably because our team wasn't ready then.