### PR TITLE
feat: 1999 add meetu.ps and secure.meetupstatic as no-rel tag links

### DIFF
--- a/packages/mwp-core/src/util/linkify.js
+++ b/packages/mwp-core/src/util/linkify.js
@@ -5,6 +5,8 @@ var urlRegex = new RegExp(
 	/(?:(?:(?:[a-z]+:)?\/\/)|www\.)(?:\S+(?::\S*)?@)?(?:localhost|(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])(?:\.(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])){3}|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})))(?::\d{2,5})?(?:[/?#]([^\s"()]|[(][^\s"]*?[)])*)?/gi
 );
 
+const MEETUP_DOMAINS = ['meetup.com', 'secure.meetupstatic.com', 'meetu.ps'];
+
 const getRelAttr = (followedExternalDomains, link, target) => {
 	if (!followedExternalDomains) {
 		return target === '_blank' ? 'rel="nofollow noopener noreferrer"' : '';
@@ -12,7 +14,7 @@ const getRelAttr = (followedExternalDomains, link, target) => {
 	try {
 		const urlObj = new URL(link);
 		const domain = urlObj.hostname.replace('www.', '');
-		if (domain === 'meetup.com') {
+		if (MEETUP_DOMAINS.includes(domain)) {
 			return '';
 		} else if (followedExternalDomains.includes(domain)) {
 			return 'rel="ugc"';

--- a/packages/mwp-core/src/util/linkify.test.js
+++ b/packages/mwp-core/src/util/linkify.test.js
@@ -186,6 +186,18 @@ describe('rel attribute', () => {
 			expectedLink
 		);
 	});
+	it('should not render a rel attribute for meetupstatic', () => {
+		const expectedLink =
+			'<a class="link" href="https://secure.meetupstatic.com" title="https://secure.meetupstatic.com" target="" >https://secure.meetupstatic.com</a>';
+		expect(linkify('https://secure.meetupstatic.com', {}, ['youtube.com'])).toBe(
+			expectedLink
+		);
+	});
+	it('should not render a rel attribute for meetu.ps', () => {
+		const expectedLink =
+			'<a class="link" href="https://meetu.ps" title="https://meetu.ps" target="" >https://meetu.ps</a>';
+		expect(linkify('https://meetu.ps', {}, ['youtube.com'])).toBe(expectedLink);
+	});
 	it('should render a "ugc" rel attribute', () => {
 		const expectedLink =
 			'<a class="link" href="https://www.youtube.com" title="https://www.youtube.com" target="" rel="ugc">https://www.youtube.com</a>';


### PR DESCRIPTION
https://app.shortcut.com/meetup/story/1999/extend-the-whitelist-for-domains-that-are-exlcuded-from-nofollow-tags

Links from "https://secure.meetupstatic.com" or "https://meetu.ps" should get no tag (they are currently get the nofollow tag, even though they are Meetup links)

