### PR TITLE
[fe10016]: Replace http with https links in linkify

### DIFF
--- a/packages/mwp-core/src/util/linkify.js
+++ b/packages/mwp-core/src/util/linkify.js
@@ -23,6 +23,24 @@ const getRelAttr = (followedExternalDomains, link, target) => {
 	}
 };
 
+export const getSubDomain = (url: string) => {
+	if (!url || !url.includes(`//`)) {
+		return 'www';
+	}
+
+	const [, domain] = url.split(`//`);
+	if (domain) {
+		const levels = domain.split('.');
+
+		if (levels.length > 2) {
+			const [subdomain] = domain.split('.');
+			return subdomain || 'www';
+		}
+	}
+
+	return 'www';
+};
+
 /**
  * Generates HTML link tag element with target
  *
@@ -37,8 +55,8 @@ const createLink = (options: Object, followedExternalDomains?: Array<string>) =>
 	const target = options.target || '';
 	const targetAttr = `target="${target}"`;
 	const hasProtocolRE = /^(?:https?:|ws:|ftp:)?\/\//;
-	const hasMeetupHttpLinkRE = /http:\/\/www.meetup/g;
-	const meetupHttps = 'https://www.meetup';
+	const hasMeetupHttpLinkRE = /https?:\/\/([a-z0-9-]+?\.)?meetup/g;
+	const meetupHttps = `https://${getSubDomain(href)}.meetup`;
 	const link = hasProtocolRE.test(href) ? href : `http://${href}`;
 	const meetupLink = link.replace(hasMeetupHttpLinkRE, meetupHttps);
 	const isMeetupLinkUpdated = meetupLink !== link;

--- a/packages/mwp-core/src/util/linkify.test.js
+++ b/packages/mwp-core/src/util/linkify.test.js
@@ -1,19 +1,40 @@
-import linkify from './linkify';
+import linkify, { getSubDomain } from './linkify';
+
+describe('getSubDomain', () => {
+	it('should return corrent url subdomain', () => {
+		expect(getSubDomain()).toBe('www');
+		expect(getSubDomain(`meetup.com`)).toBe('www');
+		expect(getSubDomain(`http://meetup.com`)).toBe('www');
+		expect(getSubDomain(`https://meetup.com`)).toBe('www');
+		expect(getSubDomain(`http://www.meetup.com`)).toBe('www');
+		expect(getSubDomain(`https://www.meetup.com`)).toBe('www');
+		expect(getSubDomain(`http://secure.meetup.com`)).toBe('secure');
+		expect(getSubDomain(`https://secure.meetup.com`)).toBe('secure');
+		expect(getSubDomain(`http://www.amazon.co.uk`)).toBe('www');
+		expect(getSubDomain(`https://www.amazon.co.uk`)).toBe('www');
+	});
+});
 
 describe('linkify', () => {
-	const httpBase = 'http://www.meetup.com',
-		expectedLink =
-			'<a class="link" href="https://www.meetup.com" title="https://www.meetup.com" target="" >https://www.meetup.com</a>';
+	const httpBase = 'http://www.meetup.com';
+	const secureBase = 'https://secure.meetup.com';
+	const expectedLink =
+		'<a class="link" href="https://www.meetup.com" title="https://www.meetup.com" target="" >https://www.meetup.com</a>';
 
 	it('should turn a meetup link text with http into a HTML anchor with https', () => {
 		expect(linkify(httpBase)).toBe(expectedLink);
 	});
+
+	it('should turn a meetup link text with http and without www into a HTML anchor with https and www', () => {
+		expect(linkify('http://meetup.com')).toBe(expectedLink);
+	});
+
 	it('should turn a link text with https into a HTML anchor with https', () => {
-		const secureBase = 'https://secure.meetup.com';
 		const expectedSecureLink =
 			'<a class="link" href="https://secure.meetup.com" title="https://secure.meetup.com" target="" >https://secure.meetup.com</a>';
 		expect(linkify(secureBase)).toBe(expectedSecureLink);
 	});
+
 	it('should turn a link text with a target into an HTML anchor with a target', () => {
 		const targetLink =
 			'<a class="link" href="https://www.meetup.com" title="https://www.meetup.com" target="foo" >https://www.meetup.com</a>';


### PR DESCRIPTION
https://app.shortcut.com/meetup/story/10016/replace-http-with-https-links-for-messages-page-pages-with-structured-data