### PR TITLE
update apollo graphql edge endpoint to use www. domain by default

### DIFF
--- a/packages/mwp-app-render/src/util/getClient.js
+++ b/packages/mwp-app-render/src/util/getClient.js
@@ -1,7 +1,7 @@
 import ApolloClient, { InMemoryCache } from 'apollo-boost';
 import fetch from 'isomorphic-fetch';
 
-const GRAPHQL_ENDPOINT = process.env.GRAPHQL_ENDPOINT || 'https://api.meetup.com/gql';
+const GRAPHQL_ENDPOINT = process.env.GRAPHQL_ENDPOINT || 'https://www.meetup.com/gql';
 
 let cachedClient;
 


### PR DESCRIPTION
we've already adopted this approach in build-meetup with great success. 

this change improves page performance but reducing network requests, increases response time as we don't have to wait before we can start executing the intended requests and reduces invocation load on graphql-edge-api