### PR TITLE
173950031: Restore Node v10.21.0, improve error logging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-    - '10.20'
+    - '10.21'
 cache:
     directories:
         - node_modules

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "A collection of Node web application utilities for the Meetup web platform",
   "engines": {
-    "node": "^10.20.1",
+    "node": "^10.21.0",
     "yarn": "^1.9.4"
   },
   "main": "./lib/index.js",

--- a/packages/mwp-api-proxy-plugin/package.json
+++ b/packages/mwp-api-proxy-plugin/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "Hapi plugin to activate the REST API proxy behavior + route",
   "engines": {
-    "node": "^10.20.1",
+    "node": "^10.21.0",
     "yarn": "^1.9.4"
   },
   "main": "./lib/index.js",

--- a/packages/mwp-api-state/package.json
+++ b/packages/mwp-api-state/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "Redux helpers to manage API data in a MWP app",
   "engines": {
-    "node": "^10.20.1",
+    "node": "^10.21.0",
     "yarn": "^1.9.4"
   },
   "main": "./lib/index.js",

--- a/packages/mwp-app-render/package.json
+++ b/packages/mwp-app-render/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "MWP application rendering tools",
   "engines": {
-    "node": "^10.20.1",
+    "node": "^10.21.0",
     "yarn": "^1.9.4"
   },
   "main": "./lib/index.js",

--- a/packages/mwp-app-route-plugin/package.json
+++ b/packages/mwp-app-route-plugin/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "Hapi plugin to activate the wildcard application route",
   "engines": {
-    "node": "^10.20.1",
+    "node": "^10.21.0",
     "yarn": "^1.9.4"
   },
   "main": "./lib/index.js",

--- a/packages/mwp-app-server/package.json
+++ b/packages/mwp-app-server/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "Hapi server startup module for MWP applications",
   "engines": {
-    "node": "^10.20.1",
+    "node": "^10.21.0",
     "yarn": "^1.9.4"
   },
   "main": "./lib/index.js",

--- a/packages/mwp-auth-plugin/package.json
+++ b/packages/mwp-auth-plugin/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "Hapi plugin providing user authentication for MWP apps",
   "engines": {
-    "node": "^10.20.1",
+    "node": "^10.21.0",
     "yarn": "^1.9.4"
   },
   "main": "./lib/index.js",

--- a/packages/mwp-config/package.json
+++ b/packages/mwp-config/package.json
@@ -3,7 +3,7 @@
     "version": "0.0.1",
     "description": "All the config you might ever need for a MWP app",
     "engines": {
-		"node": "^10.20.1",
+		"node": "^10.21.0",
 		"yarn": "^1.9.4"
 	},
     "config": {},

--- a/packages/mwp-cookie/package.json
+++ b/packages/mwp-cookie/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "Platform cookie-management code",
   "engines": {
-    "node": "^10.20.1",
+    "node": "^10.21.0",
     "yarn": "^1.9.4"
   },
   "main": "./lib/index.js",

--- a/packages/mwp-core/package.json
+++ b/packages/mwp-core/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "Core utilities for MWP apps",
   "engines": {
-    "node": "^10.20.1",
+    "node": "^10.21.0",
     "yarn": "^1.9.4"
   },
   "main": "./lib/index.js",

--- a/packages/mwp-csp-plugin/package.json
+++ b/packages/mwp-csp-plugin/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Sets content security policy headers",
   "engines": {
-    "node": "^10.20.1",
+    "node": "^10.21.0",
     "yarn": "^1.9.4"
   },
   "main": "./lib/index.js",

--- a/packages/mwp-i18n/package.json
+++ b/packages/mwp-i18n/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "Internationalization helpers for MWP apps",
   "engines": {
-    "node": "^10.20.1",
+    "node": "^10.21.0",
     "yarn": "^1.9.4"
   },
   "main": "./lib/index.js",

--- a/packages/mwp-language-plugin/package.json
+++ b/packages/mwp-language-plugin/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "Hapi plugin for determining the requested language for MWP apps",
   "engines": {
-    "node": "^10.20.1",
+    "node": "^10.21.0",
     "yarn": "^1.9.4"
   },
   "main": "./lib/index.js",

--- a/packages/mwp-logger-plugin/package.json
+++ b/packages/mwp-logger-plugin/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "Hapi logging plugin for MWP apps",
   "engines": {
-    "node": "^10.20.1",
+    "node": "^10.21.0",
     "yarn": "^1.9.4"
   },
   "main": "./lib/index.js",

--- a/packages/mwp-logger-plugin/src/index.js
+++ b/packages/mwp-logger-plugin/src/index.js
@@ -53,6 +53,7 @@ const onRequestError = (request, event, tags) => {
 	logger.error({
 		err: `Request ${event.request} failed: ${err}`,
 		context: request,
+		error: event.error,
 	});
 };
 

--- a/packages/mwp-router/package.json
+++ b/packages/mwp-router/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "React routing tools for MWP apps",
   "engines": {
-    "node": "^10.20.1",
+    "node": "^10.21.0",
     "yarn": "^1.9.4"
   },
   "main": "./lib/index.js",

--- a/packages/mwp-store/package.json
+++ b/packages/mwp-store/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "Redux store management for MWP apps",
   "engines": {
-    "node": "^10.20.1",
+    "node": "^10.21.0",
     "yarn": "^1.9.4"
   },
   "main": "./lib/index.js",

--- a/packages/mwp-sw-plugin/package.json
+++ b/packages/mwp-sw-plugin/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "Hapi plugin for serving a service worker script",
   "engines": {
-    "node": "^10.20.1",
+    "node": "^10.21.0",
     "yarn": "^1.9.4"
   },
   "main": "./lib/index.js",

--- a/packages/mwp-test-utils/package.json
+++ b/packages/mwp-test-utils/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "Helpers for running unit tests in MWP apps",
   "engines": {
-    "node": "^10.20.1",
+    "node": "^10.21.0",
     "yarn": "^1.9.4"
   },
   "main": "./lib/index.js",

--- a/packages/mwp-toaster/package.json
+++ b/packages/mwp-toaster/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "Toast UI controller for MWP apps",
   "engines": {
-    "node": "^10.20.1",
+    "node": "^10.21.0",
     "yarn": "^1.9.4"
   },
   "main": "./lib/index.js",

--- a/packages/mwp-tracking-plugin/package.json
+++ b/packages/mwp-tracking-plugin/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "Data collection for MWP apps, including activity and click tracking",
   "engines": {
-    "node": "^10.20.1",
+    "node": "^10.21.0",
     "yarn": "^1.9.4"
   },
   "main": "./lib/index.js",


### PR DESCRIPTION
*Description*
This reverts https://github.com/meetup/meetup-web-platform/pull/690 which was done to test a hypothesis that upgrading Node.js to 10.21 caused mup-web stability issues. Errors didn't go away after the revert, so the hypothesis proved to be wrong. 
In addition this PR adds the full `event.error` object to the log context, in hope to get more information about errors we are seeing