### PR TITLE
[ch15602] Remove hreflang for US-based groups

### DIFF
--- a/packages/mwp-app-render/src/components/SEOHead.jsx
+++ b/packages/mwp-app-render/src/components/SEOHead.jsx
@@ -67,8 +67,8 @@ export const SEOHeadComponent = ({
 		baseUrl,
 		localeCode,
 		route,
-		forcedLocaleCode,
-		isGenerateAlternateLinks
+		isGenerateAlternateLinks,
+		forcedLocaleCode
 	);
 
 	const ldJsonTags = ldJson.map((jsonObj, index) => (

--- a/packages/mwp-app-render/src/components/SEOHead.jsx
+++ b/packages/mwp-app-render/src/components/SEOHead.jsx
@@ -28,6 +28,7 @@ import {
  * @param {Boolean} robots Instructs search engines whether or not we'd like them to crawl the pages and its links
  * @param {String} forcedRobotsContent overrides robots content when is not empty
  * @param {String} route The current route
+ * @param {String} groupCountry The group's country
  * @module SEOHead
  */
 export const SEOHeadComponent = ({

--- a/packages/mwp-app-render/src/components/SEOHead.jsx
+++ b/packages/mwp-app-render/src/components/SEOHead.jsx
@@ -113,6 +113,7 @@ SEOHeadComponent.propTypes = {
 	pageTitle: PropTypes.string,
 	robots: PropTypes.bool,
 	route: PropTypes.string.isRequired,
+	isGenerateAlternateLinks: PropTypes.bool,
 };
 
 SEOHeadComponent.defaultProps = {
@@ -122,6 +123,7 @@ SEOHeadComponent.defaultProps = {
 	ldJson: [],
 	localeCode: 'en-US',
 	robots: true,
+	isGenerateAlternateLinks: true,
 };
 
 export default SEOHeadComponent;

--- a/packages/mwp-app-render/src/components/SEOHead.jsx
+++ b/packages/mwp-app-render/src/components/SEOHead.jsx
@@ -28,7 +28,7 @@ import {
  * @param {Boolean} robots Instructs search engines whether or not we'd like them to crawl the pages and its links
  * @param {String} forcedRobotsContent overrides robots content when is not empty
  * @param {String} route The current route
- * @param {String} groupCountry The group's country
+ * @param {Boolean} isGenerateAlternateLinks Defines if we need to generate alternate link tags for the page
  * @module SEOHead
  */
 export const SEOHeadComponent = ({
@@ -46,7 +46,7 @@ export const SEOHeadComponent = ({
 	robots,
 	forcedRobotsContent,
 	route,
-	groupCountry,
+	isGenerateAlternateLinks,
 }) => {
 	const metaData = generateMetaData({
 		appPath: `meetup:/${route}`,
@@ -68,7 +68,7 @@ export const SEOHeadComponent = ({
 		localeCode,
 		route,
 		forcedLocaleCode,
-		groupCountry
+		isGenerateAlternateLinks
 	);
 
 	const ldJsonTags = ldJson.map((jsonObj, index) => (

--- a/packages/mwp-app-render/src/components/SEOHead.jsx
+++ b/packages/mwp-app-render/src/components/SEOHead.jsx
@@ -46,6 +46,7 @@ export const SEOHeadComponent = ({
 	robots,
 	forcedRobotsContent,
 	route,
+	groupCountry,
 }) => {
 	const metaData = generateMetaData({
 		appPath: `meetup:/${route}`,
@@ -66,7 +67,8 @@ export const SEOHeadComponent = ({
 		baseUrl,
 		localeCode,
 		route,
-		forcedLocaleCode
+		forcedLocaleCode,
+		groupCountry
 	);
 
 	const ldJsonTags = ldJson.map((jsonObj, index) => (

--- a/packages/mwp-app-render/src/util/seo/__snapshots__/links.test.js.snap
+++ b/packages/mwp-app-render/src/util/seo/__snapshots__/links.test.js.snap
@@ -171,3 +171,12 @@ Array [
   />,
 ]
 `;
+
+exports[`generateCanonicalUrlLinkTags should not generate locale <link />s when isGenerateAlternateLinks = false 1`] = `
+Array [
+  <link
+    href="http://www.mock-base-url.com/mockroute"
+    rel="canonical"
+  />,
+]
+`;

--- a/packages/mwp-app-render/src/util/seo/links.js
+++ b/packages/mwp-app-render/src/util/seo/links.js
@@ -28,7 +28,7 @@ export const generateCanonicalUrl = (
  * @param  {String} baseUrl base url of the page (protocol + hostname)
  * @param  {String} localeCode   locale of user
  * @param  {String} forcedLocaleCode  locale of group
- * @param {String} groupCountry The group's country
+ * @param {Boolean} isGenerateAlternateLinks Defines if we need to generate alternate link tags for the page
  * @param  {String} route   redux'd route to the current page
  * @return {Array}  array of React.element's
  */
@@ -37,7 +37,7 @@ export const generateCanonicalUrlLinkTags = (
 	localeCode,
 	route,
 	forcedLocaleCode = '',
-	groupCountry
+	isGenerateAlternateLinks
 ) => {
 	let result = [
 		<link
@@ -87,18 +87,17 @@ export const generateCanonicalUrlLinkTags = (
 		return [...acc, locationDependentTag];
 	}, []);
 
-	const alternateLinks =
-		groupCountry === 'US' // if group is from US don't add alternate link tags
-			? ''
-			: [
-					...localeLinks,
-					<link
-						rel="alternate"
-						hrefLang="x-default"
-						href={`${baseUrl}${route}`}
-						key="default"
-					/>,
-			  ];
+	const alternateLinks = isGenerateAlternateLinks
+		? ''
+		: [
+				...localeLinks,
+				<link
+					rel="alternate"
+					hrefLang="x-default"
+					href={`${baseUrl}${route}`}
+					key="default"
+				/>,
+		  ];
 
 	result = [...result, ...alternateLinks];
 

--- a/packages/mwp-app-render/src/util/seo/links.js
+++ b/packages/mwp-app-render/src/util/seo/links.js
@@ -28,6 +28,7 @@ export const generateCanonicalUrl = (
  * @param  {String} baseUrl base url of the page (protocol + hostname)
  * @param  {String} localeCode   locale of user
  * @param  {String} forcedLocaleCode  locale of group
+ * @param {String} groupCountry The group's country
  * @param  {String} route   redux'd route to the current page
  * @return {Array}  array of React.element's
  */
@@ -35,7 +36,8 @@ export const generateCanonicalUrlLinkTags = (
 	baseUrl,
 	localeCode,
 	route,
-	forcedLocaleCode = ''
+	forcedLocaleCode = '',
+	groupCountry
 ) => {
 	let result = [
 		<link
@@ -85,16 +87,20 @@ export const generateCanonicalUrlLinkTags = (
 		return [...acc, locationDependentTag];
 	}, []);
 
-	result = [
-		...result,
-		...localeLinks,
-		<link
-			rel="alternate"
-			hrefLang="x-default"
-			href={`${baseUrl}${route}`}
-			key="default"
-		/>,
-	];
+	const alternateLinks =
+		groupCountry === 'US' // if group is from US don't add alternate link tags
+			? ''
+			: [
+					...localeLinks,
+					<link
+						rel="alternate"
+						hrefLang="x-default"
+						href={`${baseUrl}${route}`}
+						key="default"
+					/>,
+			  ];
+
+	result = [...result, ...alternateLinks];
 
 	return result;
 };

--- a/packages/mwp-app-render/src/util/seo/links.js
+++ b/packages/mwp-app-render/src/util/seo/links.js
@@ -88,8 +88,7 @@ export const generateCanonicalUrlLinkTags = (
 	}, []);
 
 	const alternateLinks = isGenerateAlternateLinks
-		? ''
-		: [
+		? [
 				...localeLinks,
 				<link
 					rel="alternate"
@@ -97,7 +96,8 @@ export const generateCanonicalUrlLinkTags = (
 					href={`${baseUrl}${route}`}
 					key="default"
 				/>,
-		  ];
+		  ]
+		: '';
 
 	result = [...result, ...alternateLinks];
 

--- a/packages/mwp-app-render/src/util/seo/links.js
+++ b/packages/mwp-app-render/src/util/seo/links.js
@@ -36,8 +36,8 @@ export const generateCanonicalUrlLinkTags = (
 	baseUrl,
 	localeCode,
 	route,
-	forcedLocaleCode = '',
-	isGenerateAlternateLinks
+	isGenerateAlternateLinks,
+	forcedLocaleCode = ''
 ) => {
 	let result = [
 		<link

--- a/packages/mwp-app-render/src/util/seo/links.test.js
+++ b/packages/mwp-app-render/src/util/seo/links.test.js
@@ -4,12 +4,14 @@ describe('generateCanonicalUrlLinkTags', () => {
 	const MOCK_BASE_URL = 'http://www.mock-base-url.com';
 	const MOCK_ROUTE = '/mockroute';
 	const MOCK_LOCALE_CODE = 'fr-FR';
+	const MOCK_IS_GENERATE_ALTERNATE_LINKS = true;
 
 	it('should generate locale <link />s for all locales', () => {
 		const canonicalUrlMetaTags = generateCanonicalUrlLinkTags(
 			MOCK_BASE_URL,
 			'en-US',
-			MOCK_ROUTE
+			MOCK_ROUTE,
+			MOCK_IS_GENERATE_ALTERNATE_LINKS
 		);
 		expect(canonicalUrlMetaTags).toMatchSnapshot();
 	});
@@ -18,7 +20,8 @@ describe('generateCanonicalUrlLinkTags', () => {
 		const canonicalUrlMetaTags = generateCanonicalUrlLinkTags(
 			MOCK_BASE_URL,
 			MOCK_LOCALE_CODE,
-			MOCK_ROUTE
+			MOCK_ROUTE,
+			MOCK_IS_GENERATE_ALTERNATE_LINKS
 		);
 		expect(
 			canonicalUrlMetaTags.filter(el => el.props.rel === 'canonical')
@@ -29,7 +32,8 @@ describe('generateCanonicalUrlLinkTags', () => {
 		const canonicalUrlMetaTags = generateCanonicalUrlLinkTags(
 			MOCK_BASE_URL,
 			'en-US',
-			MOCK_ROUTE
+			MOCK_ROUTE,
+			MOCK_IS_GENERATE_ALTERNATE_LINKS
 		);
 		expect(
 			canonicalUrlMetaTags.filter(el => el.props.rel === 'canonical')
@@ -40,7 +44,8 @@ describe('generateCanonicalUrlLinkTags', () => {
 		const canonicalUrlMetaTags = generateCanonicalUrlLinkTags(
 			MOCK_BASE_URL,
 			MOCK_LOCALE_CODE,
-			MOCK_ROUTE
+			MOCK_ROUTE,
+			MOCK_IS_GENERATE_ALTERNATE_LINKS
 		);
 		expect(
 			canonicalUrlMetaTags.filter(el => el.props.hrefLang === 'x-default')

--- a/packages/mwp-app-render/src/util/seo/links.test.js
+++ b/packages/mwp-app-render/src/util/seo/links.test.js
@@ -51,4 +51,14 @@ describe('generateCanonicalUrlLinkTags', () => {
 			canonicalUrlMetaTags.filter(el => el.props.hrefLang === 'x-default')
 		).toMatchSnapshot();
 	});
+
+	it('should not generate locale <link />s when isGenerateAlternateLinks = false', () => {
+		const canonicalUrlMetaTags = generateCanonicalUrlLinkTags(
+			MOCK_BASE_URL,
+			'en-US',
+			MOCK_ROUTE,
+			false
+		);
+		expect(canonicalUrlMetaTags).toMatchSnapshot();
+	});
 });


### PR DESCRIPTION
Related ticket: https://app.clubhouse.io/meetup/story/15602/remove-hreflang-tags-add-noindex-for-all-us-groups-and-events

Tested locally with 25.2.3299-beta build 