### PR TITLE
5258 change meetup http links to https (linkify.js)

### DIFF
--- a/packages/mwp-core/src/util/linkify.js
+++ b/packages/mwp-core/src/util/linkify.js
@@ -37,10 +37,16 @@ const createLink = (options: Object, followedExternalDomains?: Array<string>) =>
 	const target = options.target || '';
 	const targetAttr = `target="${target}"`;
 	const hasProtocolRE = /^(?:https?:|ws:|ftp:)?\/\//;
+	const hasMeetupHttpLinkRE = /http:\/\/www.meetup/g;
+	const meetupHttps = 'https://www.meetup';
 	const link = hasProtocolRE.test(href) ? href : `http://${href}`;
+	const meetupLink = link.replace(hasMeetupHttpLinkRE, meetupHttps);
+	const isMeetupLinkUpdated = meetupLink !== link;
 	const relAttr = getRelAttr(followedExternalDomains, link, target);
 
-	return `<a class="link" href="${link}" title="${href}" ${targetAttr} ${relAttr}>${href}</a>`;
+	return isMeetupLinkUpdated
+		? `<a class="link" href="${meetupLink}" title="${meetupLink}" ${targetAttr} ${relAttr}>${meetupLink}</a>`
+		: `<a class="link" href="${link}" title="${href}" ${targetAttr} ${relAttr}>${href}</a>`;
 };
 
 /**

--- a/packages/mwp-core/src/util/linkify.test.js
+++ b/packages/mwp-core/src/util/linkify.test.js
@@ -3,9 +3,9 @@ import linkify from './linkify';
 describe('linkify', () => {
 	const httpBase = 'http://www.meetup.com',
 		expectedLink =
-			'<a class="link" href="http://www.meetup.com" title="http://www.meetup.com" target="" >http://www.meetup.com</a>';
+			'<a class="link" href="https://www.meetup.com" title="https://www.meetup.com" target="" >https://www.meetup.com</a>';
 
-	it('should turn a link text with http into a HTML anchor with http', () => {
+	it('should turn a meetup link text with http into a HTML anchor with https', () => {
 		expect(linkify(httpBase)).toBe(expectedLink);
 	});
 	it('should turn a link text with https into a HTML anchor with https', () => {
@@ -16,7 +16,7 @@ describe('linkify', () => {
 	});
 	it('should turn a link text with a target into an HTML anchor with a target', () => {
 		const targetLink =
-			'<a class="link" href="http://www.meetup.com" title="http://www.meetup.com" target="foo" >http://www.meetup.com</a>';
+			'<a class="link" href="https://www.meetup.com" title="https://www.meetup.com" target="foo" >https://www.meetup.com</a>';
 		expect(linkify(httpBase, { target: 'foo' })).toBe(targetLink);
 	});
 	it('should turn a link text with a `_blank` target into an HTML anchor with `rel="nofollow noopener noreferrer"`', () => {
@@ -40,7 +40,7 @@ describe('linkify', () => {
 	it('should prefix a plain link with a protocol', () => {
 		const plainBase = 'www.meetup.com';
 		const expectedLink =
-			'<a class="link" href="http://www.meetup.com" title="www.meetup.com" target="" >www.meetup.com</a>';
+			'<a class="link" href="https://www.meetup.com" title="https://www.meetup.com" target="" >https://www.meetup.com</a>';
 		expect(linkify(plainBase)).toBe(expectedLink);
 	});
 });


### PR DESCRIPTION
Fixes https://app.clubhouse.io/meetup/story/5258/change-meetup-links-from-http-to-https

tested locally with mup-web using the beta build generated by this PR 
yarn add -W \
    mwp-api-state@25.2.3278-beta \
    mwp-app-render@25.2.3278-beta \
    mwp-app-server@25.2.3278-beta \
    mwp-config@25.2.3278-beta \
    mwp-core@25.2.3278-beta \
    mwp-i18n@25.2.3278-beta \
    mwp-router@25.2.3278-beta \
    mwp-store@25.2.3278-beta \
    mwp-toaster@25.2.3278-beta