### PR TITLE
docs: call the internal variant endpoint

### DIFF
--- a/packages/mwp-api-state/Queries.md
+++ b/packages/mwp-api-state/Queries.md
@@ -572,14 +572,14 @@ The variants service provides its own public API endpoint returning JSON. See
 and [the OpenAPI spec](https://github.com/meetup/variant/blob/master/src/main/openapi/meetup-scala-server/variant.yaml).
 
 To use it in production, set the `endpoint` to
-`https://variant-ext.data.meetuphq.io/variant/v2/${experimentId}/${entityId}`
+`https://variant.data.meetuphq.io/variant/v2/${experimentId}/${entityId}`
 where `expirementId` is the name of your experiment in the variants service,
 and `entityId` is a _member ID_, _chapter ID_, or group `urlname`, depending
 on the type of experiment.
 
 _In dev_, use the `variantNoEnrollment` version of the endpoint (documented in the OpenAPI spec)
 in order to prevent the experiment data from showing up in site analytics (Looker), i.e.
-`https://variant-ext.data.meetuphq.io/variantNoEnrollment/v2/${experimentId}/${entityId}`
+`https://variant.data.meetuphq.io/variantNoEnrollment/v2/${experimentId}/${entityId}`
 
 ```js
 import { getProperty } from '@meetup/api-state-selectors';
@@ -589,7 +589,7 @@ const variantEndpoint =
 	process.env.NODE_ENV === 'production' ? 'variant' : 'variantNoEnrollment';
 
 const myVariantQuery = {
-	endpoint: `https://variant-ext.data.meetuphq.io/${variantEndpoint}/v2/my-cool-experiment/${member.id}`,
+	endpoint: `https://variant.data.meetuphq.io/${variantEndpoint}/v2/my-cool-experiment/${member.id}`,
 	ref: MY_VARIANT_REF,
 };
 


### PR DESCRIPTION
The `-ext` endpoint is mostly intended for testing and special cases where going out through the internet is unavoidable (e.g. mobile clients making direct calls to variant).

You'll need to confirm that networking is set up from mup-web (this client) and the "data realtime services" account. Account details are in https://github.com/meetup/variant/#where-is-it

Thank you for considering switching off of variant-ext endpoint.