### PR TITLE
174334143: add SameSite policy to click-track cookie.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [25.1]
+
+-   **Improved** add `SameSite` policy to click-track cookie
+
 ## [25.0]
 
 -   **Removed** Retire `mwp-csp-plugin`. All common security headers have been consolidated in Fastly.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CI_BUILD_NUMBER ?= $(USER)-snapshot
-VERSION ?= 25.0.$(CI_BUILD_NUMBER)
+VERSION ?= 25.1.$(CI_BUILD_NUMBER)
 
 version:
 	@echo $(VERSION)

--- a/packages/mwp-tracking-plugin/src/util/clickState.js
+++ b/packages/mwp-tracking-plugin/src/util/clickState.js
@@ -18,7 +18,11 @@ const BrowserCookies = JSCookie.withConverter({
 export const setClickCookie = clickTracking => {
 	const domain = window.location.host.replace(/[^.]+/, '').replace(/:\d+/, ''); // strip leading subdomain, e.g. www or beta2 and trailing port
 	const cookieVal = JSON.stringify(clickTracking);
-	BrowserCookies.set(COOKIE_NAME, cookieVal, { domain });
+	BrowserCookies.set(COOKIE_NAME, cookieVal, {
+		domain,
+		secure: true,
+		sameSite: 'lax',
+	});
 };
 export const getClickCookie = () => BrowserCookies.getJSON(COOKIE_NAME);
 


### PR DESCRIPTION
Pivotal: https://www.pivotaltracker.com/n/projects/2409221/stories/174334143

**Context**
Chrome started enforcing SameSite cookie policy since version 80. Now any cookie that doesn't explicitly specify SameSite attribute is defaulted to SameSite=Lax, which prevents a browser from sending that cookie in cross-domain requests.

Added `SameSite` and `Secure` attributes for `click-track` cookie.

According to [this](https://github.com/js-cookie/js-cookie/issues/276) thread `js-cookie` lib should support custom attributes since version 2.2.0.

