### PR TITLE
175130076 dont use plain text ld key

### DIFF
--- a/packages/mwp-app-route-plugin/README.md
+++ b/packages/mwp-app-route-plugin/README.md
@@ -7,5 +7,4 @@ This plugin is mainly concerned with 2 things.
 #### Note:
 In order to properly access your LaunchDarkly flags the secret must exist within AWS Secrets Manager.
 
-The secret ID should be `LaunchDarkly` It should contain a key `apiAccessToken` 
-with the value being the LaunchDarkly SDK key.
+The Secret Name should be `LaunchDarkly` It should contain a key `apiAccessToken` with the value of the LD api key.

--- a/packages/mwp-app-route-plugin/README.md
+++ b/packages/mwp-app-route-plugin/README.md
@@ -1,0 +1,11 @@
+# mwp-app-route-plugin
+This plugin is mainly concerned with 2 things.
+
+1. Rendering a route with the appropriate language.
+2. Fetching runtime flags from Launch Darkly.
+
+#### Note:
+In order to properly access your LaunchDarkly flags the secret must exist within AWS Secrets Manager.
+
+The secret ID should be `LaunchDarkly` It should contain a key `apiAccessToken` 
+with the value being the LaunchDarkly SDK key.

--- a/packages/mwp-app-route-plugin/src/index.js
+++ b/packages/mwp-app-route-plugin/src/index.js
@@ -19,6 +19,7 @@ export function register(
 
 	return fetchLaunchDarklySdkKey().then(launchDarklySdkKey => {
 		console.log(`Using fetched key ${launchDarklySdkKey.substring(0, 5)}`);
+
 		const ldClient = LaunchDarkly.init(options.ldkey || launchDarklySdkKey, {
 			offline: process.env.NODE_ENV === 'test',
 		});
@@ -42,7 +43,9 @@ export function register(
 		// https://github.com/launchdarkly/node-client/issues/96
 		// use waitForInitialization to catch launch darkly failures
 		return ldClient.waitForInitialization().catch(error => {
+			console.error('The LaunchDarkly key may not have resolved properly.  Double check that it is in the SecretsManager, has a name of LaunchDarkly and a key of "apiAccessToken"');
 			console.error(error);
+			return {}; // return empty flags on connection error
 		});
 	});
 }

--- a/packages/mwp-app-route-plugin/src/index.js
+++ b/packages/mwp-app-route-plugin/src/index.js
@@ -18,7 +18,9 @@ export function register(
 	server.route(getRoute(options.languageRenderers));
 
 	return fetchLaunchDarklySdkKey().then(launchDarklySdkKey => {
-		console.log(`Using fetched key ${launchDarklySdkKey.substring(0, 5)}`);
+		console.log(
+			`Using fetched key ${(launchDarklySdkKey || '').substring(0, 5)}`
+		);
 
 		const ldClient = LaunchDarkly.init(options.ldkey || launchDarklySdkKey, {
 			offline: process.env.NODE_ENV === 'test',
@@ -43,7 +45,9 @@ export function register(
 		// https://github.com/launchdarkly/node-client/issues/96
 		// use waitForInitialization to catch launch darkly failures
 		return ldClient.waitForInitialization().catch(error => {
-			console.error('The LaunchDarkly key may not have resolved properly.  Double check that it is in the SecretsManager, has a name of LaunchDarkly and a key of "apiAccessToken"');
+			console.error(
+				'The LaunchDarkly key may not have resolved properly.  Double check that it is in the SecretsManager, has a name of LaunchDarkly and a key of "apiAccessToken"'
+			);
 			console.error(error);
 			return {}; // return empty flags on connection error
 		});

--- a/packages/mwp-app-route-plugin/src/index.js
+++ b/packages/mwp-app-route-plugin/src/index.js
@@ -45,7 +45,7 @@ export function register(
 			// use waitForInitialization to catch launch darkly failures
 			return ldClient.waitForInitialization().catch(error => {
 				console.error(error);
-				return new Promise(resolve => resolve({})); // return empty flags on error
+				return {}; // return empty flags on error
 			});
 		})
 		.catch(error => {

--- a/packages/mwp-app-route-plugin/src/index.js
+++ b/packages/mwp-app-route-plugin/src/index.js
@@ -31,7 +31,13 @@ export function register(
 				'The LaunchDarkly key may not have resolved properly.  Double check that it is in the SecretsManager, has a name of LaunchDarkly and a key of "apiAccessToken"'
 			);
 
-			return {}
+			server.expose('getFlags', (user: LaunchDarklyUser) => {
+				server.app.logger.error({
+					error,
+					member: user,
+				});
+				return {}; // return empty flags on error
+			});
 		}
 
 		server.expose('getFlags', (user: LaunchDarklyUser) => {

--- a/packages/mwp-app-route-plugin/src/index.js
+++ b/packages/mwp-app-route-plugin/src/index.js
@@ -1,8 +1,23 @@
 // @flow
+import AWS from 'aws-sdk';
 import LaunchDarkly from 'launchdarkly-node-server-sdk';
 import getRoute from './route';
 
-const LAUNCH_DARKLY_SDK_KEY = 'sdk-86b4c7a9-a450-4527-a572-c80a603a200f';
+function fetchLaunchDarklySdkKey() {
+	const secretsManager = new AWS.SecretsManager({ region: 'us-east-1' });
+
+	return secretsManager
+		.getSecretValue({ SecretId: 'LaunchDarkly' })
+		.promise()
+		.then(({ SecretString }) => {
+			return SecretString === undefined
+				? ''
+				: JSON.parse(SecretString).apiAccessToken;
+		});
+}
+
+// Only fetch from the param store once, wait for the promise to resolve in the reigster fn
+const ldSdkKeyPromise = fetchLaunchDarklySdkKey();
 
 /*
  * The server app route plugin - this applies a wildcard catch-all route that
@@ -17,28 +32,31 @@ export function register(
 ): Promise<any> {
 	server.route(getRoute(options.languageRenderers));
 
-	const ldClient = LaunchDarkly.init(options.ldkey || LAUNCH_DARKLY_SDK_KEY, {
-		offline: process.env.NODE_ENV === 'test',
-	});
-	server.expose('getFlags', (user: LaunchDarklyUser) => {
-		return ldClient.allFlagsState(user).then(
-			state => state.allValues(),
-			err => {
-				server.app.logger.error({
-					err,
-					member: user,
-				});
-				return {}; // return empty flags on error
-			}
-		);
-	});
-	// set up launchdarkly instance before continuing
-	server.events.on('stop', ldClient.close);
+	return ldSdkKeyPromise.then(launchDarklySdkKey => {
+		const ldClient = LaunchDarkly.init(options.ldkey || launchDarklySdkKey, {
+			offline: process.env.NODE_ENV === 'test',
+		});
+		server.expose('getFlags', (user: LaunchDarklyUser) => {
+			return ldClient.allFlagsState(user).then(
+				state => state.allValues(),
+				err => {
+					server.app.logger.error({
+						err,
+						member: user,
+					});
+					return {}; // return empty flags on error
+				}
+			);
+		});
 
-	// https://github.com/launchdarkly/node-client/issues/96
-	// use waitForInitialization to catch launch darkly failures
-	return ldClient.waitForInitialization().catch(error => {
-		console.error(error);
+		// set up launchdarkly instance before continuing
+		server.events.on('stop', ldClient.close);
+
+		// https://github.com/launchdarkly/node-client/issues/96
+		// use waitForInitialization to catch launch darkly failures
+		return ldClient.waitForInitialization().catch(error => {
+			console.error(error);
+		});
 	});
 }
 

--- a/packages/mwp-app-route-plugin/src/index.js
+++ b/packages/mwp-app-route-plugin/src/index.js
@@ -3,7 +3,7 @@ import AWS from 'aws-sdk';
 import LaunchDarkly from 'launchdarkly-node-server-sdk';
 import getRoute from './route';
 
-function fetchLaunchDarklySdkKey() {
+function fetchLaunchDarklySdkKey(): Promise<string> {
 	const secretsManager = new AWS.SecretsManager({ region: 'us-east-1' });
 
 	return secretsManager
@@ -19,6 +19,8 @@ function fetchLaunchDarklySdkKey() {
 // Only fetch from the param store once, wait for the promise to resolve in the reigster fn
 const ldSdkKeyPromise = fetchLaunchDarklySdkKey();
 
+console.log('Fetching SDK key from AWS')
+
 /*
  * The server app route plugin - this applies a wildcard catch-all route that
  * will call the server app rendering function for the correct request language.
@@ -33,6 +35,7 @@ export function register(
 	server.route(getRoute(options.languageRenderers));
 
 	return ldSdkKeyPromise.then(launchDarklySdkKey => {
+		console.log(`Using fetched key ${launchDarklySdkKey.substring(0,5)}`)
 		const ldClient = LaunchDarkly.init(options.ldkey || launchDarklySdkKey, {
 			offline: process.env.NODE_ENV === 'test',
 		});

--- a/packages/mwp-app-route-plugin/src/index.js
+++ b/packages/mwp-app-route-plugin/src/index.js
@@ -48,7 +48,7 @@ export function register(
 			// use waitForInitialization to catch launch darkly failures
 			return ldClient.waitForInitialization().catch(error => {
 				console.error(error);
-				return {}; // return empty flags on connection error
+				return new Promise((resolve) => resolve({})); // return empty flags on error
 			});
 		} catch (error) {
 			console.error(
@@ -60,7 +60,7 @@ export function register(
 					error,
 					member: user,
 				});
-				return {}; // return empty flags on error
+				return new Promise((resolve) => resolve({})); // return empty flags on error
 			});
 		}
 	});

--- a/packages/mwp-app-route-plugin/src/util/secretsHelper.js
+++ b/packages/mwp-app-route-plugin/src/util/secretsHelper.js
@@ -4,6 +4,7 @@ import AWS from 'aws-sdk';
 const secretsManager = new AWS.SecretsManager({ region: 'us-east-1' });
 
 export function fetchLaunchDarklySdkKey(): Promise<string> {
+	console.warn('Calling fetchLaunchDarklySdkKey');
 	return secretsManager
 		.getSecretValue({ SecretId: 'LaunchDarkly-error' })
 		.promise()

--- a/packages/mwp-app-route-plugin/src/util/secretsHelper.js
+++ b/packages/mwp-app-route-plugin/src/util/secretsHelper.js
@@ -8,14 +8,11 @@ export function fetchLaunchDarklySdkKey(): Promise<string> {
 	return secretsManager
 		.getSecretValue({ SecretId: 'LaunchDarkly-error' })
 		.promise()
-		.then(({ SecretString }) => {
-			return SecretString === undefined
-				? ''
-				: JSON.parse(SecretString).apiAccessToken;
-		}).catch(error => {
+		.then(({ SecretString }) => JSON.parse(SecretString).apiAccessToken)
+		.catch(error => {
 			console.error(
 				'The LaunchDarkly key may not have resolved properly.  Double check that it is in the SecretsManager, has a name of LaunchDarkly and a key of "apiAccessToken"'
 			);
-            throw error;
-        });
+			throw error;
+		});
 }

--- a/packages/mwp-app-route-plugin/src/util/secretsHelper.js
+++ b/packages/mwp-app-route-plugin/src/util/secretsHelper.js
@@ -5,7 +5,7 @@ const secretsManager = new AWS.SecretsManager({ region: 'us-east-1' });
 
 export function fetchLaunchDarklySdkKey(): Promise<string> {
 	return secretsManager
-		.getSecretValue({ SecretId: 'LaunchDarkly' })
+		.getSecretValue({ SecretId: 'LaunchDarkly-fail' })
 		.promise()
 		.then(({ SecretString }) => {
 			return SecretString === undefined

--- a/packages/mwp-app-route-plugin/src/util/secretsHelper.js
+++ b/packages/mwp-app-route-plugin/src/util/secretsHelper.js
@@ -11,5 +11,7 @@ export function fetchLaunchDarklySdkKey(): Promise<string> {
 			return SecretString === undefined
 				? ''
 				: JSON.parse(SecretString).apiAccessToken;
-		});
+		}).catch(error => {
+            return '';
+        });
 }

--- a/packages/mwp-app-route-plugin/src/util/secretsHelper.js
+++ b/packages/mwp-app-route-plugin/src/util/secretsHelper.js
@@ -6,7 +6,7 @@ const secretsManager = new AWS.SecretsManager({ region: 'us-east-1' });
 export function fetchLaunchDarklySdkKey(): Promise<string> {
 	console.warn('Calling fetchLaunchDarklySdkKey');
 	return secretsManager
-		.getSecretValue({ SecretId: 'LaunchDarkly-error' })
+		.getSecretValue({ SecretId: 'LaunchDarkly' })
 		.promise()
 		.then(({ SecretString }) => JSON.parse(SecretString).apiAccessToken)
 		.catch(error => {

--- a/packages/mwp-app-route-plugin/src/util/secretsHelper.js
+++ b/packages/mwp-app-route-plugin/src/util/secretsHelper.js
@@ -5,14 +5,16 @@ const secretsManager = new AWS.SecretsManager({ region: 'us-east-1' });
 
 export function fetchLaunchDarklySdkKey(): Promise<string> {
 	return secretsManager
-		.getSecretValue({ SecretId: 'LaunchDarkly-fail' })
+		.getSecretValue({ SecretId: 'LaunchDarkly-error' })
 		.promise()
 		.then(({ SecretString }) => {
 			return SecretString === undefined
 				? ''
 				: JSON.parse(SecretString).apiAccessToken;
 		}).catch(error => {
-
-            return undefined;
+			console.error(
+				'The LaunchDarkly key may not have resolved properly.  Double check that it is in the SecretsManager, has a name of LaunchDarkly and a key of "apiAccessToken"'
+			);
+            throw error;
         });
 }

--- a/packages/mwp-app-route-plugin/src/util/secretsHelper.js
+++ b/packages/mwp-app-route-plugin/src/util/secretsHelper.js
@@ -4,14 +4,13 @@ import AWS from 'aws-sdk';
 const secretsManager = new AWS.SecretsManager({ region: 'us-east-1' });
 
 export function fetchLaunchDarklySdkKey(): Promise<string> {
-	console.warn('Calling fetchLaunchDarklySdkKey');
 	return secretsManager
 		.getSecretValue({ SecretId: 'LaunchDarkly' })
 		.promise()
 		.then(({ SecretString }) => JSON.parse(SecretString).apiAccessToken)
 		.catch(error => {
 			console.error(
-				'The LaunchDarkly key may not have resolved properly.  Double check that it is in the SecretsManager, has a name of LaunchDarkly and a key of "apiAccessToken"'
+				'The LaunchDarkly key may not have resolved properly.  Double check that it is in the SecretsManager, has a name of "LaunchDarkly" and a key of "apiAccessToken"'
 			);
 			throw error;
 		});

--- a/packages/mwp-app-route-plugin/src/util/secretsHelper.js
+++ b/packages/mwp-app-route-plugin/src/util/secretsHelper.js
@@ -12,6 +12,7 @@ export function fetchLaunchDarklySdkKey(): Promise<string> {
 				? ''
 				: JSON.parse(SecretString).apiAccessToken;
 		}).catch(error => {
-            return '';
+
+            return undefined;
         });
 }

--- a/packages/mwp-app-route-plugin/src/util/secretsHelper.js
+++ b/packages/mwp-app-route-plugin/src/util/secretsHelper.js
@@ -1,0 +1,15 @@
+// @flow
+import AWS from 'aws-sdk';
+
+const secretsManager = new AWS.SecretsManager({ region: 'us-east-1' });
+
+export function fetchLaunchDarklySdkKey(): Promise<string> {
+	return secretsManager
+		.getSecretValue({ SecretId: 'LaunchDarkly' })
+		.promise()
+		.then(({ SecretString }) => {
+			return SecretString === undefined
+				? ''
+				: JSON.parse(SecretString).apiAccessToken;
+		});
+}


### PR DESCRIPTION
Fixes: https://www.pivotaltracker.com/story/show/175130076

### Context:
The LD private SDK key exists in plain text.  We need to remove this AND rotate the key.

### Solution
By fetching the LD key from AWS, we can then rotate the key with ease.

An issue that has to be double checked - this key MUST exist in the secrets manager of the sub account.  We may run into issues here for anything that is not deployed to meetupprod.

I will ensure that the key exists in the deployed environments before merging this.